### PR TITLE
Cache QEMU builds and prune phone-only linker dependencies

### DIFF
--- a/.github/workflows/06-qemu-full-stack-stress.yml
+++ b/.github/workflows/06-qemu-full-stack-stress.yml
@@ -14,11 +14,13 @@ on:
     paths:
       - '.github/workflows/06-qemu-full-stack-stress.yml'
       - 'tests/qemu/full_stack_stress.c'
+      - 'sources.lock'
+      - 'scripts/common.sh'
+      - 'scripts/01_prepare_source.sh'
       - 'scripts/03_apply_linux_4.19.153.sh'
-      - 'scripts/09_prepare_susfs_v1_5_5_a52xq.sh'
-      - 'scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v2.sh'
-      - 'scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v3.sh'
-      - 'scripts/09_integrate_susfs_v1_5_5.sh'
+      - 'scripts/05_repair_bpf_verifier.sh'
+      - 'scripts/07_*.sh'
+      - 'scripts/09_*.sh'
       - 'scripts/11_qemu_full_stack_stress.sh'
       - 'scripts/11_qemu_full_stack_stress_scoped.sh'
 
@@ -33,8 +35,112 @@ env:
   JOBS: '4'
 
 jobs:
+  prepare-source:
+    name: Prepare shared Linux 4.19.153 + SukiSU + SUSFS source
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    outputs:
+      prepared_source_cache_key: ${{ steps.source-key.outputs.key }}
+
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          df -h
+
+      - name: Calculate prepared-source cache key
+        id: source-key
+        run: |
+          echo "key=a52-prepared-source-v1-${{ runner.os }}-${{ hashFiles('sources.lock', 'scripts/common.sh', 'scripts/01_prepare_source.sh', 'scripts/03_apply_linux_4.19.153.sh', 'scripts/05_repair_bpf_verifier.sh', 'scripts/07_*.sh', 'scripts/09_*.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore prepared source
+        id: prepared-source-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            workspace/touchgrass-a52xq
+            artifacts/susfs-v1.5.5-integration.txt
+          key: ${{ steps.source-key.outputs.key }}
+
+      - name: Install source-preparation dependencies
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils make gcc g++ bc bison flex \
+            libssl-dev libelf-dev python3 rsync cpio gzip file binutils
+
+      - name: Prepare exact touchGrass baseline source
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: |
+          chmod +x scripts/*.sh
+          ./scripts/01_prepare_source.sh
+
+      - name: Apply official Linux 4.19.153 update
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/03_apply_linux_4.19.153.sh
+
+      - name: Apply BPF verifier repair
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/05_repair_bpf_verifier.sh
+
+      - name: Integrate pinned SukiSU Ultra with Kernel Unmount blocked
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/07_integrate_sukisu.sh
+
+      - name: Correct SukiSU Kconfig placement
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/07_fix_sukisu_kconfig.sh
+
+      - name: Apply SukiSU Linux 4.19 compatibility layers
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: |
+          ./scripts/07_patch_sukisu_4.19_compat.sh
+          ./scripts/07_patch_sukisu_4.19_file_wrapper.sh
+          ./scripts/07_patch_sukisu_4.19_manager_policy.sh
+          ./scripts/07_patch_sukisu_4.19_runtime_selinux.sh
+          ./scripts/07_normalize_sukisu_4.19_legacy_sepolicy.sh
+          ./scripts/07_fix_sukisu_4.19_selinux_rcu_deadlock.sh
+          ./scripts/07_fix_sukisu_4.19_filename_trans_bitmap.sh
+          ./scripts/07_patch_sukisu_4.19_supercall.sh
+
+      - name: Prepare exact A52XQ SUSFS v1.5.5 integration logic
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/09_prepare_susfs_v1_5_5_a52xq.sh
+
+      - name: Make A52XQ SUSFS namespace resolution context-safe
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v2.sh
+
+      - name: Integrate quarantined SUSFS source into disposable test tree
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        run: ./scripts/09_integrate_susfs_v1_5_5.sh
+
+      - name: Verify prepared source
+        run: |
+          test -d workspace/touchgrass-a52xq/.git
+          test -d workspace/touchgrass-a52xq/KernelSU/.git
+          test -s artifacts/susfs-v1.5.5-integration.txt
+          git -C workspace/touchgrass-a52xq rev-parse --verify HEAD
+          git -C workspace/touchgrass-a52xq/KernelSU rev-parse --verify HEAD
+
+      - name: Save prepared source
+        if: steps.prepared-source-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            workspace/touchgrass-a52xq
+            artifacts/susfs-v1.5.5-integration.txt
+          key: ${{ steps.source-key.outputs.key }}
+
   qemu-stress:
     name: QEMU ${{ matrix.profile }} - Linux 4.19.153 + BPF + SukiSU + SUSFS
+    needs: prepare-source
     runs-on: ubuntu-22.04
     timeout-minutes: 180
     strategy:
@@ -55,52 +161,71 @@ jobs:
           sudo rm -rf /opt/ghc || true
           df -h
 
-      - name: Install kernel, ARM64 and QEMU dependencies
+      - name: Install kernel, ARM64, QEMU and cache dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            git curl xz-utils make gcc g++ bc bison flex \
+            git curl xz-utils make gcc g++ bc bison flex ccache \
             libssl-dev libelf-dev python3 rsync cpio gzip file binutils \
             qemu-system-arm gcc-aarch64-linux-gnu libc6-dev-arm64-cross
           qemu-system-aarch64 --version
           aarch64-linux-gnu-gcc --version | head -n 1
+          ccache --version | head -n 1
 
-      - name: Prepare exact touchGrass baseline source
+      - name: Restore prepared source
+        id: prepared-source-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            workspace/touchgrass-a52xq
+            artifacts/susfs-v1.5.5-integration.txt
+          key: ${{ needs.prepare-source.outputs.prepared_source_cache_key }}
+
+      - name: Verify restored prepared source
         run: |
+          test '${{ steps.prepared-source-restore.outputs.cache-hit }}' = 'true'
           chmod +x scripts/*.sh
-          ./scripts/01_prepare_source.sh
+          test -d workspace/touchgrass-a52xq/.git
+          test -d workspace/touchgrass-a52xq/KernelSU/.git
+          test -s artifacts/susfs-v1.5.5-integration.txt
 
-      - name: Apply official Linux 4.19.153 update
-        run: ./scripts/03_apply_linux_4.19.153.sh
+      - name: Restore ${{ matrix.profile }} compiler cache
+        id: ccache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .ccache
+          key: a52-qemu-ccache-v1-${{ runner.os }}-${{ matrix.profile }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            a52-qemu-ccache-v1-${{ runner.os }}-${{ matrix.profile }}-
 
-      - name: Apply BPF verifier repair
-        run: ./scripts/05_repair_bpf_verifier.sh
-
-      - name: Integrate pinned SukiSU Ultra with Kernel Unmount blocked
-        run: ./scripts/07_integrate_sukisu.sh
-
-      - name: Correct SukiSU Kconfig placement
-        run: ./scripts/07_fix_sukisu_kconfig.sh
-
-      - name: Apply SukiSU Linux 4.19 compatibility layers
+      - name: Configure compiler cache
+        id: ccache-config
         run: |
-          ./scripts/07_patch_sukisu_4.19_compat.sh
-          ./scripts/07_patch_sukisu_4.19_file_wrapper.sh
-          ./scripts/07_patch_sukisu_4.19_manager_policy.sh
-          ./scripts/07_patch_sukisu_4.19_runtime_selinux.sh
-          ./scripts/07_normalize_sukisu_4.19_legacy_sepolicy.sh
-          ./scripts/07_fix_sukisu_4.19_selinux_rcu_deadlock.sh
-          ./scripts/07_fix_sukisu_4.19_filename_trans_bitmap.sh
-          ./scripts/07_patch_sukisu_4.19_supercall.sh
-
-      - name: Prepare exact A52XQ SUSFS v1.5.5 integration logic
-        run: ./scripts/09_prepare_susfs_v1_5_5_a52xq.sh
-
-      - name: Make A52XQ SUSFS namespace resolution context-safe
-        run: ./scripts/09_fix_susfs_v1_5_5_a52xq_resolver_v2.sh
-
-      - name: Integrate quarantined SUSFS source into disposable test tree
-        run: ./scripts/09_integrate_susfs_v1_5_5.sh
+          mkdir -p "$GITHUB_WORKSPACE/.ccache"
+          source scripts/common.sh
+          configure_toolchain
+          bundled_clang="$CC"
+          real_clang="${bundled_clang}.ccache-real"
+          test -x "$bundled_clang"
+          test ! -e "$real_clang"
+          mv "$bundled_clang" "$real_clang"
+          printf '#!/usr/bin/env bash\nexec ccache %q "$@"\n' "$real_clang" > "$bundled_clang"
+          chmod +x "$bundled_clang"
+          {
+            echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache"
+            echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE"
+            echo "CCACHE_NOHASHDIR=true"
+            echo "CCACHE_COMPRESS=true"
+          } >> "$GITHUB_ENV"
+          export CCACHE_DIR="$GITHUB_WORKSPACE/.ccache"
+          export CCACHE_BASEDIR="$GITHUB_WORKSPACE"
+          export CCACHE_NOHASHDIR=true
+          export CCACHE_COMPRESS=true
+          ccache --set-config=max_size=2G
+          ccache --set-config=compiler_check=content
+          ccache --zero-stats
+          ccache --show-config
+          "$bundled_clang" --version | head -n 1
 
       - name: Run non-flashable ${{ matrix.profile }} QEMU stress lab
         env:
@@ -109,6 +234,19 @@ jobs:
           ./scripts/11_qemu_full_stack_stress_scoped.sh \
             '${{ matrix.profile }}' \
             "$STRESS_SECONDS"
+
+      - name: Record compiler-cache statistics
+        if: always() && steps.ccache-config.outcome == 'success'
+        run: |
+          mkdir -p artifacts
+          ccache --show-stats > artifacts/ccache-${{ matrix.profile }}.txt || true
+
+      - name: Save ${{ matrix.profile }} compiler cache
+        if: always() && steps.ccache-config.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: a52-qemu-ccache-v1-${{ runner.os }}-${{ matrix.profile }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Record runner and source state
         if: always()

--- a/scripts/11_qemu_full_stack_stress_scoped.sh
+++ b/scripts/11_qemu_full_stack_stress_scoped.sh
@@ -38,12 +38,14 @@ replace_once(
   SECURITYFS \\
   SECURITY_SELINUX \\
 """,
-    """  SECURITY \\
+    """  IPV6 \\
+  SAMSUNG_PRODUCT_SHIP \\
+  SECURITY \\
   SECURITY_NETWORK \\
   SECURITYFS \\
   SECURITY_SELINUX \\
 """,
-    "enable SELinux network dependency",
+    "enable generic networking and SELinux dependencies",
 )
 
 replace_once(
@@ -54,6 +56,21 @@ replace_once(
   TASKSTATS \\
   ARCH_QCOM \\
   COMMON_CLK_QCOM \\
+  SEC_PM \\
+  SEC_MM \\
+  SOC_BUS \\
+  INPUT \\
+  HID \\
+  DRM \\
+  FB \\
+  MEDIA_SUPPORT \\
+  SOUND \\
+  SND \\
+  USB \\
+  MMC \\
+  ATA \\
+  SCSI \\
+  NETFILTER \\
   SCHED_WALT \\
 """,
     "extend unused QEMU subsystem disable list",
@@ -72,7 +89,7 @@ config_value SECURITY_SELINUX_SIDTAB_HASH_BITS 9
 
 replace_once(
     """(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|KVM|KEXEC|CRASH_DUMP|NFS_FS|TRANSPARENT_HUGEPAGE|FANOTIFY|SCHED_WALT)""",
-    """(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|KVM|KEXEC|CRASH_DUMP|NFS_FS|TRANSPARENT_HUGEPAGE|FANOTIFY|TASKSTATS|ARCH_QCOM|COMMON_CLK_QCOM|SECURITY_NETWORK|NETWORK_SECMARK|SECURITY_SELINUX|SECURITY_SELINUX_SIDTAB_HASH_BITS|SCHED_WALT)""",
+    """(MODULES|EXT4_FS|KPROBES|KSU|PROVE_LOCKING|KASAN|IPV6|SAMSUNG_PRODUCT_SHIP|KVM|KEXEC|CRASH_DUMP|NFS_FS|TRANSPARENT_HUGEPAGE|FANOTIFY|TASKSTATS|ARCH_QCOM|COMMON_CLK_QCOM|SEC_PM|SEC_MM|SOC_BUS|INPUT|HID|DRM|FB|MEDIA_SUPPORT|SOUND|SND|USB|MMC|ATA|SCSI|NETFILTER|SECURITY_NETWORK|NETWORK_SECMARK|SECURITY_SELINUX|SECURITY_SELINUX_SIDTAB_HASH_BITS|SCHED_WALT)""",
     "extend QEMU key-symbol diagnostics",
 )
 
@@ -81,12 +98,14 @@ replace_once(
   KSU \\
 """,
     """  EXT4_FS \\
+  IPV6 \\
+  SAMSUNG_PRODUCT_SHIP \\
   SECURITY_NETWORK \\
   NETWORK_SECMARK \\
   SECURITY_SELINUX \\
   KSU \\
 """,
-    "require resolved SELinux dependencies",
+    "require resolved generic network and SELinux dependencies",
 )
 
 replace_once(
@@ -96,7 +115,7 @@ for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY SCHED_
     """fi
 grep -Fq 'CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9' "$QEMU_CONFIG" \\
   || fail "QEMU config did not retain CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9"
-for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY TASKSTATS ARCH_QCOM COMMON_CLK_QCOM SCHED_WALT; do
+for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY TASKSTATS ARCH_QCOM COMMON_CLK_QCOM SEC_PM SEC_MM SOC_BUS INPUT HID DRM FB MEDIA_SUPPORT SOUND SND USB MMC ATA SCSI NETFILTER SCHED_WALT; do
 """,
     "validate resolved SELinux sidtab and disabled subsystems",
 )
@@ -104,7 +123,44 @@ for disabled in KVM KEXEC CRASH_DUMP NFS_FS TRANSPARENT_HUGEPAGE FANOTIFY TASKST
 replace_once(
     """info "Generating generic ARM64 virt config from the exact patched source tree"
 """,
-    """info "Fixing disabled QPNP power-on fallback linkage for the generic QEMU build"
+    """info "Restoring standard skb fragment release for the generic QEMU build"
+skbuff_source="$KERNEL_DIR/net/core/skbuff.c"
+python3 - "$skbuff_source" <<'PY_SKBUFF'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+old_decl = '''extern int ipa3_add_pool_page(struct page *page);
+
+'''
+old_release = '''\tfor (i = 0; i < shinfo->nr_frags; i++) {
+\t\tif (ipa3_add_pool_page(shinfo->frags[i].page.p) < 0)
+\t\t\t__skb_frag_unref(&shinfo->frags[i]);
+\t}
+'''
+new_release = '''\tfor (i = 0; i < shinfo->nr_frags; i++)
+\t\t__skb_frag_unref(&shinfo->frags[i]);
+'''
+if text.count(old_decl) != 1:
+    raise SystemExit(f"IPA skb pool declaration: expected one match, found {text.count(old_decl)}")
+if text.count(old_release) != 1:
+    raise SystemExit(f"IPA skb fragment release: expected one match, found {text.count(old_release)}")
+text = text.replace(old_decl, '', 1)
+text = text.replace(old_release, new_release, 1)
+path.write_text(text)
+PY_SKBUFF
+! grep -Fq 'ipa3_add_pool_page' "$skbuff_source" \\
+  || fail "QEMU skb fragment release still references the phone IPA pool"
+grep -Fq '__skb_frag_unref(&shinfo->frags[i]);' "$skbuff_source" \\
+  || fail "Standard QEMU skb fragment release is missing"
+git -C "$KERNEL_DIR" diff --check -- net/core/skbuff.c
+git -C "$KERNEL_DIR" diff -- net/core/skbuff.c \\
+  > "$QEMU_ARTIFACT_DIR/qemu-skb-fragment-release-compat.patch"
+test -s "$QEMU_ARTIFACT_DIR/qemu-skb-fragment-release-compat.patch" \\
+  || fail "QEMU skb fragment release compatibility patch is empty"
+
+info "Fixing disabled QPNP power-on fallback linkage for the generic QEMU build"
 qpnp_pon_header="$KERNEL_DIR/include/linux/input/qpnp-power-on.h"
 python3 - "$qpnp_pon_header" <<'PY_QPNP_PON'
 from pathlib import Path
@@ -138,7 +194,7 @@ test -s "$QEMU_ARTIFACT_DIR/qemu-qpnp-pon-fallback-compat.patch" \\
 
 info "Generating generic ARM64 virt config from the exact patched source tree"
 """,
-    "make disabled QPNP power-on fallback internal to each translation unit",
+    "prune phone-only linker dependencies from the generic QEMU build",
 )
 
 replace_once(
@@ -177,7 +233,14 @@ grep -Fq '  COMMON_CLK_QCOM \' "$RUNTIME_SCRIPT"
 grep -Fq '  SECURITY_NETWORK \' "$RUNTIME_SCRIPT"
 grep -Fq '  NETWORK_SECMARK \' "$RUNTIME_SCRIPT"
 grep -Fq '  SECURITY_SELINUX \' "$RUNTIME_SCRIPT"
+grep -Fq '  IPV6 \' "$RUNTIME_SCRIPT"
+grep -Fq '  SAMSUNG_PRODUCT_SHIP \' "$RUNTIME_SCRIPT"
+grep -Fq '  SEC_PM \' "$RUNTIME_SCRIPT"
+grep -Fq '  SEC_MM \' "$RUNTIME_SCRIPT"
+grep -Fq '  NETFILTER \' "$RUNTIME_SCRIPT"
 grep -Fq 'CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9' "$RUNTIME_SCRIPT"
+grep -Fq '__skb_frag_unref(&shinfo->frags[i]);' "$RUNTIME_SCRIPT"
+grep -Fq 'qemu-skb-fragment-release-compat.patch' "$RUNTIME_SCRIPT"
 grep -Fq 'static inline int qpnp_pon_wd_config(bool enable)' "$RUNTIME_SCRIPT"
 grep -Fq 'qemu-qpnp-pon-fallback-compat.patch' "$RUNTIME_SCRIPT"
 grep -Fq 'qemu_genheaders="$QEMU_OUT/scripts/selinux/genheaders/genheaders"' "$RUNTIME_SCRIPT"


### PR DESCRIPTION
## Summary

- prepare the patched Linux 4.19.153 + SukiSU + SUSFS source once in a dedicated job
- save and restore that exact prepared tree for both Lockdep and KASAN jobs
- add separate persistent `ccache` stores for the bundled Clang compiler used by each profile
- save compiler caches even when a late compile, link, or runtime step fails
- record compiler-cache statistics in the diagnostic artifacts
- prune unused Samsung, Qualcomm, multimedia, storage, input and netfilter subsystems from the generic QEMU guest
- enable built-in IPv6 and the normal Samsung product-ship delay path
- restore standard upstream-style skb fragment release in the disposable QEMU source tree instead of calling the phone-only IPA page pool

## Why

Run 29128379606 confirmed that the QPNP fallback fix worked: both profiles completed object compilation and reached the final `vmlinux` link. The link then failed with 23 unique unresolved vendor symbols, including `sec_delay_check`, `ion_account_print_usage`, `qcom_smem_get`, QPNP/SEC PM hooks, touchscreen DRM notifier helpers, MMC Qualcomm PM-QoS helpers, `ipa3_add_pool_page`, IPv6 lookup code and a custom domain-filter netfilter match.

These symbols come from phone-specific subsystems selected by the broad ARM64 vendor `defconfig`; none is exercised by the QEMU stress guest. The scoped fix disables those top-level subsystems only in the generic guest, while retaining BPF, SukiSU, SUSFS, SELinux, KASAN/Lockdep, namespaces, tmpfs and the PL011 QEMU console.

The Samsung non-ship delay macro directly references `sec_delay_check`, so the generic guest now enables `CONFIG_SAMSUNG_PRODUCT_SHIP=y`, which uses the normal delay implementation. IPv6 is forced built-in rather than modular to keep BPF networking references inside `vmlinux`.

The vendor `net/core/skbuff.c` unconditionally calls the Qualcomm IPA page-pool helper. For the generic guest only, that path is replaced with the standard `__skb_frag_unref()` behavior and the generated patch is saved in the diagnostic artifact.

## Cache safety

The prepared-source cache uses an exact key derived from `sources.lock`, `common.sh`, and every source preparation, Linux update, BPF, SukiSU and SUSFS integration script. No fallback prefix is used for this cache, so a changed pin or preparation script cannot restore an older patched tree.

The compiler cache is separate for Lockdep and KASAN. `ccache` validates compiler content, source input and flags before reusing an object. Each cache is capped at 2 GiB and is saved even after late failures.

## Scope and safety

All source compatibility edits occur after the strict A52 object audit and before the disposable generic QEMU build. The A52 defconfig, physical-device drivers, device tree, packaging, stress workload and all phone-flashable outputs remain unchanged.

The first run after merging will populate the prepared-source and compiler caches. Later retries should skip repeated source integration and reuse most unchanged objects.