### PR TITLE
Add minimal Android 4.19 GKI build probe

### DIFF
--- a/.github/workflows/30-gki-4.19-minimal-probe.yml
+++ b/.github/workflows/30-gki-4.19-minimal-probe.yml
@@ -1,0 +1,68 @@
+name: 30 - Minimal Android 4.19 GKI probe
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/gki-4.19-minimal-probe
+    paths:
+      - '.github/workflows/30-gki-4.19-minimal-probe.yml'
+      - 'scripts/30_build_ack_4_19_gki_minimal.sh'
+      - 'gki-sources.lock'
+      - 'projects/gki-4.19-minimal/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a52-gki-4.19-minimal-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  JOBS: '4'
+
+jobs:
+  build-gki:
+    name: Build untouched ACK 4.19 GKI
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          df -h
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git make bc bison flex libssl-dev libelf-dev \
+            clang-14 lld-14 llvm-14 python3 rsync cpio xz-utils file
+
+      - name: Build stock Android 4.19 GKI image
+        run: |
+          chmod +x scripts/30_build_ack_4_19_gki_minimal.sh
+          ./scripts/30_build_ack_4_19_gki_minimal.sh
+
+      - name: Record runner state
+        if: always()
+        run: |
+          mkdir -p artifacts/gki-4.19-minimal
+          df -h > artifacts/gki-4.19-minimal/runner-disk.txt
+          free -h > artifacts/gki-4.19-minimal/runner-memory.txt
+          uname -a > artifacts/gki-4.19-minimal/runner-uname.txt
+
+      - name: Upload GKI build and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-ack-4.19-gki-minimal-${{ github.run_number }}
+          path: artifacts/gki-4.19-minimal/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/30-gki-4.19-minimal-probe.yml
+++ b/.github/workflows/30-gki-4.19-minimal-probe.yml
@@ -51,7 +51,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             git make bc bison flex libssl-dev libelf-dev \
-            clang-14 lld-14 llvm-14 python3 rsync cpio xz-utils file
+            clang-14 lld-14 llvm-14 \
+            gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            python3 rsync cpio xz-utils file
 
       - name: Build stock Android 4.19 GKI image
         run: |

--- a/.github/workflows/30-gki-4.19-minimal-probe.yml
+++ b/.github/workflows/30-gki-4.19-minimal-probe.yml
@@ -10,6 +10,14 @@ on:
       - 'scripts/30_build_ack_4_19_gki_minimal.sh'
       - 'gki-sources.lock'
       - 'projects/gki-4.19-minimal/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/30-gki-4.19-minimal-probe.yml'
+      - 'scripts/30_build_ack_4_19_gki_minimal.sh'
+      - 'gki-sources.lock'
+      - 'projects/gki-4.19-minimal/**'
 
 permissions:
   contents: read

--- a/.github/workflows/30-gki-4.19-minimal-probe.yml
+++ b/.github/workflows/30-gki-4.19-minimal-probe.yml
@@ -2,14 +2,6 @@ name: 30 - Minimal Android 4.19 GKI probe
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - agent/gki-4.19-minimal-probe
-    paths:
-      - '.github/workflows/30-gki-4.19-minimal-probe.yml'
-      - 'scripts/30_build_ack_4_19_gki_minimal.sh'
-      - 'gki-sources.lock'
-      - 'projects/gki-4.19-minimal/**'
   pull_request:
     branches:
       - main
@@ -24,10 +16,10 @@ permissions:
 
 concurrency:
   group: a52-gki-4.19-minimal-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
-  JOBS: '4'
+  JOBS: '8'
 
 jobs:
   build-gki:

