### PR TITLE
Fix recursive ARM64 defconfig generation in QEMU stress lab

### DIFF
--- a/.github/workflows/06-qemu-full-stack-stress.yml
+++ b/.github/workflows/06-qemu-full-stack-stress.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - '.github/workflows/06-qemu-full-stack-stress.yml'
       - 'tests/qemu/full_stack_stress.c'
+      - 'scripts/03_apply_linux_4.19.153.sh'
       - 'scripts/09_prepare_susfs_v1_5_5_a52xq.sh'
       - 'scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v2.sh'
       - 'scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v3.sh'

--- a/scripts/03_apply_linux_4.19.153.sh
+++ b/scripts/03_apply_linux_4.19.153.sh
@@ -137,6 +137,15 @@ require_fixed "crypto/algif_aead.c" "aead_request_set_callback(&areq->cra_u.aead
 require_fixed "crypto/algif_aead.c" "CRYPTO_TFM_REQ_MAY_SLEEP |"
 require_absent "crypto/algif_aead.c" "if (err == -EINPROGRESS || err == -EBUSY)"
 
+info "Installing pinned upstream ARM64 defconfig for generic QEMU builds"
+install -D -m 0644 \
+  "$STABLE_DIR/arch/arm64/configs/defconfig" \
+  "$KERNEL_DIR/arch/arm64/configs/defconfig"
+cmp -s \
+  "$STABLE_DIR/arch/arm64/configs/defconfig" \
+  "$KERNEL_DIR/arch/arm64/configs/defconfig" \
+  || fail "Installed ARM64 QEMU defconfig does not match Linux $TO_TAG"
+
 find "$KERNEL_DIR" -type f -name '*.rej' -delete
 actual_version=$(kernel_version)
 test "$actual_version" = "$TARGET_VERSION" || fail "Resolved tree reports Linux $actual_version instead of $TARGET_VERSION"
@@ -146,6 +155,7 @@ test "$actual_version" = "$TARGET_VERSION" || fail "Resolved tree reports Linux 
   printf 'resolution=accepted-known-preapplied-hunks\n'
   printf 'manual_crypto_adaptation=CRYPTO_TFM_REQ_MAY_SLEEP\n'
   printf 'skipped_absent_driver=drivers/slimbus/qcom-ngd-ctrl.c\n'
+  printf 'qemu_arm64_defconfig_commit=%s\n' "$to_sha"
   printf 'validated_reject_count=%s\n' "${#actual_rejects[@]}"
   printf 'kernel_version=%s\n' "$actual_version"
 } | tee "$RESOLUTION_LOG"


### PR DESCRIPTION
## Summary

- copy the generic ARM64 defconfig from the already fetched and commit-verified Linux v4.19.153 stable tree into the generated touchGrass source tree
- verify that the installed config is byte-for-byte identical to the pinned upstream file
- record the upstream commit used for the QEMU defconfig
- include the stable-update preparation script in the QEMU workflow path filter

## Why

The vendor ARM64 Makefile sets `KBUILD_DEFCONFIG := defconfig`, but the touchGrass source tree does not contain `arch/arm64/configs/defconfig`. Running `make defconfig` therefore recursively invokes the same target until the runner fails with `Argument list too long`.

This change supplies the missing generic ARM64 defconfig from the exact Linux v4.19.153 tree that the workflow already fetches and verifies at commit `79524e8c64bda80bb35ab490177d0e6813bf112c`.

## Safety

The file is added only to the disposable generated kernel source tree. The A52 object audit still uses `a52xq_defconfig`, and the workflow remains non-flashable.