### PR TITLE
Fix nested Python quoting in QEMU stress wrapper

### DIFF
--- a/scripts/11_qemu_full_stack_stress_scoped.sh
+++ b/scripts/11_qemu_full_stack_stress_scoped.sh
@@ -112,16 +112,17 @@ import sys
 
 path = Path(sys.argv[1])
 text = path.read_text()
-old = """int qpnp_pon_wd_config(bool enable)
+# This snippet is embedded in an outer triple-double-quoted string.
+old = '''int qpnp_pon_wd_config(bool enable)
 {
 \treturn -ENODEV;
 }
-"""
-new = """static inline int qpnp_pon_wd_config(bool enable)
+'''
+new = '''static inline int qpnp_pon_wd_config(bool enable)
 {
 \treturn -ENODEV;
 }
-"""
+'''
 count = text.count(old)
 if count != 1:
     raise SystemExit(f"disabled qpnp_pon_wd_config fallback: expected one match, found {count}")


### PR DESCRIPTION
## Summary

- replace the inner QPNP patch literals with triple-single-quoted Python strings
- keep the outer runtime-script transformation as triple-double-quoted text
- preserve the intended `qpnp_pon_wd_config()` `static inline` compatibility fix unchanged

## Why

Run 29128091236 did not reach the A52 audit or generic QEMU kernel build. Both KASAN and Lockdep jobs failed immediately when `scripts/11_qemu_full_stack_stress_scoped.sh` executed its embedded Python transformation.

PR #11 inserted an inner Python snippet using `old = """..."""` and `new = """..."""` inside an outer `"""..."""` replacement string. Those inner delimiters prematurely terminated the outer string, producing a Python syntax error. This also explains why the run-13 artifacts contain only the pre-stress preparation records and no QEMU config, build log, Image, initramfs, or serial output.

The corrected form uses `'''...'''` for the inner literals. A focused `python -m py_compile` parser test passes with the corrected nested structure.

## Safety

This is a wrapper-only quoting correction. It does not change the A52 defconfig, kernel source patch semantics, QEMU configuration, stress workload, device tree, packaging, or any flashable artifact.