--- a/gki-sources.lock
+++ b/gki-sources.lock
@@ -1,0 +1,12 @@
+# Official Android Common Kernel source used by the minimal GKI probe.
+# This is intentionally separate from sources.lock, which tracks touchGrass.
+
+GKI_REPO=https://android.googlesource.com/kernel/common
+GKI_BRANCH=deprecated/android-4.19-stable
+GKI_COMMIT=a8bf86a0e0fa05070897a210d706d5c4d83c26ac
+GKI_DEFCONFIG=gki_defconfig
+GKI_ARCH=arm64
+
+# The first checkpoint uses the Ubuntu 22.04 LLVM 14 packages.
+# Record the exact installed versions in every workflow artifact.
+LLVM_MAJOR=14

--- a/projects/gki-4.19-minimal/README.md
+++ b/projects/gki-4.19-minimal/README.md
@@ -1,0 +1,92 @@
+# Minimal Android 4.19 GKI project for a52xq
+
+## Goal
+
+Start from the smallest official Android Common Kernel GKI configuration that is remotely compatible with the Samsung Galaxy A52 5G generation, then add device support only after the stock GKI kernel builds cleanly.
+
+The known working rollback remains the existing touchGrass Linux 4.19.200 flashable package. This project does not modify or replace it.
+
+## Why the first target is Android 4.19 GKI
+
+The Galaxy A52 5G launched with a Samsung and Qualcomm Linux 4.19 vendor kernel. Its current layout is non-A/B, uses Android boot header version 2, embeds the base DTB in `boot.img`, and has no `vendor_boot` or `init_boot` partition.
+
+A modern GKI 2.0 kernel such as 5.10 or 6.1 expects a different kernel and vendor-module architecture. Moving directly to it would require porting the SM7125 platform, rebuilding the complete vendor module set, and changing boot integration. That is not a simple kernel update.
+
+Android's older GKI 1.0 work included a 4.19 GKI configuration. This makes official ACK 4.19 the correct minimal experiment, although the A52 still cannot boot the untouched generic image.
+
+## Checkpoint 0: stock GKI build probe
+
+Workflow:
+
+`30 - Minimal Android 4.19 GKI probe`
+
+Source:
+
+- Repository: `https://android.googlesource.com/kernel/common`
+- Branch: `deprecated/android-4.19-stable`
+- Pinned commit: `a8bf86a0e0fa05070897a210d706d5c4d83c26ac`
+- Defconfig: `gki_defconfig`
+- Architecture: `arm64`
+
+This checkpoint builds:
+
+- `Image`
+- `vmlinux`
+- `System.map`
+- `Module.symvers`
+- the expanded and minimal GKI configurations
+- all modules produced by the generic configuration
+- compiler, source, checksum, and build logs
+
+## Safety gate
+
+The output from Checkpoint 0 is not flashable.
+
+It intentionally contains no Samsung A52 board support, no SM7125 device tree, no Samsung boot-image packaging, no SukiSU, no SUSFS, and no AnyKernel3 package. The workflow also writes a flashing warning into the artifact.
+
+Do not copy the generated `Image` into the existing flashable ZIP.
+
+## Success criteria
+
+Checkpoint 0 passes only when:
+
+1. The pinned ACK commit is checked out exactly.
+2. The official arm64 `gki_defconfig` is generated without manual device changes.
+3. `Image` and modules build successfully with LLVM.
+4. The workflow uploads the complete diagnostic artifact.
+
+A clean compile proves only that the generic kernel source and toolchain are usable. It does not prove that the kernel can boot on a52xq.
+
+## Planned checkpoints
+
+### Checkpoint 1: compatibility inventory
+
+Compare the stock GKI configuration and exported symbols with the known working touchGrass 4.19.200 build. Classify each A52 dependency as:
+
+- available in GKI core
+- available as a GKI module
+- missing and suitable for a vendor module
+- missing and required before module loading
+- Samsung or Qualcomm code that must remain built into the kernel
+
+### Checkpoint 2: early-boot platform skeleton
+
+Add only the minimum SM7125 support required to reach early console or ramoops. Keep display, camera, audio, sensors, Wi-Fi, and root modifications out of scope.
+
+### Checkpoint 3: boot-layout integration
+
+Determine whether a hybrid header-v2 image can be used for development or whether a true GKI-style header-v3 and vendor ramdisk arrangement is possible with the Samsung bootloader and partition table.
+
+### Checkpoint 4: controlled hardware bring-up
+
+Add hardware groups one at a time and retain a rollback image for every device test.
+
+## Stop conditions
+
+Stop before packaging or flashing when any of the following is true:
+
+- the stock GKI build is not reproducible
+- the required early-boot drivers cannot be separated from the old vendor core
+- the Samsung bootloader rejects the required boot format
+- there is no reliable ramoops or recovery path
+- a generated image exceeds the known boot partition limits

