### PR TITLE
Complete A52 GKI 4.19 comparison with touchGrass and UN1CA

### DIFF
--- a/.github/workflows/31-gki-touchgrass-compatibility-inventory.yml
+++ b/.github/workflows/31-gki-touchgrass-compatibility-inventory.yml
@@ -7,15 +7,13 @@ on:
       - rebase/resukisu-linux-4.19.325
     paths:
       - '.github/workflows/31-gki-touchgrass-compatibility-inventory.yml'
-      - 'gki-sources.lock'
-      - 'scripts/30_build_ack_4_19_gki_inventory.sh'
-      - 'scripts/31_collect_touchgrass_4.19.200_inventory.sh'
       - 'scripts/32_compare_gki_touchgrass.py'
       - 'scripts/34_collect_touchgrass_4.19.325_inventory.sh'
       - 'projects/gki-4.19-a52-compatibility/**'
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: a52-gki-touchgrass-compat-${{ github.ref }}
@@ -25,10 +23,12 @@ env:
   JOBS: '4'
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 5G
+  BASELINE_ARTIFACT_ID: '8343518420'
+  BASELINE_ARTIFACT_DIGEST: 'sha256:828d0d9486057dd969f956fd27f0130c0648e7fe90ddaec0467d5c90bd7d9b5e'
 
 jobs:
   compatibility-inventory:
-    name: Compare ACK GKI with touchGrass 4.19.200 and 4.19.325
+    name: Finalize same-version ACK and touchGrass 4.19.325 comparison
     runs-on: ubuntu-22.04
     timeout-minutes: 360
 
@@ -48,44 +48,46 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             git curl xz-utils zip unzip make gcc g++ bc bison flex ccache patch \
-            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar \
-            clang-14 lld-14 llvm-14 gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar
 
-      - name: Restore touchGrass compiler cache
+      - name: Restore compiler cache
         uses: actions/cache@v4
         with:
           path: .ccache
           key: a52xq-gki-full-compat-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
-            a52xq-gki-compat-4.19.200-${{ runner.os }}-
             a52xq-linux-4.19.325-ccache-${{ runner.os }}-
+            a52xq-gki-compat-4.19.200-${{ runner.os }}-
             a52xq-linux-4.19.200-ccache-${{ runner.os }}-
             a52xq-gki-full-compat-${{ runner.os }}-
 
