### PR TITLE
Generate SELinux headers before QEMU Image build

### DIFF
--- a/scripts/11_qemu_full_stack_stress_scoped.sh
+++ b/scripts/11_qemu_full_stack_stress_scoped.sh
@@ -58,6 +58,30 @@ replace_once(
     "extend resolved-config disabled validation",
 )
 
+replace_once(
+    """info "Building generic ARM64 QEMU kernel with $PROFILE diagnostics"\n""",
+    """info "Generating SELinux headers for the generic QEMU output tree"
+make -C "$KERNEL_DIR" O="$QEMU_OUT" \\
+  DTC_EXT="$KERNEL_DIR/tools/dtc" \\
+  scripts/selinux/genheaders/
+qemu_genheaders="$QEMU_OUT/scripts/selinux/genheaders/genheaders"
+test -x "$qemu_genheaders" || fail "QEMU SELinux genheaders tool is missing"
+mkdir -p "$QEMU_OUT/security/selinux"
+"$qemu_genheaders" \\
+  "$QEMU_OUT/security/selinux/flask.h" \\
+  "$QEMU_OUT/security/selinux/av_permissions.h"
+test -s "$QEMU_OUT/security/selinux/flask.h" || fail "QEMU SELinux flask.h was not generated"
+test -s "$QEMU_OUT/security/selinux/av_permissions.h" || fail "QEMU SELinux av_permissions.h was not generated"
+sha256sum \\
+  "$QEMU_OUT/security/selinux/flask.h" \\
+  "$QEMU_OUT/security/selinux/av_permissions.h" \\
+  > "$QEMU_ARTIFACT_DIR/qemu-selinux-generated-headers.sha256"
+
+info "Building generic ARM64 QEMU kernel with $PROFILE diagnostics"
+""",
+    "generate SELinux headers before the generic QEMU Image build",
+)
+
 path.write_text(text)
 PY
 
@@ -67,5 +91,7 @@ grep -Fq '  TASKSTATS \' "$RUNTIME_SCRIPT"
 grep -Fq '  ARCH_QCOM \' "$RUNTIME_SCRIPT"
 grep -Fq '  COMMON_CLK_QCOM \' "$RUNTIME_SCRIPT"
 grep -Fq 'TASKSTATS ARCH_QCOM COMMON_CLK_QCOM SCHED_WALT' "$RUNTIME_SCRIPT"
+grep -Fq 'qemu_genheaders="$QEMU_OUT/scripts/selinux/genheaders/genheaders"' "$RUNTIME_SCRIPT"
+grep -Fq 'qemu-selinux-generated-headers.sha256' "$RUNTIME_SCRIPT"
 
 "$RUNTIME_SCRIPT" "$@"


### PR DESCRIPTION
## Summary

- generate the SELinux `flask.h` and `av_permissions.h` files inside the generic QEMU output tree before compiling the kernel Image
- verify that the generated headers are non-empty
- store their SHA-256 hashes in the non-flashable diagnostic artifact
- keep the A52 phone defconfig and phone build path unchanged

## Why

Run 29126115017 passed the earlier taskstats, Qualcomm-driver, scheduler, BPF, and Kconfig blockers. Both KASAN and Lockdep builds then failed identically while compiling `drivers/kernelsu/infra/file_wrapper.o` because `security/selinux/include/objsec.h` could not find generated `flask.h`.

The focused A52 object audit already handles this vendor build-system gap by building `scripts/selinux/genheaders/` and placing `flask.h` plus `av_permissions.h` under the selected output directory. The generic QEMU output tree did not repeat that preparation before `make Image`.

This change applies the same known-working generation sequence to the disposable QEMU output tree immediately before the full kernel build.

## Safety

This remains a generic non-flashable QEMU diagnostic path. It does not modify the A52 defconfig, boot image packaging, device tree, or physical-device artifacts.