--- a/scripts/30_build_ack_4_19_gki_minimal.sh
+++ b/scripts/30_build_ack_4_19_gki_minimal.sh
@@ -52,6 +52,10 @@ if [[ ! -x "$LLVM_BIN/clang" || ! -x "$LLVM_BIN/ld.lld" ]]; then
   echo "LLVM ${LLVM_MAJOR} was not found in $LLVM_BIN" >&2
   exit 1
 fi
+if ! command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
+  echo "The aarch64-linux-gnu cross toolchain was not found" >&2
+  exit 1
+fi
 export PATH="$LLVM_BIN:$PATH"
 
 rm -rf "$WORK_DIR" "$ARTIFACT_DIR"
@@ -101,6 +105,9 @@ set_stage "toolchain-recording"
   echo "== llvm-ar =="
   llvm-ar --version
   echo
+  echo "== arm64 gcc prefix =="
+  aarch64-linux-gnu-gcc --version
+  echo
   echo "== make =="
   make --version
 } > "$ARTIFACT_DIR/toolchain.txt"
@@ -109,6 +116,15 @@ make_args=(
   -C "$SRC_DIR"
   O="$OUT_DIR"
   ARCH="$GKI_ARCH"
+  CROSS_COMPILE=aarch64-linux-gnu-
+  CLANG_TRIPLE=aarch64-linux-gnu-
+  CC=clang
+  LD=ld.lld
+  AR=llvm-ar
+  NM=llvm-nm
+  OBJCOPY=llvm-objcopy
+  OBJDUMP=llvm-objdump
+  STRIP=llvm-strip
   LLVM=1
   LLVM_IAS=1
 )

