### PR TITLE
Repair BPF attach flow and focus QEMU guest config

### DIFF
--- a/scripts/05_repair_bpf_verifier.sh
+++ b/scripts/05_repair_bpf_verifier.sh
@@ -200,7 +200,7 @@ grep -Fq 'ctx_access = BPF_CLASS(insn->code) == BPF_STX;' "$VERIFIER" || fail "c
 grep -Fq 'struct bpf_id_pair idmap_scratch[BPF_ID_MAP_SIZE];' "$HEADER" || fail "Header id-map scratch definition is missing"
 grep -Fq 'ptype = BPF_PROG_TYPE_SK_MSG;' "$SYSCALL" || fail "SK_MSG attach type repair is missing"
 grep -Fq 'ptype = BPF_PROG_TYPE_SK_SKB;' "$SYSCALL" || fail "SK_SKB attach type repair is missing"
-! grep -Fq $'case BPF_SK_MSG_VERDICT:\n\t\tret = sock_map_get_from_fd(attr, prog);' "$SYSCALL" || fail "Uninitialized sock-map attach call remains"
+! sed -n '/case BPF_SK_MSG_VERDICT:/,+2p' "$SYSCALL" | grep -Fq 'ret = sock_map_get_from_fd(attr, prog);' || fail "Uninitialized sock-map attach call remains"
 
 git -C "$KERNEL_DIR" diff --check -- include/linux/bpf_verifier.h kernel/bpf/verifier.c kernel/bpf/syscall.c
 git -C "$KERNEL_DIR" diff --binary -- include/linux/bpf_verifier.h kernel/bpf/verifier.c kernel/bpf/syscall.c > "$PATCH_OUT"

--- a/scripts/05_repair_bpf_verifier.sh
+++ b/scripts/05_repair_bpf_verifier.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/common.sh"
 TARGET_VERSION=4.19.153
 HEADER="$KERNEL_DIR/include/linux/bpf_verifier.h"
 VERIFIER="$KERNEL_DIR/kernel/bpf/verifier.c"
+SYSCALL="$KERNEL_DIR/kernel/bpf/syscall.c"
 REPORT="$ARTIFACTS_DIR/bpf-verifier-repair.txt"
 PATCH_OUT="$ARTIFACTS_DIR/bpf-verifier-repair.patch"
 
@@ -14,19 +15,23 @@ test -f "$ARTIFACTS_DIR/apply-result-v4.19.153.txt" || fail "Linux 4.19.153 upda
 grep -q '^apply_exit=0$' "$ARTIFACTS_DIR/apply-result-v4.19.153.txt" || fail "Linux 4.19.153 update did not complete successfully"
 test -f "$HEADER" || fail "Missing $HEADER"
 test -f "$VERIFIER" || fail "Missing $VERIFIER"
+test -f "$SYSCALL" || fail "Missing $SYSCALL"
 
 cp "$HEADER" "$ARTIFACTS_DIR/bpf_verifier.h.before"
 cp "$VERIFIER" "$ARTIFACTS_DIR/verifier.c.before"
+cp "$SYSCALL" "$ARTIFACTS_DIR/syscall.c.before"
 
-python3 - "$HEADER" "$VERIFIER" <<'PY'
+python3 - "$HEADER" "$VERIFIER" "$SYSCALL" <<'PY'
 from pathlib import Path
 import re
 import sys
 
 header_path = Path(sys.argv[1])
 verifier_path = Path(sys.argv[2])
+syscall_path = Path(sys.argv[3])
 header = header_path.read_text()
 verifier = verifier_path.read_text()
+syscall = syscall_path.read_text()
 
 
 def sub_once(text: str, pattern: str, replacement: str, label: str, flags: int = 0) -> str:
@@ -34,6 +39,14 @@ def sub_once(text: str, pattern: str, replacement: str, label: str, flags: int =
     if count != 1:
         raise SystemExit(f"{label}: expected exactly one match, found {count}")
     return updated
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected exactly one match, found {count}")
+    return text.replace(old, new, 1)
+
 
 # REG_LIVE_DONE was added locally, checked in two places, but never set.
 header = sub_once(
@@ -134,8 +147,45 @@ verifier = sub_once(
     "initialize ctx_access using upstream branch semantics",
 )
 
+# The vendor BPF attach backport called sock_map_get_from_fd() before prog was
+# initialized and left ptype unset for SK_MSG/SK_SKB attach types. Restore the
+# upstream type-selection flow, adapted to the vendor helper name/signature.
+syscall = replace_once(
+    syscall,
+    "\tcase BPF_SK_MSG_VERDICT:\n"
+    "\t\tret = sock_map_get_from_fd(attr, prog);\n"
+    "\t\tbreak;\n"
+    "\tcase BPF_SK_SKB_STREAM_PARSER:\n"
+    "\tcase BPF_SK_SKB_STREAM_VERDICT:\n"
+    "\t\tret = sock_map_get_from_fd(attr, prog);\n"
+    "\t\tbreak;\n",
+    "\tcase BPF_SK_MSG_VERDICT:\n"
+    "\t\tptype = BPF_PROG_TYPE_SK_MSG;\n"
+    "\t\tbreak;\n"
+    "\tcase BPF_SK_SKB_STREAM_PARSER:\n"
+    "\tcase BPF_SK_SKB_STREAM_VERDICT:\n"
+    "\t\tptype = BPF_PROG_TYPE_SK_SKB;\n"
+    "\t\tbreak;\n",
+    "restore socket-map attach type selection",
+)
+
+# The same backport omitted the break after BPF_LIRC_MODE2, causing it to fall
+# through and be treated as a cgroup-sysctl program.
+syscall = replace_once(
+    syscall,
+    "\tcase BPF_LIRC_MODE2:\n"
+    "\t\tptype = BPF_PROG_TYPE_LIRC_MODE2;\n"
+    "\tcase BPF_CGROUP_SYSCTL:\n",
+    "\tcase BPF_LIRC_MODE2:\n"
+    "\t\tptype = BPF_PROG_TYPE_LIRC_MODE2;\n"
+    "\t\tbreak;\n"
+    "\tcase BPF_CGROUP_SYSCTL:\n",
+    "restore LIRC attach-type break",
+)
+
 header_path.write_text(header)
 verifier_path.write_text(verifier)
+syscall_path.write_text(syscall)
 PY
 
 # Strict post-repair checks.
@@ -148,9 +198,12 @@ grep -Fq 'if (env->explore_alu_limits)' "$VERIFIER" || fail "explore_alu_limits 
 grep -Fq 'ctx_access = true;' "$VERIFIER" || fail "ctx_access read assignment is missing"
 grep -Fq 'ctx_access = BPF_CLASS(insn->code) == BPF_STX;' "$VERIFIER" || fail "ctx_access write assignment is missing"
 grep -Fq 'struct bpf_id_pair idmap_scratch[BPF_ID_MAP_SIZE];' "$HEADER" || fail "Header id-map scratch definition is missing"
+grep -Fq 'ptype = BPF_PROG_TYPE_SK_MSG;' "$SYSCALL" || fail "SK_MSG attach type repair is missing"
+grep -Fq 'ptype = BPF_PROG_TYPE_SK_SKB;' "$SYSCALL" || fail "SK_SKB attach type repair is missing"
+! grep -Fq $'case BPF_SK_MSG_VERDICT:\n\t\tret = sock_map_get_from_fd(attr, prog);' "$SYSCALL" || fail "Uninitialized sock-map attach call remains"
 
-git -C "$KERNEL_DIR" diff --check -- include/linux/bpf_verifier.h kernel/bpf/verifier.c
-git -C "$KERNEL_DIR" diff --binary -- include/linux/bpf_verifier.h kernel/bpf/verifier.c > "$PATCH_OUT"
+git -C "$KERNEL_DIR" diff --check -- include/linux/bpf_verifier.h kernel/bpf/verifier.c kernel/bpf/syscall.c
+git -C "$KERNEL_DIR" diff --binary -- include/linux/bpf_verifier.h kernel/bpf/verifier.c kernel/bpf/syscall.c > "$PATCH_OUT"
 test -s "$PATCH_OUT" || fail "BPF repair produced no patch"
 sha256sum "$PATCH_OUT" > "$PATCH_OUT.sha256"
 
@@ -161,8 +214,9 @@ sha256sum "$PATCH_OUT" > "$PATCH_OUT.sha256"
   printf 'unified_id_map_size=BPF_ID_MAP_SIZE\n'
   printf 'restored_guard=env->explore_alu_limits\n'
   printf 'initialized_ctx_access=upstream-branch-semantics\n'
-  printf 'changed_files=include/linux/bpf_verifier.h,kernel/bpf/verifier.c\n'
+  printf 'repaired_attach_types=SK_MSG,SK_SKB,LIRC_MODE2\n'
+  printf 'changed_files=include/linux/bpf_verifier.h,kernel/bpf/verifier.c,kernel/bpf/syscall.c\n'
   printf 'patch_sha256=%s\n' "$(cut -d' ' -f1 "$PATCH_OUT.sha256")"
 } | tee "$REPORT"
 
-info "BPF verifier source repair completed"
+info "BPF verifier and syscall source repair completed"

--- a/scripts/11_qemu_full_stack_stress.sh
+++ b/scripts/11_qemu_full_stack_stress.sh
@@ -68,7 +68,7 @@ require_config_y() {
 }
 
 require_config_disabled() {
-  ! grep -Fq "CONFIG_$1=y" "$QEMU_CONFIG" || fail "QEMU config unexpectedly enabled CONFIG_$1"
+  ! grep -Eq "^CONFIG_$1=(y|m)$" "$QEMU_CONFIG" || fail "QEMU config unexpectedly enabled CONFIG_$1"
 }
 
 info "Compiling exact A52 full-stack objects without producing a flashable device Image"
@@ -104,6 +104,7 @@ set +e
     CONFIG_SECTION_MISMATCH_WARN_ONLY=y \
     W=1 V=1 -j"${JOBS:-4}" \
     kernel/bpf/verifier.o \
+    kernel/bpf/syscall.o \
     drivers/kernelsu/ \
     fs/susfs.o \
     fs/susfs_sukisu_compat.o \
@@ -118,6 +119,7 @@ test "$a52_audit_rc" -eq 0 || fail "A52 full-stack object audit failed"
 
 for object in \
   kernel/bpf/verifier.o \
+  kernel/bpf/syscall.o \
   drivers/kernelsu/built-in.a \
   fs/susfs.o \
   fs/susfs_sukisu_compat.o \
@@ -129,6 +131,7 @@ done
 cp "$A52_AUDIT_OUT/.config" "$QEMU_ARTIFACT_DIR/a52-audit-config"
 sha256sum \
   "$A52_AUDIT_OUT/kernel/bpf/verifier.o" \
+  "$A52_AUDIT_OUT/kernel/bpf/syscall.o" \
   "$A52_AUDIT_OUT/drivers/kernelsu/built-in.a" \
   "$A52_AUDIT_OUT/fs/susfs.o" \
   "$A52_AUDIT_OUT/fs/susfs_sukisu_compat.o" \
@@ -202,12 +205,16 @@ for symbol in \
   config_enable "$symbol"
 done
 
-# These host/boot-management features are irrelevant inside the QEMU guest and
-# exercise vendor ARM64 code that is incompatible with the generic v4.19 config.
+# These subsystems are not exercised by the QEMU guest. Keeping them disabled
+# avoids unrelated vendor-only API mismatches while preserving the intended
+# BPF, SukiSU, SUSFS, KASAN and Lockdep coverage.
 for symbol in \
   KVM \
   KEXEC \
   CRASH_DUMP \
+  NFS_FS \
+  TRANSPARENT_HUGEPAGE \
+  FANOTIFY \
   KPM \
   KSU_DEBUG \
   KSU_SUSFS_SUS_PATH \
@@ -252,7 +259,7 @@ make -C "$KERNEL_DIR" O="$QEMU_OUT" \
 # Save the resolved configuration before validation so failed runs remain diagnosable.
 cp "$QEMU_CONFIG" "$QEMU_ARTIFACT_DIR/qemu-config-$PROFILE"
 grep -E '^(CONFIG_|# CONFIG_)' "$QEMU_CONFIG" \
-  | grep -E '(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|KVM|KEXEC|CRASH_DUMP)' \
+  | grep -E '(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|KVM|KEXEC|CRASH_DUMP|NFS_FS|TRANSPARENT_HUGEPAGE|FANOTIFY)' \
   > "$QEMU_ARTIFACT_DIR/qemu-config-key-symbols-$PROFILE.txt" || true
 
 for required in \
@@ -278,7 +285,7 @@ if test "$PROFILE" = lockdep; then
 else
   require_config_y KASAN
 fi
-for disabled in KVM KEXEC CRASH_DUMP; do
+for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY; do
   require_config_disabled "$disabled"
 done
 ! grep -Eq '^CONFIG_KSU_SUSFS_(SUS_PATH|SUS_KSTAT|TRY_UMOUNT|OPEN_REDIRECT|SUS_SU)=y$' "$QEMU_CONFIG" \
@@ -288,7 +295,6 @@ info "Building generic ARM64 QEMU kernel with $PROFILE diagnostics"
 set +e
 make -C "$KERNEL_DIR" O="$QEMU_OUT" \
   DTC_EXT="$KERNEL_DIR/tools/dtc" \
-  KCFLAGS="$AUDIT_FLAGS" \
   CONFIG_SECTION_MISMATCH_WARN_ONLY=y \
   -j"${JOBS:-4}" Image 2>&1 | tee "$QEMU_BUILD_LOG"
 qemu_build_rc=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

- repair the malformed vendor BPF `BPF_PROG_ATTACH` switch so SK_MSG and SK_SKB attach types select a program type before `bpf_prog_get_type()`
- restore the missing `break` after `BPF_LIRC_MODE2`
- add `kernel/bpf/syscall.o` to the strict A52 object audit and artifact hashes
- disable NFS, transparent huge pages, and fanotify only in the disposable generic QEMU guest configuration because the stress workload does not exercise them
- keep strict `-Werror` flags on the targeted A52 audit while allowing the complete vendor QEMU build to use its normal warning policy
- validate disabled symbols against both built-in and module states

## Why

Run 29124188900 passed the complete Kconfig dependency chain and compiled beyond the previous KVM/kexec failures. Both profiles then exposed:

1. A real BPF backport defect in `kernel/bpf/syscall.c`: `ptype` and `prog` were used before initialization for socket-map attach types.
2. Unrelated generic-defconfig build blockers in NFS, fanotify, and transparent huge-page code. These subsystems are not used by `tests/qemu/full_stack_stress.c`.
3. The full vendor tree was being compiled with the same strict warning promotion intended for the focused A52 object audit, turning unrelated legacy warnings into fatal errors.

The BPF path is actively exercised and is therefore repaired and audited strictly. The unrelated guest subsystems are omitted without reducing BPF, SukiSU, SUSFS, KASAN, Lockdep, mount-namespace, procfs, or statfs coverage.

## Safety

This does not create a flashable artifact. The A52 phone defconfig is unchanged, and the exact A52 audit becomes stricter by adding `kernel/bpf/syscall.o`. The additional config exclusions apply only to the generic non-flashable QEMU guest kernel.