### PR TITLE
Exclude unused taskstats and QCOM drivers from QEMU guest

### DIFF
--- a/.github/workflows/06-qemu-full-stack-stress.yml
+++ b/.github/workflows/06-qemu-full-stack-stress.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v3.sh'
       - 'scripts/09_integrate_susfs_v1_5_5.sh'
       - 'scripts/11_qemu_full_stack_stress.sh'
+      - 'scripts/11_qemu_full_stack_stress_scoped.sh'
 
 permissions:
   contents: read
@@ -105,7 +106,7 @@ jobs:
         env:
           STRESS_SECONDS: ${{ github.event.inputs.stress_seconds || '600' }}
         run: |
-          ./scripts/11_qemu_full_stack_stress.sh \
+          ./scripts/11_qemu_full_stack_stress_scoped.sh \
             '${{ matrix.profile }}' \
             "$STRESS_SECONDS"
 

--- a/scripts/11_qemu_full_stack_stress_scoped.sh
+++ b/scripts/11_qemu_full_stack_stress_scoped.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_SCRIPT="$SCRIPT_DIR/11_qemu_full_stack_stress.sh"
+RUNTIME_SCRIPT="$SCRIPT_DIR/.11_qemu_full_stack_stress.scoped.$$"
+
+cleanup() {
+  rm -f "$RUNTIME_SCRIPT"
+}
+trap cleanup EXIT
+
+test -f "$BASE_SCRIPT" || {
+  printf 'Missing base QEMU stress script: %s\n' "$BASE_SCRIPT" >&2
+  exit 1
+}
+
+cp "$BASE_SCRIPT" "$RUNTIME_SCRIPT"
+
+python3 - "$RUNTIME_SCRIPT" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+
+
+def replace_once(old: str, new: str, label: str) -> None:
+    global text
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    text = text.replace(old, new, 1)
+
+
+replace_once(
+    """  FANOTIFY \\
+  SCHED_WALT \\
+""",
+    """  FANOTIFY \\
+  TASKSTATS \\
+  ARCH_QCOM \\
+  COMMON_CLK_QCOM \\
+  SCHED_WALT \\
+""",
+    "extend unused QEMU subsystem disable list",
+)
+
+replace_once(
+    """(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|KVM|KEXEC|CRASH_DUMP|NFS_FS|TRANSPARENT_HUGEPAGE|FANOTIFY|SCHED_WALT)""",
+    """(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|KVM|KEXEC|CRASH_DUMP|NFS_FS|TRANSPARENT_HUGEPAGE|FANOTIFY|TASKSTATS|ARCH_QCOM|COMMON_CLK_QCOM|SCHED_WALT)""",
+    "extend QEMU key-symbol diagnostics",
+)
+
+replace_once(
+    """for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY SCHED_WALT; do""",
+    """for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY TASKSTATS ARCH_QCOM COMMON_CLK_QCOM SCHED_WALT; do""",
+    "extend resolved-config disabled validation",
+)
+
+path.write_text(text)
+PY
+
+chmod +x "$RUNTIME_SCRIPT"
+bash -n "$RUNTIME_SCRIPT"
+grep -Fq '  TASKSTATS \' "$RUNTIME_SCRIPT"
+grep -Fq '  ARCH_QCOM \' "$RUNTIME_SCRIPT"
+grep -Fq '  COMMON_CLK_QCOM \' "$RUNTIME_SCRIPT"
+grep -Fq 'TASKSTATS ARCH_QCOM COMMON_CLK_QCOM SCHED_WALT' "$RUNTIME_SCRIPT"
+
+"$RUNTIME_SCRIPT" "$@"


### PR DESCRIPTION
## Summary

- run the full-stack lab through a scoped wrapper that modifies only the disposable generic QEMU configuration
- disable `CONFIG_TASKSTATS`, `CONFIG_ARCH_QCOM`, and `CONFIG_COMMON_CLK_QCOM`
- record these symbols in the key-config artifact and fail if any remains built-in or modular
- keep the original A52 object audit and phone defconfig unchanged

## Why

Run 29125399647 passed the previous non-WALT scheduler blocker, then both KASAN and Lockdep builds failed identically at two later points:

1. `kernel/taskstats.c` contains a malformed bare `#elif`, exposed only because the broad generic ARM64 defconfig enables `CONFIG_TASKSTATS=y`.
2. `drivers/clk/qcom/common.h` embeds `struct clk_hw` without a complete definition when generic defconfig pulls Qualcomm clock drivers into the guest build.

The QEMU stress program does not use taskstats or Qualcomm SoC clock/platform support. The QEMU `virt` guest relies on the explicitly enabled PL011, virtio, generic PCI, procfs, namespaces, BPF, SukiSU, SUSFS, KASAN, and Lockdep paths instead.

Disabling the unused subsystems avoids patching unrelated vendor code and keeps the diagnostic kernel focused on the code under test.

## Safety

This remains non-flashable. The A52 phone defconfig, WALT-enabled phone scheduler, and A52-specific object audit are unchanged. The wrapper creates a temporary runtime copy of the existing stress script, validates its exact replacements, executes it, and removes the copy afterward.