--- a/scripts/30_build_ack_4_19_gki_minimal.sh
+++ b/scripts/30_build_ack_4_19_gki_minimal.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK_FILE="$ROOT_DIR/gki-sources.lock"
+WORK_DIR="${WORK_DIR:-$ROOT_DIR/work-gki-4.19}"
+SRC_DIR="$WORK_DIR/common"
+OUT_DIR="$WORK_DIR/out"
+ARTIFACT_DIR="$ROOT_DIR/artifacts/gki-4.19-minimal"
+JOBS="${JOBS:-4}"
+
+if [[ ! -f "$LOCK_FILE" ]]; then
+  echo "Missing $LOCK_FILE" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$LOCK_FILE"
+
+required_vars=(GKI_REPO GKI_BRANCH GKI_COMMIT GKI_DEFCONFIG GKI_ARCH LLVM_MAJOR)
+for var_name in "${required_vars[@]}"; do
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Missing $var_name in $LOCK_FILE" >&2
+    exit 1
+  fi
+done
+
+LLVM_BIN="/usr/lib/llvm-${LLVM_MAJOR}/bin"
+if [[ ! -x "$LLVM_BIN/clang" || ! -x "$LLVM_BIN/ld.lld" ]]; then
+  echo "LLVM ${LLVM_MAJOR} was not found in $LLVM_BIN" >&2
+  exit 1
+fi
+export PATH="$LLVM_BIN:$PATH"
+
+rm -rf "$WORK_DIR" "$ARTIFACT_DIR"
+mkdir -p "$WORK_DIR" "$ARTIFACT_DIR/logs"
+
+{
+  echo "Repository: $GKI_REPO"
+  echo "Branch: $GKI_BRANCH"
+  echo "Pinned commit: $GKI_COMMIT"
+  echo "Architecture: $GKI_ARCH"
+  echo "Defconfig: $GKI_DEFCONFIG"
+} | tee "$ARTIFACT_DIR/source-selection.txt"
+
+echo "Cloning the pinned Android Common Kernel revision"
+git clone --no-tags --depth=1 --branch "$GKI_BRANCH" "$GKI_REPO" "$SRC_DIR" \
+  2>&1 | tee "$ARTIFACT_DIR/logs/01-clone.log"
+
+actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
+if [[ "$actual_commit" != "$GKI_COMMIT" ]]; then
+  echo "Branch head is $actual_commit, fetching the pinned commit $GKI_COMMIT"
+  git -C "$SRC_DIR" fetch --no-tags --depth=1 origin "$GKI_COMMIT" \
+    2>&1 | tee -a "$ARTIFACT_DIR/logs/01-clone.log"
+  git -C "$SRC_DIR" checkout --detach FETCH_HEAD
+  actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
+fi
+
+if [[ "$actual_commit" != "$GKI_COMMIT" ]]; then
+  echo "Pinned source verification failed: expected $GKI_COMMIT, got $actual_commit" >&2
+  exit 1
+fi
+
+{
+  echo "git_commit=$actual_commit"
+  git -C "$SRC_DIR" show -s --format='commit_date=%cI%nsubject=%s' HEAD
+} > "$ARTIFACT_DIR/source-revision.txt"
+
+{
+  clang --version
+  ld.lld --version
+  llvm-ar --version | head -n 1
+  make --version | head -n 1
+} > "$ARTIFACT_DIR/toolchain.txt"
+
+make_args=(
+  -C "$SRC_DIR"
+  O="$OUT_DIR"
+  ARCH="$GKI_ARCH"
+  LLVM=1
+  LLVM_IAS=1
+)
+
+echo "Generating the official GKI defconfig"
+make "${make_args[@]}" "$GKI_DEFCONFIG" \
+  2>&1 | tee "$ARTIFACT_DIR/logs/02-defconfig.log"
+
+cp "$OUT_DIR/.config" "$ARTIFACT_DIR/gki_defconfig.expanded"
+make "${make_args[@]}" savedefconfig \
+  2>&1 | tee "$ARTIFACT_DIR/logs/03-savedefconfig.log"
+cp "$OUT_DIR/defconfig" "$ARTIFACT_DIR/gki_defconfig.minimal"
+
+kernel_version="$(make -s "${make_args[@]}" kernelversion)"
+printf '%s\n' "$kernel_version" > "$ARTIFACT_DIR/kernel-version.txt"
+
+echo "Building the stock arm64 GKI Image and modules"
+set +e
+make "${make_args[@]}" -j"$JOBS" Image modules \
+  2>&1 | tee "$ARTIFACT_DIR/logs/04-build.log"
+build_status=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$build_status" > "$ARTIFACT_DIR/build-exit-code.txt"
+
+# Always collect diagnostics, including on a failed build.
+for file_name in Image vmlinux System.map Module.symvers .config; do
+  if [[ -f "$OUT_DIR/$file_name" ]]; then
+    cp "$OUT_DIR/$file_name" "$ARTIFACT_DIR/$file_name"
+  fi
+done
+
+mkdir -p "$ARTIFACT_DIR/modules"
+while IFS= read -r -d '' module_path; do
+  relative_path="${module_path#"$OUT_DIR/"}"
+  mkdir -p "$ARTIFACT_DIR/modules/$(dirname "$relative_path")"
+  cp "$module_path" "$ARTIFACT_DIR/modules/$relative_path"
+done < <(find "$OUT_DIR" -type f -name '*.ko' -print0)
+
+tar -C "$ARTIFACT_DIR" -czf "$ARTIFACT_DIR/modules.tar.gz" modules
+rm -rf "$ARTIFACT_DIR/modules"
+
+for abi_file in "$SRC_DIR"/abi_gki_aarch64*; do
+  [[ -f "$abi_file" ]] && cp "$abi_file" "$ARTIFACT_DIR/"
+done
+
+if [[ -f "$OUT_DIR/.config" ]]; then
+  grep -E '^(CONFIG_MODULES|CONFIG_MODVERSIONS|CONFIG_MODULE_SIG|CONFIG_ANDROID|CONFIG_ANDROID_BINDER|CONFIG_DM_VERITY|CONFIG_VIRTUALIZATION|CONFIG_KALLSYMS|CONFIG_BPF|CONFIG_CGROUP_BPF)=' \
+    "$OUT_DIR/.config" > "$ARTIFACT_DIR/config-summary.txt" || true
+fi
+
+if [[ -f "$ARTIFACT_DIR/Image" ]]; then
+  file "$ARTIFACT_DIR/Image" > "$ARTIFACT_DIR/image-file.txt"
+  stat "$ARTIFACT_DIR/Image" > "$ARTIFACT_DIR/image-stat.txt"
+fi
+
+find "$ARTIFACT_DIR" -maxdepth 1 -type f -print0 \
+  | sort -z \
+  | xargs -0 sha256sum > "$ARTIFACT_DIR/SHA256SUMS"
+
+cat > "$ARTIFACT_DIR/FLASHING-NOTICE.txt" <<'EOF'
+THIS OUTPUT IS NOT FLASHABLE.
+
+It is a stock Android Common Kernel GKI build probe. It does not yet contain
+the Samsung Galaxy A52 5G SM7125 board support, Samsung boot integration,
+device tree integration, or the vendor-driver arrangement required by the
+phone. Do not place this Image in AnyKernel3 or flash it to the boot partition.
+EOF
+
+if (( build_status != 0 )); then
+  echo "The GKI build failed. Diagnostics were collected in $ARTIFACT_DIR." >&2
+  exit "$build_status"
+fi
+
+echo "Minimal GKI build completed: $kernel_version"
+echo "Artifacts: $ARTIFACT_DIR"

