### PR TITLE
Enable MODULES dependency for QEMU KPROBES builds

### DIFF
--- a/scripts/11_qemu_full_stack_stress.sh
+++ b/scripts/11_qemu_full_stack_stress.sh
@@ -168,6 +168,7 @@ for symbol in \
   BPF \
   BPF_SYSCALL \
   BPF_EVENTS \
+  MODULES \
   KPROBES \
   KPROBE_EVENTS \
   EXT4_FS \
@@ -198,7 +199,6 @@ for symbol in \
 done
 
 for symbol in \
-  MODULES \
   KPM \
   KSU_DEBUG \
   KSU_SUSFS_SUS_PATH \
@@ -243,7 +243,7 @@ make -C "$KERNEL_DIR" O="$QEMU_OUT" \
 # Save the resolved configuration before validation so failed runs remain diagnosable.
 cp "$QEMU_CONFIG" "$QEMU_ARTIFACT_DIR/qemu-config-$PROFILE"
 grep -E '^(CONFIG_|# CONFIG_)' "$QEMU_CONFIG" \
-  | grep -E '(EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN)' \
+  | grep -E '(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN)' \
   > "$QEMU_ARTIFACT_DIR/qemu-config-key-symbols-$PROFILE.txt" || true
 
 for required in \
@@ -252,6 +252,7 @@ for required in \
   VIRTIO_MMIO \
   BLK_DEV_INITRD \
   BPF_SYSCALL \
+  MODULES \
   KPROBES \
   EXT4_FS \
   KSU \


### PR DESCRIPTION
## Summary

- enable `CONFIG_MODULES=y` in the disposable generic ARM64 QEMU configuration
- stop disabling module support before `olddefconfig`
- require `MODULES` in resolved-config validation
- include `MODULES` in the concise Kconfig diagnostic report

## Why

Linux v4.19.153 defines `KPROBES` with:

```text
config KPROBES
    depends on MODULES
    depends on HAVE_KPROBES
```

The previous QEMU configuration enabled `KPROBES` and then explicitly disabled `MODULES`. As a result, `olddefconfig` removed `KPROBES`; SukiSU's `KSU` option then lost its `KPROBES && EXT4_FS` dependency, and KSU/SUSFS disappeared from both Lockdep and KASAN configs.

The latest run confirms that the prior EXT4 fix worked and that Lockdep/KASAN themselves resolve correctly. This PR repairs the next dependency in that chain.

## Safety

This affects only the generic, non-flashable QEMU diagnostic kernel. The A52 phone defconfig and A52 object audit are unchanged. Enabling module support in the configuration does not build or package phone kernel modules in this workflow; the job still builds only the generic QEMU `Image`.