-      - name: Prepare reviewed touchGrass 4.19.200 source
+      - name: Restore verified ACK and touchGrass 4.19.200 baseline artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          chmod +x scripts/*.sh scripts/*.py
-          ./scripts/01_prepare_source.sh
-          ./scripts/03_apply_linux_4.19.153.sh
-          ./scripts/04_apply_linux_4.19.154.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
-          ./scripts/checkpoint_resolve_linux_4.19.159.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
-          ./scripts/checkpoint_resolve_linux_4.19.164.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
-          ./scripts/checkpoint_resolve_linux_4.19.180.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
-          ./scripts/checkpoint_resolve_linux_4.19.200.sh
-
-      - name: Build and collect touchGrass 4.19.200 hardware baseline
-        run: |
-          ./scripts/07_patch_resukisu_exec_hook.sh
-          ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.200 safe
-          ./scripts/31_collect_touchgrass_4.19.200_inventory.sh
+          set -Eeuo pipefail
+          mkdir -p artifacts/compatibility
+          curl --fail --location --silent --show-error \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/$BASELINE_ARTIFACT_ID/zip" \
+            -o baseline-artifact.zip
+          unzip -q baseline-artifact.zip -d artifacts/compatibility
+          test -s artifacts/compatibility/gki/Module.symvers
+          test -s artifacts/compatibility/touchgrass/Module.symvers
+          test -s artifacts/compatibility/report/common-symbol-crc-mismatches.csv
+          mv artifacts/compatibility/report artifacts/compatibility/report-4.19.200
+          {
+            echo "artifact_id=$BASELINE_ARTIFACT_ID"
+            echo "artifact_digest=$BASELINE_ARTIFACT_DIGEST"
+            echo "source_run=29413873452"
+          } > artifacts/compatibility/BASELINE-ARTIFACT.lock
 
       - name: Prepare build-verified touchGrass 4.19.325 source
         run: |
           set -Eeuo pipefail
+          chmod +x scripts/*.sh scripts/*.py
           ./scripts/01_prepare_source.sh
           ./scripts/03_apply_linux_4.19.153.sh
           ./scripts/04_apply_linux_4.19.154.sh
@@ -102,16 +104,6 @@ jobs:
           ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.325
           ./scripts/34_collect_touchgrass_4.19.325_inventory.sh
 
-      - name: Build untouched Android 4.19 GKI reference
-        run: ./scripts/30_build_ack_4_19_gki_inventory.sh
-
-      - name: Compare GKI against hardware baseline 4.19.200
-        run: |
-          python3 scripts/32_compare_gki_touchgrass.py \
-            --gki artifacts/compatibility/gki \
-            --touchgrass artifacts/compatibility/touchgrass \
-            --out artifacts/compatibility/report-4.19.200
-
       - name: Compare same-version GKI and touchGrass 4.19.325 ABI
         run: |
           python3 scripts/32_compare_gki_touchgrass.py \
@@ -122,14 +114,14 @@ jobs:
       - name: Record runner and source state
         if: always()
         run: |
-          mkdir -p artifacts/compatibility/runner
-          df -h > artifacts/compatibility/runner/disk.txt
-          free -h > artifacts/compatibility/runner/memory.txt
-          uname -a > artifacts/compatibility/runner/uname.txt
-          ccache --show-stats > artifacts/compatibility/runner/ccache.txt 2>&1 || true
+          mkdir -p artifacts/compatibility/runner-final
+          df -h > artifacts/compatibility/runner-final/disk.txt
+          free -h > artifacts/compatibility/runner-final/memory.txt
+          uname -a > artifacts/compatibility/runner-final/uname.txt
+          ccache --show-stats > artifacts/compatibility/runner-final/ccache.txt 2>&1 || true
           if [ -d workspace/touchgrass-a52xq/.git ]; then
             git -C workspace/touchgrass-a52xq status --short \
-              > artifacts/compatibility/runner/touchgrass-source-status.txt || true
+              > artifacts/compatibility/runner-final/touchgrass-source-status.txt || true
           fi
 
       - name: Upload complete three-way compatibility inventory

--- a/.github/workflows/31-gki-touchgrass-compatibility-inventory.yml
+++ b/.github/workflows/31-gki-touchgrass-compatibility-inventory.yml
@@ -1,4 +1,4 @@
-name: 31 - GKI 4.19 versus A52 compatibility inventory
+name: 31 - Full GKI 4.19 versus A52 compatibility inventory
 
 on:
   workflow_dispatch:
@@ -11,6 +11,7 @@ on:
       - 'scripts/30_build_ack_4_19_gki_inventory.sh'
       - 'scripts/31_collect_touchgrass_4.19.200_inventory.sh'
       - 'scripts/32_compare_gki_touchgrass.py'
+      - 'scripts/34_collect_touchgrass_4.19.325_inventory.sh'
       - 'projects/gki-4.19-a52-compatibility/**'
 
 permissions:
@@ -27,7 +28,7 @@ env:
 
 jobs:
   compatibility-inventory:
-    name: Compare ACK GKI with reviewed touchGrass 4.19.200
+    name: Compare ACK GKI with touchGrass 4.19.200 and 4.19.325
     runs-on: ubuntu-22.04
     timeout-minutes: 360
 
@@ -54,12 +55,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          key: a52xq-gki-compat-4.19.200-${{ runner.os }}-${{ github.run_id }}
+          key: a52xq-gki-full-compat-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
-            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
             a52xq-gki-compat-4.19.200-${{ runner.os }}-
+            a52xq-linux-4.19.325-ccache-${{ runner.os }}-
+            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
+            a52xq-gki-full-compat-${{ runner.os }}-
 
-      - name: Prepare reviewed touchGrass source
+      - name: Prepare reviewed touchGrass 4.19.200 source
         run: |
           chmod +x scripts/*.sh scripts/*.py
           ./scripts/01_prepare_source.sh
@@ -74,21 +77,47 @@ jobs:
           ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
           ./scripts/checkpoint_resolve_linux_4.19.200.sh
 
-      - name: Rebuild known 4.19.200 ReSukiSU baseline
+      - name: Build and collect touchGrass 4.19.200 hardware baseline
         run: |
           ./scripts/07_patch_resukisu_exec_hook.sh
           ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.200 safe
           ./scripts/31_collect_touchgrass_4.19.200_inventory.sh
 
+      - name: Prepare build-verified touchGrass 4.19.325 source
+        run: |
+          set -Eeuo pipefail
+          ./scripts/01_prepare_source.sh
+          ./scripts/03_apply_linux_4.19.153.sh
+          ./scripts/04_apply_linux_4.19.154.sh
+          ./scripts/05_merge_linux_4.19.325.sh
+          for repair in scripts/06*_linux_4.19.325*.sh; do
+            printf 'Running %s\n' "$repair"
+            "$repair"
+          done
+
+      - name: Build and collect touchGrass 4.19.325 same-version baseline
+        run: |
+          set -Eeuo pipefail
+          ./scripts/07_patch_resukisu_exec_hook.sh
+          ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.325
+          ./scripts/34_collect_touchgrass_4.19.325_inventory.sh
+
       - name: Build untouched Android 4.19 GKI reference
         run: ./scripts/30_build_ack_4_19_gki_inventory.sh
 
-      - name: Generate compatibility inventory
+      - name: Compare GKI against hardware baseline 4.19.200
         run: |
           python3 scripts/32_compare_gki_touchgrass.py \
             --gki artifacts/compatibility/gki \
             --touchgrass artifacts/compatibility/touchgrass \
-            --out artifacts/compatibility/report
+            --out artifacts/compatibility/report-4.19.200
+
+      - name: Compare same-version GKI and touchGrass 4.19.325 ABI
+        run: |
+          python3 scripts/32_compare_gki_touchgrass.py \
+            --gki artifacts/compatibility/gki \
+            --touchgrass artifacts/compatibility/touchgrass-4.19.325 \
+            --out artifacts/compatibility/report-4.19.325
 
       - name: Record runner and source state
         if: always()
@@ -103,11 +132,11 @@ jobs:
               > artifacts/compatibility/runner/touchgrass-source-status.txt || true
           fi
 
-      - name: Upload compatibility inventory
+      - name: Upload complete three-way compatibility inventory
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-gki-4.19-compatibility-inventory-${{ github.run_number }}-NON-FLASHABLE
+          name: a52xq-gki-4.19-full-comparison-${{ github.run_number }}-NON-FLASHABLE
           path: artifacts/compatibility/
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/31-gki-touchgrass-compatibility-inventory.yml
+++ b/.github/workflows/31-gki-touchgrass-compatibility-inventory.yml
@@ -1,0 +1,113 @@
+name: 31 - GKI 4.19 versus A52 compatibility inventory
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - rebase/resukisu-linux-4.19.325
+    paths:
+      - '.github/workflows/31-gki-touchgrass-compatibility-inventory.yml'
+      - 'gki-sources.lock'
+      - 'scripts/30_build_ack_4_19_gki_inventory.sh'
+      - 'scripts/31_collect_touchgrass_4.19.200_inventory.sh'
+      - 'scripts/32_compare_gki_touchgrass.py'
+      - 'projects/gki-4.19-a52-compatibility/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a52-gki-touchgrass-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JOBS: '4'
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 5G
+
+jobs:
+  compatibility-inventory:
+    name: Compare ACK GKI with reviewed touchGrass 4.19.200
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out compatibility branch
+        uses: actions/checkout@v4
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          df -h
+
+      - name: Install build and analysis dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils zip unzip make gcc g++ bc bison flex ccache patch \
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar \
+            clang-14 lld-14 llvm-14 gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
+      - name: Restore touchGrass compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: a52xq-gki-compat-4.19.200-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
+            a52xq-gki-compat-4.19.200-${{ runner.os }}-
+
+      - name: Prepare reviewed touchGrass source
+        run: |
+          chmod +x scripts/*.sh scripts/*.py
+          ./scripts/01_prepare_source.sh
+          ./scripts/03_apply_linux_4.19.153.sh
+          ./scripts/04_apply_linux_4.19.154.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+          ./scripts/checkpoint_resolve_linux_4.19.159.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+          ./scripts/checkpoint_resolve_linux_4.19.164.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+          ./scripts/checkpoint_resolve_linux_4.19.180.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+          ./scripts/checkpoint_resolve_linux_4.19.200.sh
+
+      - name: Rebuild known 4.19.200 ReSukiSU baseline
+        run: |
+          ./scripts/07_patch_resukisu_exec_hook.sh
+          ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.200 safe
+          ./scripts/31_collect_touchgrass_4.19.200_inventory.sh
+
+      - name: Build untouched Android 4.19 GKI reference
+        run: ./scripts/30_build_ack_4_19_gki_inventory.sh
+
+      - name: Generate compatibility inventory
+        run: |
+          python3 scripts/32_compare_gki_touchgrass.py \
+            --gki artifacts/compatibility/gki \
+            --touchgrass artifacts/compatibility/touchgrass \
+            --out artifacts/compatibility/report
+
+      - name: Record runner and source state
+        if: always()
+        run: |
+          mkdir -p artifacts/compatibility/runner
+          df -h > artifacts/compatibility/runner/disk.txt
+          free -h > artifacts/compatibility/runner/memory.txt
+          uname -a > artifacts/compatibility/runner/uname.txt
+          ccache --show-stats > artifacts/compatibility/runner/ccache.txt 2>&1 || true
+          if [ -d workspace/touchgrass-a52xq/.git ]; then
+            git -C workspace/touchgrass-a52xq status --short \
+              > artifacts/compatibility/runner/touchgrass-source-status.txt || true
+          fi
+
+      - name: Upload compatibility inventory
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-gki-4.19-compatibility-inventory-${{ github.run_number }}-NON-FLASHABLE
+          path: artifacts/compatibility/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/32-un1ca-sm7225-rom-intake.yml
+++ b/.github/workflows/32-un1ca-sm7225-rom-intake.yml
@@ -1,0 +1,55 @@
+name: 32 - UN1CA SM7225 ROM compatibility intake
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - rebase/resukisu-linux-4.19.325
+    paths:
+      - '.github/workflows/32-un1ca-sm7225-rom-intake.yml'
+      - 'rom-sources.lock'
+      - 'scripts/33_collect_un1ca_sm7225_requirements.sh'
+      - 'projects/un1ca-sm7225-rom-intake/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a52-un1ca-sm7225-rom-intake-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rom-intake:
+    name: Extract pinned UN1CA A52 boot requirements
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out compatibility project
+        uses: actions/checkout@v4
+
+      - name: Install intake dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git ca-certificates
+
+      - name: Collect UN1CA SM7225 requirements
+        run: |
+          chmod +x scripts/33_collect_un1ca_sm7225_requirements.sh
+          ./scripts/33_collect_un1ca_sm7225_requirements.sh
+
+      - name: Record runner state
+        if: always()
+        run: |
+          mkdir -p artifacts/compatibility/un1ca-sm7225/runner
+          uname -a > artifacts/compatibility/un1ca-sm7225/runner/uname.txt
+          git --version > artifacts/compatibility/un1ca-sm7225/runner/git-version.txt
+
+      - name: Upload ROM compatibility intake
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-un1ca-sm7225-rom-intake-${{ github.run_number }}
+          path: artifacts/compatibility/un1ca-sm7225/
+          if-no-files-found: error
+          retention-days: 14

--- a/gki-sources.lock
+++ b/gki-sources.lock
@@ -1,0 +1,6 @@
+GKI_REPO=https://android.googlesource.com/kernel/common
+GKI_BRANCH=deprecated/android-4.19-stable
+GKI_COMMIT=a8bf86a0e0fa05070897a210d706d5c4d83c26ac
+GKI_DEFCONFIG=gki_defconfig
+GKI_ARCH=arm64
+LLVM_MAJOR=14

--- a/projects/gki-4.19-a52-compatibility/README.md
+++ b/projects/gki-4.19-a52-compatibility/README.md
@@ -1,0 +1,84 @@
+# A52 Android 4.19 GKI compatibility checkpoint
+
+## Inputs
+
+This checkpoint compares two real, reproducible builds:
+
+1. Official Android Common Kernel 4.19 GKI, pinned to commit `a8bf86a0e0fa05070897a210d706d5c4d83c26ac` and built from `gki_defconfig`.
+2. The reviewed touchGrass Linux 4.19.200 A52 build reconstructed by the existing checkpoint scripts, with the same ReSukiSU safe integration used by the verified build artifact.
+
+The workflow is intentionally non-flashable.
+
+## Initial config-only finding
+
+A direct comparison of the already verified artifacts found:
+
+- 4,086 parsed GKI config options
+- 5,428 parsed touchGrass config options
+- 2,081 device-related options with different values after excluding `CONFIG_KSU*` and `CONFIG_SUSFS*`
+- 845 options enabled in touchGrass but absent or disabled in GKI
+- the GKI `Image` is 24,646,144 bytes
+- the touchGrass 4.19.200 `Image` is 50,837,520 bytes
+
+The size difference is expected because the A52 kernel contains Samsung and Qualcomm platform drivers that the generic image does not contain.
+
+## First 24 early-boot gaps
+
+The initial comparison identifies these as the first built-in compatibility candidates:
+
+- `CONFIG_QCOM_SCM`
+- `CONFIG_QCOM_RPMH`
+- `CONFIG_QCOM_SMEM`
+- `CONFIG_QCOM_SMP2P`
+- `CONFIG_QCOM_GLINK`
+- `CONFIG_QRTR`
+- `CONFIG_QCOM_COMMAND_DB`
+- `CONFIG_COMMON_CLK_QCOM`
+- `CONFIG_SDM_GCC_LAGOON`
+- `CONFIG_QCOM_LLCC`
+- `CONFIG_QCOM_LAGOON_LLCC`
+- `CONFIG_QCOM_GDSC`
+- `CONFIG_PINCTRL_LAGOON`
+- `CONFIG_PINCTRL_QCOM_SPMI_PMIC`
+- `CONFIG_REGULATOR_QCOM_RPMH`
+- `CONFIG_REGULATOR_QCOM_SPMI`
+- `CONFIG_QTI_IOMMU_SUPPORT`
+- `CONFIG_SCSI_UFS_QCOM`
+- `CONFIG_PHY_QCOM_UFS`
+- `CONFIG_MMC_SDHCI_MSM`
+- `CONFIG_MMC_CQHCI`
+- `CONFIG_QCOM_GENI_SE`
+- `CONFIG_SERIAL_MSM_GENI`
+- `CONFIG_PSTORE_PMSG`
+
+The stock GKI configuration already provides some related core functions, but several are modules instead of built-ins. For example, `CONFIG_ARM_SMMU=m` and `CONFIG_SCSI_UFSHCD=m` in GKI while the working A52 kernel uses them built in. Because this phone has the older Samsung boot layout and no prepared GKI vendor-module environment, the first hybrid boot probe must not assume those modules can load early enough.
+
+## Workflow output
+
+`31 - GKI 4.19 versus A52 compatibility inventory` rebuilds both sides and generates:
+
+- complete config differences
+- prioritized touchGrass-enabled options missing from GKI
+- module lists
+- exported-symbol differences
+- CRC mismatches for symbols shared by both kernels
+- touchGrass DTB and DTBO output list
+- image metadata and checksums
+- a Markdown compatibility report
+
+## Custom ROM contribution
+
+The custom ROM is useful for determining the userspace-facing side of compatibility. Its ZIP or extracted images can reveal:
+
+- boot header version and kernel command line
+- ramdisk compression and first-stage init behavior
+- embedded DTB and separate DTBO requirements
+- `vendor`, `vendor_dlkm`, and `system_dlkm` module inventories
+- module load order and dependencies
+- fstab, AVB, dm-verity, VNDK, API-level, and SELinux expectations
+
+The ROM does not replace the touchGrass source as the hardware-driver reference. It complements it by showing exactly what the installed Android userspace expects.
+
+## Stop condition
+
+Do not package or flash the generic GKI output. The next flashable candidate can only be considered after a hybrid kernel reaches an observable early-boot signal through GENI serial or ramoops and its boot image passes size and layout checks.

--- a/projects/un1ca-sm7225-rom-intake/README.md
+++ b/projects/un1ca-sm7225-rom-intake/README.md
@@ -1,0 +1,35 @@
+# UN1CA SM7225 ROM intake
+
+This checkpoint pins and inspects `matei9/UN1CA_SM7125` branch `sm7225` at commit `49ec9fa5481808a9906d850297a69e029356dfeb`.
+
+## Confirmed integration behavior
+
+The A52 target does not create a new boot environment for its custom kernel. It unpacks the generated `boot.img`, downloads a TouchGrass kernel package, extracts `Image.gz`, replaces only the kernel payload, repacks with the original `mkbootimg` arguments, and appends the Samsung `SEANDROIDENFORCE` trailer.
+
+This changes the GKI project target from a generic boot image to a hybrid payload compatible with the existing UN1CA boot container.
+
+## Confirmed ROM constraints
+
+- Target: Galaxy A52 5G, `a52xq`
+- Platform: Snapdragon 750G, `sm7225`
+- Board and shipping API level: 30
+- Target platform SDK: 34
+- Boot partition: 96 MiB
+- DTBO partition: 24 MiB
+- Vendor boot partition: 96 MiB
+- Dynamic partitions enabled
+- EROFS system image format
+- Logical first-stage partitions include system, vendor, product, and odm
+- Installer configuration includes boot, dtbo, vendor_boot, vbmeta_system, and vbmeta_samsung
+
+## Engineering consequences
+
+The first GKI-derived boot probe must:
+
+1. preserve the existing UN1CA boot header, ramdisk, offsets, page size, command line, DTB arrangement, and Samsung trailer;
+2. output a validated `Image.gz` payload;
+3. fit within both the unpacked kernel allocation and the final 96 MiB boot partition;
+4. keep all early storage, Qualcomm platform, security, and first-stage filesystem dependencies built in until module loading is proven;
+5. retain the existing A52 DTB and DTBO selection for the first probe.
+
+The source tree defines the packaging contract, but the final generated `boot.img`, `vendor_boot.img`, and `dtbo.img` are still required for exact binary measurements before flashing.

--- a/rom-sources.lock
+++ b/rom-sources.lock
@@ -1,0 +1,7 @@
+UN1CA_REPO=https://github.com/matei9/UN1CA_SM7125.git
+UN1CA_BRANCH=sm7225
+UN1CA_COMMIT=49ec9fa5481808a9906d850297a69e029356dfeb
+UN1CA_PLATFORM=sm7225
+UN1CA_TARGET=a52xq
+UN1CA_KERNEL_ZIP=https://github.com/matei9/samsung_android_kernel_a52xq/releases/download/un1ca-update/TouchGrass-a52xq-20260502.zip
+UN1CA_KERNEL_MEMBER=Image.gz

--- a/scripts/30_build_ack_4_19_gki_inventory.sh
+++ b/scripts/30_build_ack_4_19_gki_inventory.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/gki-sources.lock"
+
+WORK_DIR="${WORK_DIR:-$ROOT_DIR/work-gki-4.19-inventory}"
+SRC_DIR="$WORK_DIR/common"
+OUT_DIR="$WORK_DIR/out"
+DEST="$ROOT_DIR/artifacts/compatibility/gki"
+JOBS="${JOBS:-8}"
+LLVM_BIN="/usr/lib/llvm-${LLVM_MAJOR}/bin"
+
+rm -rf "$WORK_DIR" "$DEST"
+mkdir -p "$WORK_DIR" "$DEST/logs"
+export PATH="$LLVM_BIN:$PATH"
+
+for tool in clang ld.lld llvm-ar llvm-nm llvm-objcopy llvm-objdump llvm-strip aarch64-linux-gnu-gcc; do
+  command -v "$tool" >/dev/null || { echo "Missing tool: $tool" >&2; exit 1; }
+done
+
+git clone --no-tags --depth=1 --branch "$GKI_BRANCH" "$GKI_REPO" "$SRC_DIR" \
+  2>&1 | tee "$DEST/logs/clone.log"
+
+actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
+if [[ "$actual_commit" != "$GKI_COMMIT" ]]; then
+  git -C "$SRC_DIR" fetch --no-tags --depth=1 origin "$GKI_COMMIT"
+  git -C "$SRC_DIR" checkout --detach FETCH_HEAD
+  actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
+fi
+[[ "$actual_commit" == "$GKI_COMMIT" ]] || { echo "GKI commit mismatch" >&2; exit 1; }
+
+make_args=(
+  -C "$SRC_DIR"
+  O="$OUT_DIR"
+  ARCH="$GKI_ARCH"
+  CROSS_COMPILE=aarch64-linux-gnu-
+  CLANG_TRIPLE=aarch64-linux-gnu-
+  CC=clang
+  LD=ld.lld
+  AR=llvm-ar
+  NM=llvm-nm
+  OBJCOPY=llvm-objcopy
+  OBJDUMP=llvm-objdump
+  STRIP=llvm-strip
+  LLVM=1
+  LLVM_IAS=1
+)
+
+make "${make_args[@]}" "$GKI_DEFCONFIG" 2>&1 | tee "$DEST/logs/defconfig.log"
+make "${make_args[@]}" -j"$JOBS" Image modules 2>&1 | tee "$DEST/logs/build.log"
+
+cp "$OUT_DIR/.config" "$DEST/config"
+cp "$OUT_DIR/arch/arm64/boot/Image" "$DEST/Image"
+cp "$OUT_DIR/System.map" "$DEST/System.map"
+cp "$OUT_DIR/Module.symvers" "$DEST/Module.symvers"
+make -s "${make_args[@]}" kernelrelease > "$DEST/kernel-release.txt"
+
+find "$OUT_DIR" -type f -name '*.ko' -printf '%P\n' | sort > "$DEST/modules.list"
+find "$SRC_DIR" -maxdepth 1 -type f -name 'abi_gki_aarch64*' -exec cp {} "$DEST/" \;
+
+{
+  echo "repository=$GKI_REPO"
+  echo "branch=$GKI_BRANCH"
+  echo "commit=$actual_commit"
+  echo "defconfig=$GKI_DEFCONFIG"
+  echo "image_bytes=$(stat -c %s "$DEST/Image")"
+  echo "module_count=$(wc -l < "$DEST/modules.list")"
+  echo "exported_symbol_count=$(wc -l < "$DEST/Module.symvers")"
+} > "$DEST/metadata.txt"
+
+(
+  cd "$DEST"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)

--- a/scripts/31_collect_touchgrass_4.19.200_inventory.sh
+++ b/scripts/31_collect_touchgrass_4.19.200_inventory.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+source "$(dirname "$0")/common.sh"
+
+TARGET_VERSION=4.19.200
+DEST="$PROJECT_DIR/artifacts/compatibility/touchgrass"
+OUT_DIR="$KERNEL_DIR/out"
+
+[[ "$(kernel_version)" == "$TARGET_VERSION" ]] || fail "Expected Linux $TARGET_VERSION source"
+[[ -s "$OUT_DIR/arch/arm64/boot/Image" ]] || fail "touchGrass Image is missing"
+[[ -s "$OUT_DIR/.config" ]] || fail "touchGrass final config is missing"
+[[ -s "$OUT_DIR/Module.symvers" ]] || fail "touchGrass Module.symvers is missing"
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+cp "$OUT_DIR/arch/arm64/boot/Image" "$DEST/Image"
+cp "$OUT_DIR/.config" "$DEST/config"
+cp "$OUT_DIR/Module.symvers" "$DEST/Module.symvers"
+[[ -s "$OUT_DIR/System.map" ]] && cp "$OUT_DIR/System.map" "$DEST/System.map"
+
+find "$OUT_DIR" -type f -name '*.ko' -printf '%P\n' | sort > "$DEST/modules.list"
+find "$OUT_DIR/arch/arm64/boot" -type f \( -name '*.dtb' -o -name '*.dtbo' \) \
+  -printf '%P\n' | sort > "$DEST/device-trees.list"
+
+strings "$DEST/Image" | grep -E 'Linux version|touchGrassKernel|qcom,lagoon|a52xq|sm7125|sm7225' \
+  | sort -u > "$DEST/image-platform-strings.txt" || true
+
+{
+  echo "source_repository=$TOUCHGRASS_REPO"
+  echo "source_base_commit=$TOUCHGRASS_COMMIT"
+  echo "kernel_version=$(kernel_version)"
+  echo "kernel_release=$(make -s -C "$KERNEL_DIR" O="$OUT_DIR" ARCH=arm64 kernelrelease)"
+  echo "image_bytes=$(stat -c %s "$DEST/Image")"
+  echo "module_count=$(wc -l < "$DEST/modules.list")"
+  echo "device_tree_count=$(wc -l < "$DEST/device-trees.list")"
+  echo "exported_symbol_count=$(wc -l < "$DEST/Module.symvers")"
+} > "$DEST/metadata.txt"
+
+(
+  cd "$DEST"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)

--- a/scripts/32_compare_gki_touchgrass.py
+++ b/scripts/32_compare_gki_touchgrass.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import Counter
+from pathlib import Path
+
+ROOT_ONLY_PREFIXES = ("CONFIG_KSU", "CONFIG_SUSFS")
+
+CATEGORY_PATTERNS = {
+    "boot-diagnostics": ("PSTORE", "RAMOOPS", "SERIAL", "PRINTK", "CMDLINE", "DEVTMPFS", "BLK_DEV_INITRD"),
+    "qcom-core": ("ARCH_QCOM", "QCOM_", "MSM_", "QRTR", "GLINK", "SMP2P", "SMEM", "SPMI", "PMIC", "RPMH"),
+    "clock-power": ("COMMON_CLK", "SDM_GCC", "SDM_GPUCC", "SDM_DISPCC", "SDM_CAMCC", "REGULATOR", "GDSC", "CPU_FREQ", "DEVFREQ", "THERMAL"),
+    "storage": ("SCSI_UFS", "UFS", "MMC", "SDHCI", "EXT4", "F2FS", "EROFS", "DM_VERITY", "FS_ENCRYPTION", "FS_VERITY"),
+    "iommu-memory": ("IOMMU", "SMMU", "ION", "DMA_HEAP", "CMA", "INTERCONNECT"),
+    "android-security": ("ANDROID", "BINDER", "ASHMEM", "SELINUX", "SECURITY", "SECCOMP", "AUDIT", "CGROUP", "BPF"),
+    "usb": ("USB", "DWC3", "TYPEC"),
+    "display-gpu": ("DRM", "FB_", "MDSS", "MIPI", "DSI", "KGSL", "ADRENO", "GPU"),
+    "input-touch": ("INPUT", "TOUCHSCREEN", "HID", "HALL"),
+    "audio": ("SND", "SOUND", "AUDIO", "WCD", "SLIMBUS"),
+    "camera-media": ("CAMERA", "SPECTRA", "MEDIA", "VIDEO", "V4L2"),
+    "network-modem": ("WLAN", "WIRELESS", "CFG80211", "MAC80211", "RMNET", "IPA", "QRTR", "NETFILTER"),
+    "sensors-misc": ("SENSOR", "IIO", "HWMON", "LEDS", "VIBRATOR", "NFC", "FINGERPRINT"),
+}
+
+CRITICAL_CATEGORIES = {
+    "boot-diagnostics", "qcom-core", "clock-power", "storage", "iommu-memory", "android-security"
+}
+
+CURATED_BOOT_OPTIONS = (
+    "CONFIG_QCOM_SCM", "CONFIG_QCOM_RPMH", "CONFIG_QCOM_SMEM", "CONFIG_QCOM_SMP2P",
+    "CONFIG_QCOM_GLINK", "CONFIG_QRTR", "CONFIG_QCOM_COMMAND_DB", "CONFIG_COMMON_CLK_QCOM",
+    "CONFIG_SDM_GCC_LAGOON", "CONFIG_QCOM_LLCC", "CONFIG_QCOM_LAGOON_LLCC", "CONFIG_QCOM_GDSC",
+    "CONFIG_PINCTRL_LAGOON", "CONFIG_PINCTRL_QCOM_SPMI_PMIC", "CONFIG_REGULATOR_QCOM_RPMH",
+    "CONFIG_REGULATOR_QCOM_SPMI", "CONFIG_ARM_SMMU", "CONFIG_QTI_IOMMU_SUPPORT",
+    "CONFIG_SCSI_UFSHCD", "CONFIG_SCSI_UFS_QCOM", "CONFIG_PHY_QCOM_UFS",
+    "CONFIG_MMC_SDHCI_MSM", "CONFIG_MMC_CQHCI", "CONFIG_QCOM_GENI_SE", "CONFIG_SERIAL_MSM_GENI",
+    "CONFIG_PSTORE", "CONFIG_PSTORE_RAM", "CONFIG_PSTORE_PMSG", "CONFIG_ANDROID_BINDER_IPC",
+    "CONFIG_SECURITY_SELINUX", "CONFIG_DM_VERITY", "CONFIG_EXT4_FS", "CONFIG_F2FS_FS",
+)
+
+
+def parse_config(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(errors="replace").splitlines():
+        if line.startswith("CONFIG_") and "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        elif line.startswith("# CONFIG_") and line.endswith(" is not set"):
+            values[line[2:-11]] = "n"
+    return values
+
+
+def enabled(value: str | None) -> bool:
+    return value not in (None, "n")
+
+
+def category_for(option: str) -> str:
+    for category, patterns in CATEGORY_PATTERNS.items():
+        if any(pattern in option for pattern in patterns):
+            return category
+    return "other"
+
+
+def parse_symvers(path: Path) -> dict[str, tuple[str, str]]:
+    symbols: dict[str, tuple[str, str]] = {}
+    if not path.exists():
+        return symbols
+    for line in path.read_text(errors="replace").splitlines():
+        fields = line.split()
+        if len(fields) >= 3:
+            symbols[fields[1]] = (fields[0], fields[2])
+    return symbols
+
+
+def read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text(errors="replace").splitlines() if line.strip()]
+
+
+def read_metadata(path: Path) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    if path.exists():
+        for line in path.read_text(errors="replace").splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                metadata[key] = value
+    return metadata
+
+
+def write_csv(path: Path, headers: list[str], rows: list[list[str]]) -> None:
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(headers)
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gki", type=Path, required=True)
+    parser.add_argument("--touchgrass", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    gki = parse_config(args.gki / "config")
+    touchgrass = parse_config(args.touchgrass / "config")
+
+    all_options = sorted(set(gki) | set(touchgrass))
+    different = [option for option in all_options if gki.get(option) != touchgrass.get(option)]
+    device_differences = [option for option in different if not option.startswith(ROOT_ONLY_PREFIXES)]
+    touchgrass_enabled = [
+        option for option in device_differences
+        if enabled(touchgrass.get(option)) and not enabled(gki.get(option))
+    ]
+    gki_enabled = [
+        option for option in device_differences
+        if enabled(gki.get(option)) and not enabled(touchgrass.get(option))
+    ]
+
+    rows: list[list[str]] = []
+    for option in touchgrass_enabled:
+        category = category_for(option)
+        tg_value = touchgrass.get(option, "missing")
+        gki_value = gki.get(option, "missing")
+        if option in CURATED_BOOT_OPTIONS:
+            priority = "P0-boot"
+        elif category in CRITICAL_CATEGORIES and tg_value == "y":
+            priority = "P1-platform"
+        else:
+            priority = "P2-hardware"
+        mismatch = "missing"
+        if gki_value == "m" and tg_value == "y":
+            mismatch = "gki-module-vs-touchgrass-built-in"
+        rows.append([priority, category, option, tg_value, gki_value, mismatch])
+
+    priority_order = {"P0-boot": 0, "P1-platform": 1, "P2-hardware": 2}
+    rows.sort(key=lambda row: (priority_order[row[0]], row[1], row[2]))
+    write_csv(
+        args.out / "touchgrass-enabled-not-in-gki.csv",
+        ["priority", "category", "option", "touchgrass", "gki", "difference"],
+        rows,
+    )
+
+    write_csv(
+        args.out / "all-config-differences.csv",
+        ["option", "category", "touchgrass", "gki"],
+        [[option, category_for(option), touchgrass.get(option, "missing"), gki.get(option, "missing")]
+         for option in device_differences],
+    )
+
+    write_csv(
+        args.out / "gki-enabled-not-in-touchgrass.csv",
+        ["option", "category", "gki", "touchgrass"],
+        [[option, category_for(option), gki.get(option, "missing"), touchgrass.get(option, "missing")]
+         for option in gki_enabled],
+    )
+
+    gki_symbols = parse_symvers(args.gki / "Module.symvers")
+    tg_symbols = parse_symvers(args.touchgrass / "Module.symvers")
+    common_symbols = sorted(set(gki_symbols) & set(tg_symbols))
+    tg_only_symbols = sorted(set(tg_symbols) - set(gki_symbols))
+    gki_only_symbols = sorted(set(gki_symbols) - set(tg_symbols))
+    crc_mismatches = sorted(
+        symbol for symbol in common_symbols if gki_symbols[symbol][0] != tg_symbols[symbol][0]
+    )
+
+    write_csv(
+        args.out / "touchgrass-only-exported-symbols.csv",
+        ["symbol", "crc", "source"],
+        [[symbol, tg_symbols[symbol][0], tg_symbols[symbol][1]] for symbol in tg_only_symbols],
+    )
+    write_csv(
+        args.out / "gki-only-exported-symbols.csv",
+        ["symbol", "crc", "source"],
+        [[symbol, gki_symbols[symbol][0], gki_symbols[symbol][1]] for symbol in gki_only_symbols],
+    )
+    write_csv(
+        args.out / "common-symbol-crc-mismatches.csv",
+        ["symbol", "touchgrass_crc", "gki_crc", "touchgrass_source", "gki_source"],
+        [[symbol, tg_symbols[symbol][0], gki_symbols[symbol][0], tg_symbols[symbol][1], gki_symbols[symbol][1]]
+         for symbol in crc_mismatches],
+    )
+
+    categories = Counter(category_for(option) for option in touchgrass_enabled)
+    priorities = Counter(row[0] for row in rows)
+    gki_modules = read_lines(args.gki / "modules.list")
+    tg_modules = read_lines(args.touchgrass / "modules.list")
+    device_trees = read_lines(args.touchgrass / "device-trees.list")
+    gki_meta = read_metadata(args.gki / "metadata.txt")
+    tg_meta = read_metadata(args.touchgrass / "metadata.txt")
+
+    curated_rows = []
+    for option in CURATED_BOOT_OPTIONS:
+        curated_rows.append(
+            f"| `{option}` | `{touchgrass.get(option, 'missing')}` | `{gki.get(option, 'missing')}` |"
+        )
+
+    category_rows = "\n".join(
+        f"| {category} | {count} |" for category, count in categories.most_common()
+    )
+    p0_options = [row[2] for row in rows if row[0] == "P0-boot"]
+
+    report = f"""# A52 GKI 4.19 compatibility inventory
+
+## Compared builds
+
+| Build | Kernel release | Image bytes | Modules | Exported symbols |
+|---|---:|---:|---:|---:|
+| Android Common Kernel GKI | `{gki_meta.get('kernel_release', 'unknown')}` | {gki_meta.get('image_bytes', 'unknown')} | {len(gki_modules)} | {len(gki_symbols)} |
+| touchGrass A52 baseline | `{tg_meta.get('kernel_release', 'unknown')}` | {tg_meta.get('image_bytes', 'unknown')} | {len(tg_modules)} | {len(tg_symbols)} |
+
+The touchGrass side is the reviewed Linux 4.19.200 + ReSukiSU safe build. Root-only `CONFIG_KSU*` and `CONFIG_SUSFS*` options are excluded from the device compatibility counts.
+
+## Configuration result
+
+- Total parsed GKI options: **{len(gki)}**
+- Total parsed touchGrass options: **{len(touchgrass)}**
+- Device-related options with different values: **{len(device_differences)}**
+- Enabled in touchGrass but absent or disabled in GKI: **{len(touchgrass_enabled)}**
+- P0 early-boot candidates: **{priorities.get('P0-boot', 0)}**
+- P1 platform candidates: **{priorities.get('P1-platform', 0)}**
+- P2 later hardware candidates: **{priorities.get('P2-hardware', 0)}**
+
+| Category | touchGrass-enabled options missing from GKI |
+|---|---:|
+{category_rows}
+
+## Curated early-boot comparison
+
+| Option | touchGrass | GKI |
+|---|---:|---:|
+{chr(10).join(curated_rows)}
+
+## Immediate blockers
+
+The untouched GKI image cannot boot the A52 because the generic configuration lacks the Lagoon/SM7125 platform chain. The first bring-up kernel must keep the following groups built in until module loading is proven:
+
+1. Qualcomm SCM, RPMh, SMEM, SMP2P, GLINK, QRTR and command database.
+2. Lagoon clocks, LLCC, GDSC, pinctrl and RPMh/SPMI regulators.
+3. GENI serial for early console and ramoops/pstore for failure capture.
+4. UFS core, Qualcomm UFS glue, UFS PHY, SMMU/IOMMU and the storage filesystems needed for first-stage mount.
+5. Android binder, SELinux and dm-verity compatibility required by the ROM userspace.
+
+P0 options identified by the automated comparison:
+
+{chr(10).join(f'- `{option}`' for option in p0_options)}
+
+## Symbol and module result
+
+- Common exported symbols: **{len(common_symbols)}**
+- touchGrass-only exported symbols: **{len(tg_only_symbols)}**
+- GKI-only exported symbols: **{len(gki_only_symbols)}**
+- Common symbols with different CRCs: **{len(crc_mismatches)}**
+- GKI modules: **{len(gki_modules)}**
+- touchGrass modules: **{len(tg_modules)}**
+- touchGrass DTB/DTBO outputs: **{len(device_trees)}**
+
+A CRC mismatch means a touchGrass-built vendor module cannot be assumed to load into the stock GKI kernel, even when the symbol name exists. The generated CSV files are the input for deciding which drivers can become vendor modules and which code must be rebuilt against the GKI ABI.
+
+## Next engineering gate
+
+Do not package or flash the stock GKI `Image`. The next kernel should be a hybrid development image with only P0 platform support added. Its success condition is early console or ramoops output, not a complete Android boot.
+"""
+    (args.out / "COMPATIBILITY-REPORT.md").write_text(report)
+
+    rom_checklist = """# Custom ROM intake checklist
+
+A custom ROM ZIP is useful because it shows what userspace expects from the kernel and boot images. Inspect or extract these items when available:
+
+- `boot.img`, `dtbo.img`, `vendor_boot.img`, `init_boot.img` and `vbmeta*.img`
+- `payload.bin` when the ROM is an A/B OTA package
+- kernel command line, boot header version and ramdisk compression
+- embedded DTB and DTBO identifiers
+- `vendor/lib/modules`, `vendor_dlkm/lib/modules` and `system_dlkm/lib/modules`
+- module dependency, alias and load-order files
+- `fstab*`, first-stage init files and AVB flags
+- `ro.product.*`, `ro.boot.*`, VNDK and first API-level properties
+- SELinux policy files and init services that load kernel modules
+
+The ROM cannot supply missing Qualcomm kernel source by itself, but it can identify the exact ABI, module-loading, partition and device-tree expectations that the hybrid kernel must satisfy.
+"""
+    (args.out / "CUSTOM-ROM-INPUT.md").write_text(rom_checklist)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/33_build_ack_4_19_p0_probe.sh
+++ b/scripts/33_build_ack_4_19_p0_probe.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/gki-sources.lock"
+
+WORK_DIR="${WORK_DIR:-$ROOT_DIR/work-gki-4.19-p0-probe}"
+SRC_DIR="$WORK_DIR/common"
+OUT_DIR="$WORK_DIR/out"
+DEST="$ROOT_DIR/artifacts/p0-probe"
+JOBS="${JOBS:-8}"
+LLVM_BIN="/usr/lib/llvm-${LLVM_MAJOR}/bin"
+
+rm -rf "$WORK_DIR" "$DEST"
+mkdir -p "$WORK_DIR" "$DEST/logs"
+export PATH="$LLVM_BIN:$PATH"
+
+for tool in clang ld.lld llvm-ar llvm-nm llvm-objcopy llvm-objdump llvm-strip aarch64-linux-gnu-gcc gzip; do
+  command -v "$tool" >/dev/null || { echo "Missing tool: $tool" >&2; exit 1; }
+done
+
+git init -q "$SRC_DIR"
+git -C "$SRC_DIR" remote add origin "$GKI_REPO"
+git -C "$SRC_DIR" fetch --no-tags --depth=1 origin "$GKI_COMMIT" \
+  2>&1 | tee "$DEST/logs/fetch.log"
+git -C "$SRC_DIR" checkout --quiet --detach FETCH_HEAD
+actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
+[[ "$actual_commit" == "$GKI_COMMIT" ]] || { echo "GKI commit mismatch" >&2; exit 1; }
+
+make_args=(
+  -C "$SRC_DIR"
+  O="$OUT_DIR"
+  ARCH="$GKI_ARCH"
+  CROSS_COMPILE=aarch64-linux-gnu-
+  CLANG_TRIPLE=aarch64-linux-gnu-
+  CC=clang
+  LD=ld.lld
+  AR=llvm-ar
+  NM=llvm-nm
+  OBJCOPY=llvm-objcopy
+  OBJDUMP=llvm-objdump
+  STRIP=llvm-strip
+  LLVM=1
+  LLVM_IAS=1
+)
+
+make "${make_args[@]}" "$GKI_DEFCONFIG" 2>&1 | tee "$DEST/logs/defconfig.log"
+cp "$OUT_DIR/.config" "$DEST/gki-base.config"
+
+cat > "$DEST/requested-options.txt" <<'EOF'
+CONFIG_ARCH_QCOM
+CONFIG_QCOM_SCM
+CONFIG_QCOM_RPMH
+CONFIG_QCOM_SMEM
+CONFIG_QCOM_SMP2P
+CONFIG_QCOM_SMEM_STATE
+CONFIG_QCOM_COMMAND_DB
+CONFIG_QCOM_GLINK
+CONFIG_RPMSG_QCOM_GLINK_NATIVE
+CONFIG_RPMSG_QCOM_GLINK_SMEM
+CONFIG_RPMSG_QCOM_GLINK_RPM
+CONFIG_QRTR
+CONFIG_QCOM_PDC
+CONFIG_QCOM_LLCC
+CONFIG_QCOM_LAGOON_LLCC
+CONFIG_QCOM_GDSC
+CONFIG_COMMON_CLK_QCOM
+CONFIG_QCOM_CLK_RPMH
+CONFIG_SDM_GCC_LAGOON
+CONFIG_PINCTRL_MSM
+CONFIG_PINCTRL_LAGOON
+CONFIG_PINCTRL_QCOM_SPMI_PMIC
+CONFIG_REGULATOR_QCOM_RPMH
+CONFIG_REGULATOR_RPMH
+CONFIG_REGULATOR_QCOM_SPMI
+CONFIG_QCOM_GENI_SE
+CONFIG_SERIAL_MSM_GENI
+CONFIG_SERIAL_MSM_GENI_CONSOLE
+CONFIG_SERIAL_MSM_GENI_EARLY_CONSOLE
+CONFIG_ARM_SMMU
+CONFIG_QTI_IOMMU_SUPPORT
+CONFIG_SCSI_UFSHCD
+CONFIG_SCSI_UFSHCD_PLATFORM
+CONFIG_SCSI_UFS_QCOM
+CONFIG_PHY_QCOM_UFS
+CONFIG_MMC_CQHCI
+CONFIG_MMC_SDHCI
+CONFIG_MMC_SDHCI_PLTFM
+CONFIG_MMC_SDHCI_MSM
+CONFIG_PSTORE
+CONFIG_PSTORE_RAM
+CONFIG_PSTORE_CONSOLE
+CONFIG_PSTORE_PMSG
+CONFIG_ANDROID_BINDER_IPC
+CONFIG_ANDROID_BINDERFS
+CONFIG_SECURITY_SELINUX
+CONFIG_DM_VERITY
+CONFIG_EXT4_FS
+CONFIG_F2FS_FS
+CONFIG_EROFS_FS
+EOF
+
+while IFS= read -r option; do
+  "$SRC_DIR/scripts/config" --file "$OUT_DIR/.config" --enable "${option#CONFIG_}"
+done < "$DEST/requested-options.txt"
+
+make "${make_args[@]}" olddefconfig 2>&1 | tee "$DEST/logs/olddefconfig.log"
+cp "$OUT_DIR/.config" "$DEST/final.config"
+
+python3 - "$SRC_DIR" "$DEST" <<'PY'
+from __future__ import annotations
+
+import csv
+import re
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+dest = Path(sys.argv[2])
+requested = [line.strip() for line in (dest / "requested-options.txt").read_text().splitlines() if line.strip()]
+
+
+def parse_config(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(errors="replace").splitlines():
+        if line.startswith("CONFIG_") and "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+        elif line.startswith("# CONFIG_") and line.endswith(" is not set"):
+            values[line[2:-11]] = "n"
+    return values
+
+
+def definitions(symbol: str) -> list[str]:
+    found: list[str] = []
+    pattern = re.compile(rf"^\s*(?:menu)?config\s+{re.escape(symbol)}\s*$")
+    for path in src.rglob("Kconfig*"):
+        if not path.is_file():
+            continue
+        try:
+            for number, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
+                if pattern.match(line):
+                    found.append(f"{path.relative_to(src)}:{number}")
+        except OSError:
+            pass
+    return found
+
+base = parse_config(dest / "gki-base.config")
+final = parse_config(dest / "final.config")
+rows: list[list[str]] = []
+counts = {"built-in": 0, "module": 0, "dependency-blocked": 0, "source-missing": 0}
+
+for option in requested:
+    symbol = option.removeprefix("CONFIG_")
+    locations = definitions(symbol)
+    resolved = final.get(option, "missing")
+    if not locations:
+        status = "source-missing"
+    elif resolved == "y":
+        status = "built-in"
+    elif resolved == "m":
+        status = "module"
+    else:
+        status = "dependency-blocked"
+    counts[status] += 1
+    rows.append([option, base.get(option, "missing"), resolved, status, ";".join(locations)])
+
+with (dest / "p0-option-resolution.csv").open("w", newline="") as handle:
+    writer = csv.writer(handle)
+    writer.writerow(["option", "gki_base", "p0_probe", "status", "kconfig_definition"])
+    writer.writerows(rows)
+
+platform_patterns = ("lagoon", "sm7125", "sm7225", "a52xq")
+platform_hits: list[str] = []
+for path in src.rglob("*"):
+    if not path.is_file() or path.stat().st_size > 2_000_000:
+        continue
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        continue
+    lower = text.lower()
+    matched = [pattern for pattern in platform_patterns if pattern in lower]
+    if matched:
+        platform_hits.append(f"{path.relative_to(src)}\t{','.join(matched)}")
+(dest / "platform-source-hits.txt").write_text("\n".join(platform_hits) + ("\n" if platform_hits else ""))
+
+missing = [row[0] for row in rows if row[3] == "source-missing"]
+blocked = [row[0] for row in rows if row[3] == "dependency-blocked"]
+builtin = [row[0] for row in rows if row[3] == "built-in"]
+modules = [row[0] for row in rows if row[3] == "module"]
+
+report = f"""# ACK 4.19 P0 implementation probe
+
+## Purpose
+
+This is the first implementation build after the compatibility inventory. It keeps the official Android 4.19 GKI source as the base, requests the A52 early-boot configuration set, resolves dependencies through Kconfig, and compiles a non-flashable kernel payload.
+
+## Option result
+
+- Requested options: **{len(rows)}**
+- Resolved built-in: **{counts['built-in']}**
+- Resolved as modules: **{counts['module']}**
+- Defined but dependency-blocked: **{counts['dependency-blocked']}**
+- Missing from ACK source: **{counts['source-missing']}**
+- ACK files mentioning Lagoon, SM7125, SM7225 or a52xq: **{len(platform_hits)}**
+
+## Built-in options
+
+{chr(10).join(f'- `{option}`' for option in builtin) or '- None'}
+
+## Module results
+
+{chr(10).join(f'- `{option}`' for option in modules) or '- None'}
+
+## Dependency-blocked options
+
+{chr(10).join(f'- `{option}`' for option in blocked) or '- None'}
+
+## Missing source options
+
+{chr(10).join(f'- `{option}`' for option in missing) or '- None'}
+
+## Interpretation
+
+Options that resolve to built-in can stay in the ACK-derived core. Options missing from ACK source identify the first TouchGrass or Qualcomm vendor code that must be ported. A successful compile does not make the output bootable because the A52 device tree and all missing Lagoon platform drivers are still absent.
+"""
+(dest / "P0-PROBE-REPORT.md").write_text(report)
+PY
+
+set +e
+make "${make_args[@]}" -j"$JOBS" Image modules 2>&1 | tee "$DEST/logs/build.log"
+build_rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$build_rc" > "$DEST/build.exit-code"
+
+if [[ "$build_rc" -eq 0 ]]; then
+  cp "$OUT_DIR/arch/arm64/boot/Image" "$DEST/Image"
+  gzip -n -9 -c "$DEST/Image" > "$DEST/Image.gz"
+  cp "$OUT_DIR/Module.symvers" "$DEST/Module.symvers"
+  cp "$OUT_DIR/System.map" "$DEST/System.map"
+  find "$OUT_DIR" -type f -name '*.ko' -printf '%P\n' | sort > "$DEST/modules.list"
+  make -s "${make_args[@]}" kernelrelease > "$DEST/kernel-release.txt"
+else
+  echo "The P0 configuration did not compile. Review logs/build.log." > "$DEST/BUILD-FAILED.txt"
+fi
+
+{
+  echo "repository=$GKI_REPO"
+  echo "branch=$GKI_BRANCH"
+  echo "commit=$actual_commit"
+  echo "defconfig=$GKI_DEFCONFIG"
+  echo "build_exit_code=$build_rc"
+  if [[ -s "$DEST/Image" ]]; then
+    echo "image_bytes=$(stat -c %s "$DEST/Image")"
+    echo "image_gz_bytes=$(stat -c %s "$DEST/Image.gz")"
+    echo "un1ca_kernel_member=Image.gz"
+    echo "flashable=no"
+  fi
+} > "$DEST/metadata.txt"
+
+cat > "$DEST/FLASHING-NOTICE.txt" <<'EOF'
+DO NOT FLASH THIS OUTPUT.
+
+This is a source and configuration feasibility probe. It has no A52 DTB integration and may lack mandatory Qualcomm/Samsung platform drivers. Image.gz exists only to validate the UN1CA payload format.
+EOF
+
+(
+  cd "$DEST"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)
+
+exit "$build_rc"

--- a/scripts/33_collect_un1ca_sm7225_requirements.sh
+++ b/scripts/33_collect_un1ca_sm7225_requirements.sh
@@ -15,6 +15,8 @@ mkdir -p "$WORK_DIR" "$DEST/source-files"
 git init -q "$SRC_DIR"
 git -C "$SRC_DIR" remote add origin "$UN1CA_REPO"
 git -C "$SRC_DIR" config core.sparseCheckout true
+git -C "$SRC_DIR" config remote.origin.promisor true
+git -C "$SRC_DIR" config remote.origin.partialclonefilter blob:none
 cat > "$SRC_DIR/.git/info/sparse-checkout" <<'EOF'
 /README.md
 /.github/workflows/build.yml
@@ -27,7 +29,7 @@ cat > "$SRC_DIR/.git/info/sparse-checkout" <<'EOF'
 /target/a52xq/vintf/compatibility_matrix.device.xml
 EOF
 
-git -C "$SRC_DIR" fetch --no-tags --depth=1 origin "$UN1CA_COMMIT"
+git -C "$SRC_DIR" fetch --filter=blob:none --no-tags --depth=1 origin "$UN1CA_COMMIT"
 git -C "$SRC_DIR" checkout --detach FETCH_HEAD
 actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
 [[ "$actual_commit" == "$UN1CA_COMMIT" ]] || {

--- a/scripts/33_collect_un1ca_sm7225_requirements.sh
+++ b/scripts/33_collect_un1ca_sm7225_requirements.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/rom-sources.lock"
+
+WORK_DIR="${WORK_DIR:-$ROOT_DIR/work-un1ca-sm7225}"
+SRC_DIR="$WORK_DIR/source"
+DEST="$ROOT_DIR/artifacts/compatibility/un1ca-sm7225"
+
+rm -rf "$WORK_DIR" "$DEST"
+mkdir -p "$WORK_DIR" "$DEST/source-files"
+
+git init -q "$SRC_DIR"
+git -C "$SRC_DIR" remote add origin "$UN1CA_REPO"
+git -C "$SRC_DIR" config core.sparseCheckout true
+cat > "$SRC_DIR/.git/info/sparse-checkout" <<'EOF'
+/README.md
+/.github/workflows/build.yml
+/platform/sm7225/config.sh
+/platform/sm7225/installer/recovery.fstab
+/target/a52xq/config.sh
+/target/a52xq/patches/kernel/customize.sh
+/target/a52xq/patches/kernel/module.prop
+/target/a52xq/patches/wpss/vendor/etc/init/wifi_firmware.rc
+/target/a52xq/vintf/compatibility_matrix.device.xml
+EOF
+
+git -C "$SRC_DIR" fetch --no-tags --depth=1 origin "$UN1CA_COMMIT"
+git -C "$SRC_DIR" checkout --detach FETCH_HEAD
+actual_commit="$(git -C "$SRC_DIR" rev-parse HEAD)"
+[[ "$actual_commit" == "$UN1CA_COMMIT" ]] || {
+  echo "UN1CA commit mismatch: expected $UN1CA_COMMIT, got $actual_commit" >&2
+  exit 1
+}
+
+while IFS= read -r relative_path; do
+  [[ -f "$SRC_DIR/$relative_path" ]] || {
+    echo "Missing pinned UN1CA file: $relative_path" >&2
+    exit 1
+  }
+  mkdir -p "$DEST/source-files/$(dirname "$relative_path")"
+  cp "$SRC_DIR/$relative_path" "$DEST/source-files/$relative_path"
+done <<'EOF'
+README.md
+.github/workflows/build.yml
+platform/sm7225/config.sh
+platform/sm7225/installer/recovery.fstab
+target/a52xq/config.sh
+target/a52xq/patches/kernel/customize.sh
+target/a52xq/patches/kernel/module.prop
+target/a52xq/patches/wpss/vendor/etc/init/wifi_firmware.rc
+target/a52xq/vintf/compatibility_matrix.device.xml
+EOF
+
+platform_config="$SRC_DIR/platform/sm7225/config.sh"
+target_config="$SRC_DIR/target/a52xq/config.sh"
+kernel_patch="$SRC_DIR/target/a52xq/patches/kernel/customize.sh"
+fstab="$SRC_DIR/platform/sm7225/installer/recovery.fstab"
+vintf="$SRC_DIR/target/a52xq/vintf/compatibility_matrix.device.xml"
+
+read_assignment() {
+  local file="$1"
+  local key="$2"
+  sed -n "s/^${key}=//p" "$file" | head -n 1 | tr -d '"'
+}
+
+boot_size="$(read_assignment "$platform_config" TARGET_BOOT_PARTITION_SIZE)"
+dtbo_size="$(read_assignment "$platform_config" TARGET_DTBO_PARTITION_SIZE)"
+vendor_boot_size="$(read_assignment "$platform_config" TARGET_VENDOR_BOOT_PARTITION_SIZE)"
+board_api="$(read_assignment "$platform_config" TARGET_BOARD_API_LEVEL)"
+shipping_api="$(read_assignment "$target_config" TARGET_PRODUCT_SHIPPING_API_LEVEL)"
+platform_sdk="$(read_assignment "$target_config" TARGET_PLATFORM_SDK_VERSION)"
+firmware="$(read_assignment "$target_config" TARGET_FIRMWARE)"
+super_size="$(read_assignment "$target_config" TARGET_SUPER_PARTITION_SIZE)"
+
+kernel_url="$(sed -n 's/^KERNEL_ZIP="\(.*\)"/\1/p' "$kernel_patch" | head -n 1)"
+kernel_member="$(sed -n 's/.*unzip .* "\([^"]*Image[^" ]*\)".*/\1/p' "$kernel_patch" | head -n 1)"
+
+[[ "$kernel_url" == "$UN1CA_KERNEL_ZIP" ]] || {
+  echo "Pinned kernel URL no longer matches UN1CA source" >&2
+  exit 1
+}
+[[ "$kernel_member" == "$UN1CA_KERNEL_MEMBER" ]] || {
+  echo "Pinned kernel member no longer matches UN1CA source" >&2
+  exit 1
+}
+
+grep -Fq 'unpack_bootimg --boot_img' "$kernel_patch"
+grep -Fq 'mv "$TMP_DIR/out/Image.gz" "$TMP_DIR/out/kernel"' "$kernel_patch"
+grep -Fq 'mkbootimg $MKBOOTIMG_ARGS' "$kernel_patch"
+grep -Fq 'SEANDROIDENFORCE' "$kernel_patch"
+
+{
+  echo "repository=$UN1CA_REPO"
+  echo "branch=$UN1CA_BRANCH"
+  echo "commit=$actual_commit"
+  echo "platform=$UN1CA_PLATFORM"
+  echo "target=$UN1CA_TARGET"
+  echo "firmware=$firmware"
+  echo "board_api_level=$board_api"
+  echo "shipping_api_level=$shipping_api"
+  echo "platform_sdk_version=$platform_sdk"
+  echo "boot_partition_bytes=$boot_size"
+  echo "dtbo_partition_bytes=$dtbo_size"
+  echo "vendor_boot_partition_bytes=$vendor_boot_size"
+  echo "super_partition_bytes=$super_size"
+  echo "kernel_zip=$kernel_url"
+  echo "kernel_member=$kernel_member"
+} > "$DEST/metadata.txt"
+
+awk 'NF && $1 !~ /^#/' "$fstab" > "$DEST/recovery-fstab.entries.txt"
+grep -E '<kernel-sepolicy-version>|<sepolicy-version>|<vbmeta-version>' "$vintf" \
+  > "$DEST/security-compatibility.txt"
+
+grep -E '^on |property:ro\.boot\.(rp|em\.model)' \
+  "$SRC_DIR/target/a52xq/patches/wpss/vendor/etc/init/wifi_firmware.rc" \
+  > "$DEST/wifi-firmware-selection.txt"
+
+cat > "$DEST/UN1CA-ROM-REQUIREMENTS.md" <<EOF
+# UN1CA SM7225 requirements for the A52 GKI project
+
+## Pinned ROM source
+
+- Repository: \`$UN1CA_REPO\`
+- Branch: \`$UN1CA_BRANCH\`
+- Commit: \`$actual_commit\`
+- Target: \`$UN1CA_TARGET\`
+- Platform: \`$UN1CA_PLATFORM\`
+- Stock firmware identity: \`$firmware\`
+
+## Kernel integration contract
+
+UN1CA does not rebuild the A52 boot environment around a new kernel format. Its device patch:
+
+1. unpacks the existing \`boot.img\`,
+2. downloads the TouchGrass kernel ZIP,
+3. extracts \`$kernel_member\`,
+4. replaces only the unpacked kernel payload,
+5. repacks with the original \`mkbootimg\` arguments,
+6. appends the Samsung \`SEANDROIDENFORCE\` trailer.
+
+Therefore the first compatible GKI-derived candidate must be delivered as a gzip-compressed arm64 kernel payload that can replace the existing payload without changing the ramdisk, header arguments, DTB placement, page size, or offsets.
+
+## Partition and Android constraints
+
+| Requirement | Value |
+|---|---:|
+| Boot partition | $boot_size bytes |
+| DTBO partition | $dtbo_size bytes |
+| Vendor boot partition | $vendor_boot_size bytes |
+| Super partition | $super_size bytes |
+| Board API level | $board_api |
+| Product shipping API level | $shipping_api |
+| Target platform SDK | $platform_sdk |
+| Dynamic partitions | enabled |
+| ROM filesystem | EROFS |
+
+The recovery fstab names \`boot\`, \`dtbo\`, \`vendor_boot\`, \`vbmeta_system\`, \`vbmeta_samsung\`, and logical first-stage \`system\`, \`vendor\`, \`product\`, and \`odm\` partitions. Presence in the installer configuration does not prove that UN1CA uses a GKI header-v3 vendor ramdisk arrangement. The generated binary \`boot.img\` and \`vendor_boot.img\` still need to be unpacked and measured.
+
+## Implications for the hybrid kernel
+
+- Preserve Samsung's existing boot image structure during the first boot probe.
+- Produce and validate \`Image.gz\`, not only raw \`Image\`.
+- Keep UFS, IOMMU, clocks, RPMh, regulators, binder, SELinux, dm-verity, EROFS and the first-stage filesystem chain available early enough for the ROM.
+- Treat Wi-Fi firmware selection as userspace/firmware work keyed by \`ro.boot.rp\` and \`ro.boot.em.model\`; it is not evidence that a generic GKI WLAN driver is sufficient.
+- Keep the existing A52 DTB/DTBO selection until a controlled device-tree migration is proven.
+
+## Remaining binary inputs
+
+The source repository is enough to define the packaging contract, but not enough to verify the exact boot binary layout. The most useful remaining files are the generated UN1CA \`boot.img\`, \`vendor_boot.img\`, \`dtbo.img\`, and module directories from \`vendor\`, \`vendor_dlkm\`, or \`system_dlkm\` if present.
+EOF
+
+(
+  cd "$DEST"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)

--- a/scripts/34_collect_touchgrass_4.19.325_inventory.sh
+++ b/scripts/34_collect_touchgrass_4.19.325_inventory.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+source "$(dirname "$0")/common.sh"
+
+TARGET_VERSION=4.19.325
+DEST="$PROJECT_DIR/artifacts/compatibility/touchgrass-4.19.325"
+OUT_DIR="$KERNEL_DIR/out"
+
+[[ "$(kernel_version)" == "$TARGET_VERSION" ]] || fail "Expected Linux $TARGET_VERSION source"
+[[ -s "$OUT_DIR/arch/arm64/boot/Image" ]] || fail "touchGrass Image is missing"
+[[ -s "$OUT_DIR/.config" ]] || fail "touchGrass final config is missing"
+[[ -s "$OUT_DIR/Module.symvers" ]] || fail "touchGrass Module.symvers is missing"
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+cp "$OUT_DIR/arch/arm64/boot/Image" "$DEST/Image"
+cp "$OUT_DIR/.config" "$DEST/config"
+cp "$OUT_DIR/Module.symvers" "$DEST/Module.symvers"
+[[ -s "$OUT_DIR/System.map" ]] && cp "$OUT_DIR/System.map" "$DEST/System.map"
+
+find "$OUT_DIR" -type f -name '*.ko' -printf '%P\n' | sort > "$DEST/modules.list"
+find "$OUT_DIR/arch/arm64/boot" -type f \( -name '*.dtb' -o -name '*.dtbo' \) \
+  -printf '%P\n' | sort > "$DEST/device-trees.list"
+
+strings "$DEST/Image" | grep -E 'Linux version|touchGrassKernel|qcom,lagoon|a52xq|sm7125|sm7225' \
+  | sort -u > "$DEST/image-platform-strings.txt" || true
+
+{
+  echo "source_repository=$TOUCHGRASS_REPO"
+  echo "source_base_commit=$TOUCHGRASS_COMMIT"
+  echo "kernel_version=$(kernel_version)"
+  echo "kernel_release=$(make -s -C "$KERNEL_DIR" O="$OUT_DIR" ARCH=arm64 kernelrelease)"
+  echo "image_bytes=$(stat -c %s "$DEST/Image")"
+  echo "module_count=$(wc -l < "$DEST/modules.list")"
+  echo "device_tree_count=$(wc -l < "$DEST/device-trees.list")"
+  echo "exported_symbol_count=$(wc -l < "$DEST/Module.symvers")"
+  echo "flashable=no"
+} > "$DEST/metadata.txt"
+
+(
+  cd "$DEST"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)


### PR DESCRIPTION
## Goal

Complete a reproducible, non-flashable comparison between Android Common Kernel GKI 4.19, the Galaxy A52 touchGrass hardware baseline, the same-version touchGrass 4.19.325 tree, and UN1CA's A52 boot contract.

## Compared inputs

- ACK GKI 4.19.325 at `a8bf86a0e0fa05070897a210d706d5c4d83c26ac`
- touchGrass 4.19.200 hardware baseline
- touchGrass 4.19.325 same-version build-verified baseline
- UN1CA `matei9/UN1CA_SM7125`, branch `sm7225`, commit `49ec9fa5481808a9906d850297a69e029356dfeb`

## Final configuration result

- 4,086 parsed ACK options
- 5,422 parsed touchGrass 4.19.325 options
- 2,063 non-root config differences
- 844 active touchGrass settings absent, disabled, or differently valued in ACK
- 613 touchGrass built-ins not represented in ACK
- 3 early-critical touchGrass built-ins configured as ACK modules

The touchGrass 4.19.200 and 4.19.325 configs differ in only 18 entries, confirming that the A52 vendor configuration is stable and that most GKI differences are genuine platform differences rather than version noise.

## Final same-version ABI result

ACK GKI 4.19.325 versus touchGrass 4.19.325:

- ACK exported symbols: 11,187
- touchGrass exported symbols: 13,035
- common symbol names: 10,377
- CRC mismatches: 7,773, or 74.9%
- exact common CRC matches: 2,604
- ACK-only symbols: 810
- touchGrass-only symbols: 2,658

Existing touchGrass modules are not ABI-compatible with untouched ACK GKI. Modules must be rebuilt against the selected final source and KMI, and early-boot drivers must remain built in until loading is proven.

## Source boundary

ACK contains reusable generic Qualcomm and Android frameworks, including RPMh, SMEM, command DB, GENI core, ARM SMMU, UFS core, QCOM UFS glue, MSM SDHCI, pstore, EROFS, and DWC3. It does not contain the complete A52 platform chain.

Required platform source includes:

- `ARCH_LAGOON`
- Lagoon GCC and LLCC data
- Lagoon pinctrl
- Qualcomm vendor DT hierarchy
- Lagoon base DTB and A52/Samsung DTBOs
- selected downstream Qualcomm and Samsung interfaces

The comparison also documents downstream API differences in GENI serial, GLINK/QRTR, UFS, MMC/SDHCI, IOMMU, regulators, USB, fscrypt/procfs/ext4, timers, and scheduling.

## UN1CA boot contract

UN1CA preserves the generated boot container and replaces only the compressed kernel payload with `Image.gz`, reusing the original `mkbootimg` arguments and appending Samsung's `SEANDROIDENFORCE` trailer.

The actual generated `boot.img`, `vendor_boot.img`, and `dtbo.img` are still required before any boot-image packaging work.

## Verified artifacts

Final workflow run: `29417876534`

Final artifact: `a52xq-gki-4.19-full-comparison-10-NON-FLASHABLE`

Artifact ID: `8344580505`

Artifact SHA-256: `2e137c55c1fab4937bdfbb1c12f1e2ee7795838e78ac830f90086d7a10108b95`

Every workflow step completed successfully.

## Safety

No output in this PR is flashable. The parked P0 probe script was not run. Implementation should begin only after the generated UN1CA boot images are collected and measured.