### PR TITLE
Fix nested newline escaping in QCOM socinfo patch

### DIFF
--- a/scripts/11_qemu_full_stack_stress_scoped.sh
+++ b/scripts/11_qemu_full_stack_stress_scoped.sh
@@ -165,9 +165,9 @@ import sys
 
 path = Path(sys.argv[1])
 text = path.read_text()
-old = 'obj-$(CONFIG_SOC_BUS) += socinfo.o\n'
-new = 'obj-$(CONFIG_ARCH_QCOM) += socinfo.o\n'
-count = text.count(old)
+old = 'obj-$(CONFIG_SOC_BUS) += socinfo.o'
+new = 'obj-$(CONFIG_ARCH_QCOM) += socinfo.o'
+count = sum(line == old for line in text.splitlines())
 if count != 1:
     raise SystemExit(f"QCOM socinfo Makefile gate: expected one match, found {count}")
 path.write_text(text.replace(old, new, 1))


### PR DESCRIPTION
Superseded by the clean ReSukiSU + Linux 4.19.325 rebase effort on `rebase/resukisu-linux-4.19.325`. The previous SukiSU/QEMU path is intentionally retired and should not be merged.