--- a/scripts/30_build_ack_4_19_gki_minimal.sh
+++ b/scripts/30_build_ack_4_19_gki_minimal.sh
@@ -9,6 +9,28 @@ OUT_DIR="$WORK_DIR/out"
 ARTIFACT_DIR="$ROOT_DIR/artifacts/gki-4.19-minimal"
 JOBS="${JOBS:-4}"
 
+record_failure() {
+  local exit_code=$?
+  local failed_line="${BASH_LINENO[0]:-unknown}"
+  local failed_command="${BASH_COMMAND:-unknown}"
+
+  trap - ERR
+  mkdir -p "$ARTIFACT_DIR"
+  {
+    echo "exit_code=$exit_code"
+    echo "line=$failed_line"
+    echo "command=$failed_command"
+    echo "stage=$(cat "$ARTIFACT_DIR/stage.txt" 2>/dev/null || echo unknown)"
+  } > "$ARTIFACT_DIR/failure-context.txt"
+  exit "$exit_code"
+}
+trap record_failure ERR
+
+set_stage() {
+  mkdir -p "$ARTIFACT_DIR"
+  printf '%s\n' "$1" > "$ARTIFACT_DIR/stage.txt"
+}
+
 if [[ ! -f "$LOCK_FILE" ]]; then
   echo "Missing $LOCK_FILE" >&2
   exit 1
@@ -34,6 +56,7 @@ export PATH="$LLVM_BIN:$PATH"
 
 rm -rf "$WORK_DIR" "$ARTIFACT_DIR"
 mkdir -p "$WORK_DIR" "$ARTIFACT_DIR/logs"
+set_stage "source-selection"
 
 {
   echo "Repository: $GKI_REPO"
@@ -43,6 +66,7 @@ mkdir -p "$WORK_DIR" "$ARTIFACT_DIR/logs"
   echo "Defconfig: $GKI_DEFCONFIG"
 } | tee "$ARTIFACT_DIR/source-selection.txt"
 
+set_stage "source-clone"
 echo "Cloning the pinned Android Common Kernel revision"
 git clone --no-tags --depth=1 --branch "$GKI_BRANCH" "$GKI_REPO" "$SRC_DIR" \
   2>&1 | tee "$ARTIFACT_DIR/logs/01-clone.log"
@@ -66,11 +90,19 @@ fi
   git -C "$SRC_DIR" show -s --format='commit_date=%cI%nsubject=%s' HEAD
 } > "$ARTIFACT_DIR/source-revision.txt"
 
+set_stage "toolchain-recording"
 {
+  echo "== clang =="
   clang --version
+  echo
+  echo "== lld =="
   ld.lld --version
-  llvm-ar --version | head -n 1
-  make --version | head -n 1
+  echo
+  echo "== llvm-ar =="
+  llvm-ar --version
+  echo
+  echo "== make =="
+  make --version
 } > "$ARTIFACT_DIR/toolchain.txt"
 
 make_args=(
@@ -81,11 +113,13 @@ make_args=(
   LLVM_IAS=1
 )
 
+set_stage "gki-defconfig"
 echo "Generating the official GKI defconfig"
 make "${make_args[@]}" "$GKI_DEFCONFIG" \
   2>&1 | tee "$ARTIFACT_DIR/logs/02-defconfig.log"
 
 cp "$OUT_DIR/.config" "$ARTIFACT_DIR/gki_defconfig.expanded"
+set_stage "save-defconfig"
 make "${make_args[@]}" savedefconfig \
   2>&1 | tee "$ARTIFACT_DIR/logs/03-savedefconfig.log"
 cp "$OUT_DIR/defconfig" "$ARTIFACT_DIR/gki_defconfig.minimal"
@@ -93,6 +127,7 @@ cp "$OUT_DIR/defconfig" "$ARTIFACT_DIR/gki_defconfig.minimal"
 kernel_version="$(make -s "${make_args[@]}" kernelversion)"
 printf '%s\n' "$kernel_version" > "$ARTIFACT_DIR/kernel-version.txt"
 
+set_stage "kernel-build"
 echo "Building the stock arm64 GKI Image and modules"
 set +e
 make "${make_args[@]}" -j"$JOBS" Image modules \
@@ -101,6 +136,7 @@ build_status=${PIPESTATUS[0]}
 set -e
 printf '%s\n' "$build_status" > "$ARTIFACT_DIR/build-exit-code.txt"
 
+set_stage "artifact-collection"
 # Always collect diagnostics, including on a failed build.
 for file_name in Image vmlinux System.map Module.symvers .config; do
   if [[ -f "$OUT_DIR/$file_name" ]]; then
@@ -150,5 +186,6 @@ if (( build_status != 0 )); then
   exit "$build_status"
 fi
 
+set_stage "complete"
 echo "Minimal GKI build completed: $kernel_version"
 echo "Artifacts: $ARTIFACT_DIR"

--- a/scripts/30_build_ack_4_19_gki_minimal.sh
+++ b/scripts/30_build_ack_4_19_gki_minimal.sh
@@ -153,10 +153,18 @@ set -e
 printf '%s\n' "$build_status" > "$ARTIFACT_DIR/build-exit-code.txt"
 
 set_stage "artifact-collection"
-# Always collect diagnostics, including on a failed build.
-for file_name in Image vmlinux System.map Module.symvers .config; do
-  if [[ -f "$OUT_DIR/$file_name" ]]; then
-    cp "$OUT_DIR/$file_name" "$ARTIFACT_DIR/$file_name"
+declare -A output_files=(
+  [Image]="$OUT_DIR/arch/arm64/boot/Image"
+  [vmlinux]="$OUT_DIR/vmlinux"
+  [System.map]="$OUT_DIR/System.map"
+  [Module.symvers]="$OUT_DIR/Module.symvers"
+  [final.config]="$OUT_DIR/.config"
+)
+
+for artifact_name in "${!output_files[@]}"; do
+  source_path="${output_files[$artifact_name]}"
+  if [[ -f "$source_path" ]]; then
+    cp "$source_path" "$ARTIFACT_DIR/$artifact_name"
   fi
 done
 
@@ -184,10 +192,6 @@ if [[ -f "$ARTIFACT_DIR/Image" ]]; then
   stat "$ARTIFACT_DIR/Image" > "$ARTIFACT_DIR/image-stat.txt"
 fi
 
-find "$ARTIFACT_DIR" -maxdepth 1 -type f -print0 \
-  | sort -z \
-  | xargs -0 sha256sum > "$ARTIFACT_DIR/SHA256SUMS"
-
 cat > "$ARTIFACT_DIR/FLASHING-NOTICE.txt" <<'EOF'
 THIS OUTPUT IS NOT FLASHABLE.
 
@@ -198,10 +202,22 @@ phone. Do not place this Image in AnyKernel3 or flash it to the boot partition.
 EOF
 
 if (( build_status != 0 )); then
+  set_stage "failed"
+else
+  set_stage "complete"
+fi
+
+(
+  cd "$ARTIFACT_DIR"
+  find . -maxdepth 1 -type f ! -name 'SHA256SUMS' -print0 \
+    | sort -z \
+    | xargs -0 sha256sum > SHA256SUMS
+)
+
+if (( build_status != 0 )); then
   echo "The GKI build failed. Diagnostics were collected in $ARTIFACT_DIR." >&2
   exit "$build_status"
 fi
 
-set_stage "complete"
 echo "Minimal GKI build completed: $kernel_version"
 echo "Artifacts: $ARTIFACT_DIR"


### PR DESCRIPTION
## What changed

- added a pinned official Android Common Kernel 4.19 GKI source definition
- added a minimal arm64 `gki_defconfig` build script
- added a GitHub Actions workflow that builds `Image`, modules, symbols, configuration, logs, and checksums
- added project documentation with explicit safety gates and staged bring-up checkpoints

## Why

The Galaxy A52 5G currently boots a Samsung and Qualcomm Linux 4.19 vendor kernel. A direct jump to a modern 5.10 or 6.1 GKI is not a simple kernel replacement because the device uses boot header version 2, has no `vendor_boot`, and still depends on built-in SM7125 and Samsung platform code.

This PR starts with the smallest useful experiment: compile the untouched official ACK 4.19 GKI configuration and collect a complete compatibility baseline.

## Checkpoint 0 result

The untouched arm64 GKI build completed successfully from pinned ACK commit `a8bf86a0e0fa05070897a210d706d5c4d83c26ac`.

Validated output:

- kernel version: `4.19.325`
- raw arm64 `Image`: 24,646,144 bytes
- `Image` SHA-256: `293a6dbfded63a112736c4ae0d942e0540b0eee37beee7ad0d1b3b74a31a0855`
- full `vmlinux`, `System.map`, `Module.symvers`, final config, logs, and checksums
- GKI modules: `arm-smmu.ko`, `ufshcd-core.ko`, and `ufshcd-pltfrm.ko`
- workflow build exit code: `0`
- artifact stage: `complete`

The artifact is named `a52xq-ack-4.19-gki-minimal-12`.

## Safety

The generated output is intentionally not packaged and must not be flashed. It contains no A52 board support, no device tree integration, no Samsung boot integration, no SukiSU, and no SUSFS.

A successful generic build proves that the official GKI source and toolchain are usable. It does not prove device boot compatibility.

## Next checkpoint

Compare this GKI config, symbols, and modules with the known-working touchGrass Linux 4.19.200 kernel. The goal is to identify which SM7125 and Samsung components must remain built in for early boot, which can become vendor modules, and which are already provided by GKI core.