### PR TITLE
Build Linux 4.19.206 with ReSukiSU and SUSFS inline hooks

### DIFF
--- a/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
+++ b/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml'
       - 'scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh'
+      - 'scripts/55_transform_resukisu_susfs_wrapper.py'
   workflow_dispatch:
 
 permissions:
@@ -32,7 +33,7 @@ jobs:
         with:
           ref: rebase/resukisu-linux-4.19.325
 
-      - name: Hydrate PR build helper and pinned boot-image tools
+      - name: Hydrate PR build tools and pinned boot-image tools
         env:
           GH_TOKEN: ${{ github.token }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -47,11 +48,16 @@ jobs:
             test -s "$path"
           }
           fetch_file "$PR_HEAD_SHA" scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
+          fetch_file "$PR_HEAD_SHA" scripts/55_transform_resukisu_susfs_wrapper.py
           fetch_file main scripts/37_validate_a52_p1_boot_source.py
           fetch_file main scripts/38_repack_a52_p1_boot.py
           fetch_file main projects/a52-p1-boot-image/boot-source.lock
           chmod +x scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh \
+            scripts/55_transform_resukisu_susfs_wrapper.py \
             scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
+          python3 -m py_compile scripts/55_transform_resukisu_susfs_wrapper.py
+          python3 scripts/55_transform_resukisu_susfs_wrapper.py --patch-helper \
+            scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
           bash -n scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
 
       - name: Free runner disk space
@@ -81,7 +87,12 @@ jobs:
       - name: Build and repack experimental rooted boot image
         env:
           GH_TOKEN: ${{ github.token }}
-        run: scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
+        run: |
+          set -Eeuo pipefail
+          mkdir -p artifacts
+          set -o pipefail
+          scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh \
+            2>&1 | tee artifacts/linux-4.19.206-resukisu-susfs-driver.log
 
       - name: Record runner and source diagnostics
         if: always()

--- a/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
+++ b/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
@@ -1,0 +1,315 @@
+name: 55 - A52 Linux 4.19.206 ReSukiSU SUSFS inline build
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-linux-4.19.206-resukisu-susfs-inline-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JOBS: '4'
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 5G
+
+jobs:
+  build-repack:
+    name: Build and repack Linux 4.19.206 + ReSukiSU + SUSFS inline
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out pinned ReSukiSU integration project
+        uses: actions/checkout@v4
+        with:
+          ref: rebase/resukisu-linux-4.19.325
+
+      - name: Hydrate pinned boot-image validation and repack helpers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p scripts projects/a52-p1-boot-image
+          fetch_file() {
+            local ref="$1"
+            local path="$2"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${ref}" \
+              --jq '.content' | tr -d '\n' | base64 --decode > "$path"
+            test -s "$path"
+          }
+          fetch_file main scripts/37_validate_a52_p1_boot_source.py
+          fetch_file main scripts/38_repack_a52_p1_boot.py
+          fetch_file main projects/a52-p1-boot-image/boot-source.lock
+          chmod +x scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          df -h
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils gzip zip unzip make gcc g++ bc bison flex ccache patch \
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar
+
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: a52xq-linux-4.19.206-resukisu-susfs-inline-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            a52xq-linux-4.19.206-resukisu-susfs-inline-${{ runner.os }}-
+            a52xq-linux-4.19.200-susfs-ccache-${{ runner.os }}-
+            a52xq-linux-4.19.206-no-root-${{ runner.os }}-
+            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
+
+      - name: Prepare exact touchGrass source through Linux 4.19.200
+        run: |
+          set -Eeuo pipefail
+          chmod +x scripts/*.sh scripts/*.py
+          ./scripts/01_prepare_source.sh
+          ./scripts/03_apply_linux_4.19.153.sh
+          ./scripts/04_apply_linux_4.19.154.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+          ./scripts/checkpoint_resolve_linux_4.19.159.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+          ./scripts/checkpoint_resolve_linux_4.19.164.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+          ./scripts/checkpoint_resolve_linux_4.19.180.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+          ./scripts/checkpoint_resolve_linux_4.19.200.sh
+          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.200
+
+      - name: Derive and apply official Linux 4.19.206 merge
+        run: |
+          set -Eeuo pipefail
+          cp scripts/checkpoint_merge_linux_4.19.210.sh scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          sed -i \
+            -e 's/TO_TAG=v4.19.210/TO_TAG=v4.19.206/' \
+            -e '/^TARGET_COMMIT=/d' \
+            -e '/test "$to_sha" = "$TARGET_COMMIT"/d' \
+            scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          chmod +x scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          ./scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.206
+
+      - name: Apply reviewed Linux 4.19.206 merge-shape repairs
+        run: |
+          set -Eeuo pipefail
+          cp scripts/checkpoint_fix_linux_4.19.210_compile.sh scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          sed -i 's/TARGET_VERSION=4.19.210/TARGET_VERSION=4.19.206/' \
+            scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          chmod +x scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          ./scripts/checkpoint_fix_linux_4.19.206.generated.sh
+
+          python3 - <<'PY'
+          from pathlib import Path
+
+          root = Path('workspace/touchgrass-a52xq')
+
+          header = (root / 'include/linux/timerqueue.h').read_text()
+          path = root / 'drivers/soc/qcom/event_timer.c'
+          text = path.read_text()
+          newer = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+          \t.rb_root = RB_ROOT_CACHED,
+          };
+          '''
+          older = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+          \t.head = RB_ROOT,
+          \t.next = NULL,
+          };
+          '''
+          wants_newer = 'struct rb_root_cached rb_root;' in header
+          desired = newer if wants_newer else older
+          obsolete = older if wants_newer else newer
+          if desired not in text:
+              if obsolete not in text:
+                  raise SystemExit('event_timer initializer shape is unrecognized')
+              path.write_text(text.replace(obsolete, desired, 1))
+
+          path = root / 'kernel/sched/cpufreq_schedutil.c'
+          text = path.read_text()
+          call = 'sugov_clear_global_tunables();'
+          definition = 'static void sugov_clear_global_tunables(void)'
+          anchor = 'static void sugov_exit('
+          if call in text and definition not in text:
+              if anchor not in text:
+                  raise SystemExit('schedutil exit anchor missing')
+              helper = '''static void sugov_clear_global_tunables(void)
+          {
+          \tif (!have_governor_per_policy())
+          \t\tglobal_tunables = NULL;
+          }
+
+          '''
+              path.write_text(text.replace(anchor, helper + anchor, 1))
+          elif call not in text:
+              raise SystemExit('schedutil cleanup call missing after generic repair')
+          PY
+
+      - name: Restore the working A52 hardware and touchscreen configuration
+        run: |
+          set -Eeuo pipefail
+          KERNEL=workspace/touchgrass-a52xq
+          DEFCONFIG="$KERNEL/arch/arm64/configs/a52xq_defconfig"
+          "$KERNEL/scripts/config" --file "$DEFCONFIG" \
+            -e TOUCHSCREEN_STM_FTS5CU56A \
+            -e PRINTK -e PRINTK_TIME -e IKCONFIG -e IKCONFIG_PROC \
+            -e DEBUG_KERNEL -e FRAME_POINTER -e PANIC_ON_OOPS \
+            -e PSTORE -e PSTORE_RAM -e PSTORE_CONSOLE -e PSTORE_PMSG \
+            -e SERIAL_MSM_GENI -e SERIAL_MSM_GENI_CONSOLE \
+            -e ARCH_QCOM -e ARCH_LAGOON \
+            -e QCOM_SCM -e QCOM_RPMH -e QCOM_SMEM -e QCOM_SMP2P \
+            -e QCOM_COMMAND_DB -e COMMON_CLK_QCOM -e SDM_GCC_LAGOON \
+            -e PINCTRL -e PINCTRL_MSM -e PINCTRL_LAGOON \
+            -e REGULATOR -e REGULATOR_QCOM_RPMH \
+            -e IOMMU_SUPPORT -e ARM_SMMU -e QTI_IOMMU_SUPPORT \
+            -e SCSI -e SCSI_UFSHCD -e SCSI_UFSHCD_PLATFORM -e SCSI_UFS_QCOM \
+            -e PHY_QCOM_UFS \
+            -e BLK_DEV_INITRD -e DEVTMPFS -e DEVTMPFS_MOUNT \
+            -e EXT4_FS -e F2FS_FS -e FS_ENCRYPTION \
+            -e SECURITY -e SECURITY_SELINUX -e ANDROID_BINDER_IPC \
+            -e INPUT -e INPUT_TOUCHSCREEN -e INPUT_MISC -e INPUT_QPNP_POWER_ON \
+            -e DRM -e QCOM_KGSL -e QCOM_KGSL_IOMMU \
+            -e MEDIA_SUPPORT -e SOUND -e SND \
+            -e WLAN -e CFG80211 -e MAC80211 -e BT
+          "$KERNEL/scripts/config" --file "$DEFCONFIG" --set-val PANIC_TIMEOUT 10
+
+      - name: Integrate pinned ReSukiSU and SUSFS with inline hooks, then build
+        run: |
+          set -Eeuo pipefail
+          set -o pipefail
+          ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.206 susfs \
+            2>&1 | tee artifacts/linux-4.19.206-resukisu-susfs-inline.log
+
+      - name: Enforce root, hook, hardware, and safety invariants
+        run: |
+          set -Eeuo pipefail
+          IMAGE=artifacts/Image-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
+          CONFIG=artifacts/config-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
+          KERNEL=workspace/touchgrass-a52xq
+          test -s "$IMAGE"
+          test -s "$CONFIG"
+          grep -Fxq 'CONFIG_KSU=y' "$CONFIG"
+          grep -Fxq 'CONFIG_KSU_SUSFS=y' "$CONFIG"
+          grep -Fxq 'CONFIG_KSU_MULTI_MANAGER_SUPPORT=y' "$CONFIG"
+          grep -Fxq '# CONFIG_KSU_MANUAL_HOOK is not set' "$CONFIG"
+          grep -Fxq '# CONFIG_KSU_TRACEPOINT_HOOK is not set' "$CONFIG"
+          grep -Fxq '# CONFIG_KPROBES is not set' "$CONFIG"
+          grep -Fxq 'CONFIG_TOUCHSCREEN_STM_FTS5CU56A=y' "$CONFIG"
+          grep -Fxq 'CONFIG_ARCH_LAGOON=y' "$CONFIG"
+          grep -Fxq 'CONFIG_SCSI_UFS_QCOM=y' "$CONFIG"
+          grep -Fxq 'CONFIG_QCOM_KGSL=y' "$CONFIG"
+          grep -Fq 'ksu_handle_sys_read(fd, &buf, &count);' "$KERNEL/fs/read_write.c"
+          grep -Fq 'ksu_handle_input_handle_event(&type, &code, &value);' "$KERNEL/drivers/input/input.c"
+          grep -Fq 'ksu_handle_setresuid(ruid, euid, suid);' "$KERNEL/kernel/sys.c"
+          grep -Fq 'static bool ksu_kernel_umount_enabled = false;' "$KERNEL/KernelSU/kernel/feature/kernel_umount.c"
+          grep -Fq 'default_non_root_profile.umount_modules = false;' "$KERNEL/KernelSU/kernel/policy/allowlist.c"
+          grep -Fxq 'v4.1.0-2206a7dd-dirty@ReSukiSU' \
+            artifacts/Image-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe.strings.txt
+          {
+            echo 'status=build-passed'
+            echo 'hardware_validated=no'
+            echo 'kernel_version=4.19.206-touchGrassKernel+'
+            echo 'resukisu=v4.1.0-2206a7dd'
+            echo 'susfs=1.4.2-kernel-4.19'
+            echo 'hook_mode=susfs-inline'
+            echo 'manual_hook=off'
+            echo 'tracepoint_hook=off'
+            echo 'kernel_unmount_default=off'
+            echo 'module_unmount_default=off'
+            echo 'touchscreen=stm-fts-enabled'
+            echo "image_sha256=$(sha256sum "$IMAGE" | awk '{print $1}')"
+          } | tee artifacts/linux-4.19.206-resukisu-susfs-inline-metadata.txt
+
+      - name: Download and validate checksum-locked original boot image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p intake artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot
+          ASSET_LINE="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=30" \
+            --jq '.[] | .assets[] | select(.name | endswith(".img")) | [.id, .name, .created_at] | @tsv' | head -n 1)"
+          test -n "$ASSET_LINE"
+          IFS=$'\t' read -r ASSET_ID ASSET_NAME ASSET_CREATED <<< "$ASSET_LINE"
+          curl --fail --location --retry 3 --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/octet-stream' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" \
+            --output intake/boot.img
+          python3 scripts/37_validate_a52_p1_boot_source.py intake/boot.img \
+            --lock projects/a52-p1-boot-image/boot-source.lock \
+            --output artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot/source-validation.json
+          printf 'source_asset=%s\nsource_created=%s\n' "$ASSET_NAME" "$ASSET_CREATED" \
+            > artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot/source-asset.txt
+
+      - name: Repack and audit experimental rooted boot image
+        run: |
+          set -Eeuo pipefail
+          IMAGE=artifacts/Image-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
+          CONFIG=artifacts/config-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
+          OUT=artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot
+          gzip -n -9 -c "$IMAGE" > "$OUT/Image.gz"
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source intake/boot.img \
+            --kernel "$OUT/Image.gz" \
+            --output "$OUT/boot.img" \
+            --report "$OUT/repack-report.json"
+          cp "$CONFIG" "$OUT/final.config"
+          cp artifacts/linux-4.19.206-resukisu-susfs-inline-metadata.txt "$OUT/metadata.txt"
+          cat > "$OUT/NOTICE.txt" <<'EOF'
+          EXPERIMENTAL A52XQ LINUX 4.19.206 ROOTED BOOT IMAGE
+
+          ReSukiSU v4.1.0 and SUSFS v1.4.2 are enabled.
+          Hook mode: SUSFS inline hook. ReSukiSU manual and tracepoint hooks are disabled.
+          The STM FTS touchscreen and the working A52 hardware configuration are retained.
+          Kernel and module unmount defaults are disabled.
+
+          This build passed compilation and repack audits only. It has not been validated on
+          physical hardware. Back up boot and data before testing, and keep the known-working
+          4.19.206 boot image available for immediate rollback.
+          EOF
+          sha256sum "$OUT"/* > "$OUT/SHA256SUMS"
+
+      - name: Record source state
+        if: always()
+        run: |
+          mkdir -p artifacts
+          df -h > artifacts/runner-disk.txt
+          free -h > artifacts/runner-memory.txt
+          uname -a > artifacts/runner-uname.txt
+          ccache --show-stats > artifacts/ccache-final.txt 2>&1 || true
+          if [ -d workspace/touchgrass-a52xq/.git ]; then
+            git -C workspace/touchgrass-a52xq status --short > artifacts/kernel-source-status.txt || true
+            git -C workspace/touchgrass-a52xq diff --stat > artifacts/kernel-source-diff.stat.txt || true
+            git -C workspace/touchgrass-a52xq diff --check > artifacts/kernel-source-diff-check.txt 2>&1 || true
+          fi
+          if [ -d workspace/touchgrass-a52xq/KernelSU/.git ]; then
+            git -C workspace/touchgrass-a52xq/KernelSU rev-parse HEAD > artifacts/resukisu-head.txt || true
+          fi
+
+      - name: Upload experimental boot image
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Linux-4.19.206-ReSukiSU-v4.1.0-SUSFS-v1.4.2-INLINE-EXPERIMENTAL-${{ github.run_number }}
+          path: artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-linux-4.19.206-resukisu-susfs-inline-${{ github.run_number }}-diagnostics
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
+++ b/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
@@ -6,6 +6,8 @@ on:
       - '.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml'
       - 'scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh'
       - 'scripts/55_transform_resukisu_susfs_wrapper.py'
+      - 'scripts/55_apply_susfs_resukisu_compat.py'
+      - 'scripts/55_susfs_resukisu_compat.c'
   workflow_dispatch:
 
 permissions:
@@ -49,13 +51,17 @@ jobs:
           }
           fetch_file "$PR_HEAD_SHA" scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
           fetch_file "$PR_HEAD_SHA" scripts/55_transform_resukisu_susfs_wrapper.py
+          fetch_file "$PR_HEAD_SHA" scripts/55_apply_susfs_resukisu_compat.py
+          fetch_file "$PR_HEAD_SHA" scripts/55_susfs_resukisu_compat.c
           fetch_file main scripts/37_validate_a52_p1_boot_source.py
           fetch_file main scripts/38_repack_a52_p1_boot.py
           fetch_file main projects/a52-p1-boot-image/boot-source.lock
           chmod +x scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh \
             scripts/55_transform_resukisu_susfs_wrapper.py \
+            scripts/55_apply_susfs_resukisu_compat.py \
             scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
-          python3 -m py_compile scripts/55_transform_resukisu_susfs_wrapper.py
+          python3 -m py_compile scripts/55_transform_resukisu_susfs_wrapper.py \
+            scripts/55_apply_susfs_resukisu_compat.py
           python3 scripts/55_transform_resukisu_susfs_wrapper.py --patch-helper \
             scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
           bash -n scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh

--- a/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
+++ b/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
@@ -184,6 +184,11 @@ jobs:
             -e WLAN -e CFG80211 -e MAC80211 -e BT
           "$KERNEL/scripts/config" --file "$DEFCONFIG" --set-val PANIC_TIMEOUT 10
 
+      - name: Replace legacy exec dispatch with ReSukiSU-compatible guards
+        run: |
+          set -Eeuo pipefail
+          ./scripts/07_patch_resukisu_exec_hook.sh
+
       - name: Integrate pinned ReSukiSU and SUSFS with inline hooks, then build
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
+++ b/.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/55-a52-linux-4.19.206-resukisu-susfs-inline.yml'
+      - 'scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh'
   workflow_dispatch:
 
 permissions:
@@ -21,7 +22,7 @@ env:
 
 jobs:
   build-repack:
-    name: Build and repack Linux 4.19.206 + ReSukiSU + SUSFS inline
+    name: Build and repack Linux 4.19.206 plus ReSukiSU and SUSFS inline
     runs-on: ubuntu-22.04
     timeout-minutes: 360
 
@@ -31,9 +32,10 @@ jobs:
         with:
           ref: rebase/resukisu-linux-4.19.325
 
-      - name: Hydrate pinned boot-image validation and repack helpers
+      - name: Hydrate PR build helper and pinned boot-image tools
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -Eeuo pipefail
           mkdir -p scripts projects/a52-p1-boot-image
@@ -44,10 +46,13 @@ jobs:
               --jq '.content' | tr -d '\n' | base64 --decode > "$path"
             test -s "$path"
           }
+          fetch_file "$PR_HEAD_SHA" scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
           fetch_file main scripts/37_validate_a52_p1_boot_source.py
           fetch_file main scripts/38_repack_a52_p1_boot.py
           fetch_file main projects/a52-p1-boot-image/boot-source.lock
-          chmod +x scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
+          chmod +x scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh \
+            scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
+          bash -n scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
 
       - name: Free runner disk space
         run: |
@@ -65,227 +70,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          key: a52xq-linux-4.19.206-resukisu-susfs-inline-${{ runner.os }}-${{ github.run_id }}
+          key: a52xq-linux-4.19.206-resukisu-susfs-v1.5.9-inline-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
+            a52xq-linux-4.19.206-resukisu-susfs-v1.5.9-inline-${{ runner.os }}-
             a52xq-linux-4.19.206-resukisu-susfs-inline-${{ runner.os }}-
             a52xq-linux-4.19.200-susfs-ccache-${{ runner.os }}-
             a52xq-linux-4.19.206-no-root-${{ runner.os }}-
             a52xq-linux-4.19.200-ccache-${{ runner.os }}-
 
-      - name: Prepare exact touchGrass source through Linux 4.19.200
-        run: |
-          set -Eeuo pipefail
-          chmod +x scripts/*.sh scripts/*.py
-          ./scripts/01_prepare_source.sh
-          ./scripts/03_apply_linux_4.19.153.sh
-          ./scripts/04_apply_linux_4.19.154.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
-          ./scripts/checkpoint_resolve_linux_4.19.159.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
-          ./scripts/checkpoint_resolve_linux_4.19.164.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
-          ./scripts/checkpoint_resolve_linux_4.19.180.sh
-          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
-          ./scripts/checkpoint_resolve_linux_4.19.200.sh
-          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.200
-
-      - name: Derive and apply official Linux 4.19.206 merge
-        run: |
-          set -Eeuo pipefail
-          cp scripts/checkpoint_merge_linux_4.19.210.sh scripts/checkpoint_merge_linux_4.19.206.generated.sh
-          sed -i \
-            -e 's/TO_TAG=v4.19.210/TO_TAG=v4.19.206/' \
-            -e '/^TARGET_COMMIT=/d' \
-            -e '/test "$to_sha" = "$TARGET_COMMIT"/d' \
-            scripts/checkpoint_merge_linux_4.19.206.generated.sh
-          chmod +x scripts/checkpoint_merge_linux_4.19.206.generated.sh
-          ./scripts/checkpoint_merge_linux_4.19.206.generated.sh
-          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.206
-
-      - name: Apply reviewed Linux 4.19.206 merge-shape repairs
-        run: |
-          set -Eeuo pipefail
-          cp scripts/checkpoint_fix_linux_4.19.210_compile.sh scripts/checkpoint_fix_linux_4.19.206.generated.sh
-          sed -i 's/TARGET_VERSION=4.19.210/TARGET_VERSION=4.19.206/' \
-            scripts/checkpoint_fix_linux_4.19.206.generated.sh
-          chmod +x scripts/checkpoint_fix_linux_4.19.206.generated.sh
-          ./scripts/checkpoint_fix_linux_4.19.206.generated.sh
-
-          python3 - <<'PY'
-          from pathlib import Path
-
-          root = Path('workspace/touchgrass-a52xq')
-
-          header = (root / 'include/linux/timerqueue.h').read_text()
-          path = root / 'drivers/soc/qcom/event_timer.c'
-          text = path.read_text()
-          newer = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
-          \t.rb_root = RB_ROOT_CACHED,
-          };
-          '''
-          older = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
-          \t.head = RB_ROOT,
-          \t.next = NULL,
-          };
-          '''
-          wants_newer = 'struct rb_root_cached rb_root;' in header
-          desired = newer if wants_newer else older
-          obsolete = older if wants_newer else newer
-          if desired not in text:
-              if obsolete not in text:
-                  raise SystemExit('event_timer initializer shape is unrecognized')
-              path.write_text(text.replace(obsolete, desired, 1))
-
-          path = root / 'kernel/sched/cpufreq_schedutil.c'
-          text = path.read_text()
-          call = 'sugov_clear_global_tunables();'
-          definition = 'static void sugov_clear_global_tunables(void)'
-          anchor = 'static void sugov_exit('
-          if call in text and definition not in text:
-              if anchor not in text:
-                  raise SystemExit('schedutil exit anchor missing')
-              helper = '''static void sugov_clear_global_tunables(void)
-          {
-          \tif (!have_governor_per_policy())
-          \t\tglobal_tunables = NULL;
-          }
-
-          '''
-              path.write_text(text.replace(anchor, helper + anchor, 1))
-          elif call not in text:
-              raise SystemExit('schedutil cleanup call missing after generic repair')
-          PY
-
-      - name: Restore the working A52 hardware and touchscreen configuration
-        run: |
-          set -Eeuo pipefail
-          KERNEL=workspace/touchgrass-a52xq
-          DEFCONFIG="$KERNEL/arch/arm64/configs/a52xq_defconfig"
-          "$KERNEL/scripts/config" --file "$DEFCONFIG" \
-            -e TOUCHSCREEN_STM_FTS5CU56A \
-            -e PRINTK -e PRINTK_TIME -e IKCONFIG -e IKCONFIG_PROC \
-            -e DEBUG_KERNEL -e FRAME_POINTER -e PANIC_ON_OOPS \
-            -e PSTORE -e PSTORE_RAM -e PSTORE_CONSOLE -e PSTORE_PMSG \
-            -e SERIAL_MSM_GENI -e SERIAL_MSM_GENI_CONSOLE \
-            -e ARCH_QCOM -e ARCH_LAGOON \
-            -e QCOM_SCM -e QCOM_RPMH -e QCOM_SMEM -e QCOM_SMP2P \
-            -e QCOM_COMMAND_DB -e COMMON_CLK_QCOM -e SDM_GCC_LAGOON \
-            -e PINCTRL -e PINCTRL_MSM -e PINCTRL_LAGOON \
-            -e REGULATOR -e REGULATOR_QCOM_RPMH \
-            -e IOMMU_SUPPORT -e ARM_SMMU -e QTI_IOMMU_SUPPORT \
-            -e SCSI -e SCSI_UFSHCD -e SCSI_UFSHCD_PLATFORM -e SCSI_UFS_QCOM \
-            -e PHY_QCOM_UFS \
-            -e BLK_DEV_INITRD -e DEVTMPFS -e DEVTMPFS_MOUNT \
-            -e EXT4_FS -e F2FS_FS -e FS_ENCRYPTION \
-            -e SECURITY -e SECURITY_SELINUX -e ANDROID_BINDER_IPC \
-            -e INPUT -e INPUT_TOUCHSCREEN -e INPUT_MISC -e INPUT_QPNP_POWER_ON \
-            -e DRM -e QCOM_KGSL -e QCOM_KGSL_IOMMU \
-            -e MEDIA_SUPPORT -e SOUND -e SND \
-            -e WLAN -e CFG80211 -e MAC80211 -e BT
-          "$KERNEL/scripts/config" --file "$DEFCONFIG" --set-val PANIC_TIMEOUT 10
-
-      - name: Replace legacy exec dispatch with ReSukiSU-compatible guards
-        run: |
-          set -Eeuo pipefail
-          ./scripts/07_patch_resukisu_exec_hook.sh
-
-      - name: Integrate pinned ReSukiSU and SUSFS with inline hooks, then build
-        run: |
-          set -Eeuo pipefail
-          set -o pipefail
-          ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.206 susfs \
-            2>&1 | tee artifacts/linux-4.19.206-resukisu-susfs-inline.log
-
-      - name: Enforce root, hook, hardware, and safety invariants
-        run: |
-          set -Eeuo pipefail
-          IMAGE=artifacts/Image-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
-          CONFIG=artifacts/config-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
-          KERNEL=workspace/touchgrass-a52xq
-          test -s "$IMAGE"
-          test -s "$CONFIG"
-          grep -Fxq 'CONFIG_KSU=y' "$CONFIG"
-          grep -Fxq 'CONFIG_KSU_SUSFS=y' "$CONFIG"
-          grep -Fxq 'CONFIG_KSU_MULTI_MANAGER_SUPPORT=y' "$CONFIG"
-          grep -Fxq '# CONFIG_KSU_MANUAL_HOOK is not set' "$CONFIG"
-          grep -Fxq '# CONFIG_KSU_TRACEPOINT_HOOK is not set' "$CONFIG"
-          grep -Fxq '# CONFIG_KPROBES is not set' "$CONFIG"
-          grep -Fxq 'CONFIG_TOUCHSCREEN_STM_FTS5CU56A=y' "$CONFIG"
-          grep -Fxq 'CONFIG_ARCH_LAGOON=y' "$CONFIG"
-          grep -Fxq 'CONFIG_SCSI_UFS_QCOM=y' "$CONFIG"
-          grep -Fxq 'CONFIG_QCOM_KGSL=y' "$CONFIG"
-          grep -Fq 'ksu_handle_sys_read(fd, &buf, &count);' "$KERNEL/fs/read_write.c"
-          grep -Fq 'ksu_handle_input_handle_event(&type, &code, &value);' "$KERNEL/drivers/input/input.c"
-          grep -Fq 'ksu_handle_setresuid(ruid, euid, suid);' "$KERNEL/kernel/sys.c"
-          grep -Fq 'static bool ksu_kernel_umount_enabled = false;' "$KERNEL/KernelSU/kernel/feature/kernel_umount.c"
-          grep -Fq 'default_non_root_profile.umount_modules = false;' "$KERNEL/KernelSU/kernel/policy/allowlist.c"
-          grep -Fxq 'v4.1.0-2206a7dd-dirty@ReSukiSU' \
-            artifacts/Image-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe.strings.txt
-          {
-            echo 'status=build-passed'
-            echo 'hardware_validated=no'
-            echo 'kernel_version=4.19.206-touchGrassKernel+'
-            echo 'resukisu=v4.1.0-2206a7dd'
-            echo 'susfs=1.4.2-kernel-4.19'
-            echo 'hook_mode=susfs-inline'
-            echo 'manual_hook=off'
-            echo 'tracepoint_hook=off'
-            echo 'kernel_unmount_default=off'
-            echo 'module_unmount_default=off'
-            echo 'touchscreen=stm-fts-enabled'
-            echo "image_sha256=$(sha256sum "$IMAGE" | awk '{print $1}')"
-          } | tee artifacts/linux-4.19.206-resukisu-susfs-inline-metadata.txt
-
-      - name: Download and validate checksum-locked original boot image
+      - name: Build and repack experimental rooted boot image
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -Eeuo pipefail
-          mkdir -p intake artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot
-          ASSET_LINE="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=30" \
-            --jq '.[] | .assets[] | select(.name | endswith(".img")) | [.id, .name, .created_at] | @tsv' | head -n 1)"
-          test -n "$ASSET_LINE"
-          IFS=$'\t' read -r ASSET_ID ASSET_NAME ASSET_CREATED <<< "$ASSET_LINE"
-          curl --fail --location --retry 3 --silent --show-error \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H 'Accept: application/octet-stream' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" \
-            --output intake/boot.img
-          python3 scripts/37_validate_a52_p1_boot_source.py intake/boot.img \
-            --lock projects/a52-p1-boot-image/boot-source.lock \
-            --output artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot/source-validation.json
-          printf 'source_asset=%s\nsource_created=%s\n' "$ASSET_NAME" "$ASSET_CREATED" \
-            > artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot/source-asset.txt
+        run: scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
 
-      - name: Repack and audit experimental rooted boot image
-        run: |
-          set -Eeuo pipefail
-          IMAGE=artifacts/Image-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
-          CONFIG=artifacts/config-touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-safe
-          OUT=artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot
-          gzip -n -9 -c "$IMAGE" > "$OUT/Image.gz"
-          python3 scripts/38_repack_a52_p1_boot.py \
-            --source intake/boot.img \
-            --kernel "$OUT/Image.gz" \
-            --output "$OUT/boot.img" \
-            --report "$OUT/repack-report.json"
-          cp "$CONFIG" "$OUT/final.config"
-          cp artifacts/linux-4.19.206-resukisu-susfs-inline-metadata.txt "$OUT/metadata.txt"
-          cat > "$OUT/NOTICE.txt" <<'EOF'
-          EXPERIMENTAL A52XQ LINUX 4.19.206 ROOTED BOOT IMAGE
-
-          ReSukiSU v4.1.0 and SUSFS v1.4.2 are enabled.
-          Hook mode: SUSFS inline hook. ReSukiSU manual and tracepoint hooks are disabled.
-          The STM FTS touchscreen and the working A52 hardware configuration are retained.
-          Kernel and module unmount defaults are disabled.
-
-          This build passed compilation and repack audits only. It has not been validated on
-          physical hardware. Back up boot and data before testing, and keep the known-working
-          4.19.206 boot image available for immediate rollback.
-          EOF
-          sha256sum "$OUT"/* > "$OUT/SHA256SUMS"
-
-      - name: Record source state
+      - name: Record runner and source diagnostics
         if: always()
         run: |
           mkdir -p artifacts
@@ -301,12 +99,15 @@ jobs:
           if [ -d workspace/touchgrass-a52xq/KernelSU/.git ]; then
             git -C workspace/touchgrass-a52xq/KernelSU rev-parse HEAD > artifacts/resukisu-head.txt || true
           fi
+          if [ -d workspace/susfs4ksu-kernel-4.19/.git ]; then
+            git -C workspace/susfs4ksu-kernel-4.19 rev-parse HEAD > artifacts/susfs-head.txt || true
+          fi
 
       - name: Upload experimental boot image
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-Linux-4.19.206-ReSukiSU-v4.1.0-SUSFS-v1.4.2-INLINE-EXPERIMENTAL-${{ github.run_number }}
-          path: artifacts/a52xq-linux-4.19.206-resukisu-susfs-inline-boot
+          name: A52XQ-Linux-4.19.206-ReSukiSU-v4.1.0-SUSFS-v1.5.9-INLINE-EXPERIMENTAL-${{ github.run_number }}
+          path: artifacts/a52xq-linux-4.19.206-resukisu-susfs-v1.5.9-inline-boot
           if-no-files-found: error
           retention-days: 14
 
@@ -314,7 +115,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-linux-4.19.206-resukisu-susfs-inline-${{ github.run_number }}-diagnostics
+          name: a52xq-linux-4.19.206-resukisu-susfs-v1.5.9-inline-${{ github.run_number }}-diagnostics
           path: artifacts/
           if-no-files-found: warn
           retention-days: 14

--- a/scripts/55_apply_susfs_resukisu_compat.py
+++ b/scripts/55_apply_susfs_resukisu_compat.py
@@ -43,6 +43,9 @@ def main() -> None:
     text = susfs_def.read_text()
     final_guard = "#endif // #ifndef KSU_SUSFS_DEF_H\n"
     command_compat = """
+#ifndef SUSFS_MAGIC
+#define SUSFS_MAGIC 0xFAFAFAFA
+#endif
 #ifndef CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS
 #define CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS 0x55561
 #endif
@@ -51,7 +54,7 @@ def main() -> None:
 #endif
 
 """
-    if "CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS" not in text:
+    if "SUSFS_MAGIC" not in text:
         if text.count(final_guard) != 1:
             raise SystemExit("SUSFS definition final guard mismatch")
         susfs_def.write_text(text.replace(final_guard, command_compat + final_guard, 1))
@@ -148,6 +151,7 @@ void susfs_compat_show_version(void __user **user_info);
         compat_target: ["susfs_compat_show_version", "compat_call_legacy_kstat"],
         makefile: [compat_line.strip()],
         susfs_def: [
+            "SUSFS_MAGIC 0xFAFAFAFA",
             "CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS",
             "CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING",
         ],

--- a/scripts/55_apply_susfs_resukisu_compat.py
+++ b/scripts/55_apply_susfs_resukisu_compat.py
@@ -67,13 +67,110 @@ def main() -> None:
         "safe SUSFS mount visibility default",
     )
 
-    fdinfo = kernel / "fs/notify/fdinfo.c"
+    stat = kernel / "fs/stat.c"
     replace_once(
-        fdinfo,
-        "out_seq_printf:\n#endif",
-        "out_seq_printf:\n\t;\n#endif",
-        "SUSFS fdinfo label statement",
+        stat,
+        """#ifdef CONFIG_KSU
+extern int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags);
+extern void ksu_handle_newfstat_ret(unsigned int *fd, struct stat __user **statbuf_ptr);
+#if defined(__ARCH_WANT_STAT64) || defined(__ARCH_WANT_COMPAT_STAT64)
+extern void ksu_handle_fstat64_ret(unsigned long *fd, struct stat64 __user **statbuf_ptr);
+#endif
+#endif
+""",
+        """#ifdef CONFIG_KSU
+extern int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags);
+#endif
+#ifdef CONFIG_KSU_SUSFS
+extern void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr);
+#endif
+""",
+        "ReSukiSU SUSFS fstat declaration",
     )
+    replace_once(
+        stat,
+        """SYSCALL_DEFINE2(newfstat, unsigned int, fd, struct stat __user *, statbuf)
+{
+	struct kstat stat;
+	int error = vfs_fstat(fd, &stat);
+
+	if (!error)
+		error = cp_new_stat(&stat, statbuf);
+#ifdef CONFIG_KSU
+	if (!error)
+		ksu_handle_newfstat_ret(&fd, &statbuf);
+#endif
+
+	return error;
+}
+""",
+        """SYSCALL_DEFINE2(newfstat, unsigned int, fd, struct stat __user *, statbuf)
+{
+	struct kstat stat;
+	int error = vfs_fstat(fd, &stat);
+
+#ifdef CONFIG_KSU_SUSFS
+	if (!error)
+		ksu_handle_vfs_fstat((int)fd, &stat.size);
+#endif
+	if (!error)
+		error = cp_new_stat(&stat, statbuf);
+
+	return error;
+}
+""",
+        "ReSukiSU SUSFS newfstat hook",
+    )
+    replace_once(
+        stat,
+        """SYSCALL_DEFINE2(fstat64, unsigned long, fd, struct stat64 __user *, statbuf)
+{
+	struct kstat stat;
+	int error = vfs_fstat(fd, &stat);
+
+	if (!error)
+		error = cp_new_stat64(&stat, statbuf);
+#ifdef CONFIG_KSU
+	if (!error)
+		ksu_handle_fstat64_ret(&fd, &statbuf);
+#endif
+
+	return error;
+}
+""",
+        """SYSCALL_DEFINE2(fstat64, unsigned long, fd, struct stat64 __user *, statbuf)
+{
+	struct kstat stat;
+	int error = vfs_fstat(fd, &stat);
+
+#ifdef CONFIG_KSU_SUSFS
+	if (!error)
+		ksu_handle_vfs_fstat((int)fd, &stat.size);
+#endif
+	if (!error)
+		error = cp_new_stat64(&stat, statbuf);
+
+	return error;
+}
+""",
+        "ReSukiSU SUSFS fstat64 hook",
+    )
+
+    fdinfo = kernel / "fs/notify/fdinfo.c"
+    text = fdinfo.read_text()
+    newer_inotify_helper = "inotify_mark_user_mask(mark)"
+    if text.count(newer_inotify_helper) != 2:
+        raise SystemExit(
+            "SUSFS fdinfo inotify helper: expected two matches, "
+            f"found {text.count(newer_inotify_helper)}"
+        )
+    text = text.replace(newer_inotify_helper, "(mark->mask & IN_ALL_EVENTS)")
+    label = "out_seq_printf:\n#endif"
+    if text.count(label) != 1:
+        raise SystemExit(
+            f"SUSFS fdinfo label statement: expected one match, found {text.count(label)}"
+        )
+    fdinfo.write_text(text.replace(label, "out_seq_printf:\n\t;\n#endif", 1))
 
     dispatch = resukisu / "kernel/supercall/dispatch.c"
     text = dispatch.read_text()
@@ -156,7 +253,11 @@ void susfs_compat_show_version(void __user **user_info);
             "CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING",
         ],
         proc_namespace: ["susfs_hide_sus_mnts_for_all_procs = false;"],
-        fdinfo: ["out_seq_printf:\n\t;"],
+        stat: [
+            "extern void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr);",
+            "ksu_handle_vfs_fstat((int)fd, &stat.size);",
+        ],
+        fdinfo: ["out_seq_printf:\n\t;", "(mark->mask & IN_ALL_EVENTS)"],
         dispatch: [
             "susfs_compat_add_sus_kstat(arg, false);",
             "susfs_compat_add_sus_kstat(arg, true);",
@@ -168,6 +269,13 @@ void susfs_compat_show_version(void __user **user_info);
         for needle in needles:
             if needle not in content:
                 raise SystemExit(f"compatibility verification failed: {path}: {needle}")
+
+    stat_text = stat.read_text()
+    for forbidden in ("ksu_handle_newfstat_ret", "ksu_handle_fstat64_ret"):
+        if forbidden in stat_text:
+            raise SystemExit(f"obsolete manual-hook symbol remains in fs/stat.c: {forbidden}")
+    if "inotify_mark_user_mask" in fdinfo.read_text():
+        raise SystemExit("newer inotify helper remains in Linux 4.19 fdinfo.c")
 
 
 if __name__ == "__main__":

--- a/scripts/55_apply_susfs_resukisu_compat.py
+++ b/scripts/55_apply_susfs_resukisu_compat.py
@@ -14,59 +14,7 @@ def replace_once(path: Path, old: str, new: str, label: str) -> None:
     path.write_text(text.replace(old, new, 1))
 
 
-def main() -> None:
-    if len(sys.argv) != 4:
-        raise SystemExit(
-            "usage: 55_apply_susfs_resukisu_compat.py KERNEL_DIR RESUKISU_DIR COMPAT_C"
-        )
-
-    kernel = Path(sys.argv[1])
-    resukisu = Path(sys.argv[2])
-    compat_source = Path(sys.argv[3])
-
-    if not compat_source.is_file():
-        raise SystemExit(f"compatibility source missing: {compat_source}")
-
-    compat_target = kernel / "fs/susfs_resukisu_compat.c"
-    shutil.copyfile(compat_source, compat_target)
-
-    makefile = kernel / "fs/Makefile"
-    text = makefile.read_text()
-    anchor = "obj-$(CONFIG_KSU_SUSFS) += susfs.o\n"
-    compat_line = "obj-$(CONFIG_KSU_SUSFS) += susfs_resukisu_compat.o\n"
-    if compat_line not in text:
-        if text.count(anchor) != 1:
-            raise SystemExit("SUSFS fs/Makefile anchor mismatch")
-        makefile.write_text(text.replace(anchor, anchor + compat_line, 1))
-
-    susfs_def = kernel / "include/linux/susfs_def.h"
-    text = susfs_def.read_text()
-    final_guard = "#endif // #ifndef KSU_SUSFS_DEF_H\n"
-    command_compat = """
-#ifndef SUSFS_MAGIC
-#define SUSFS_MAGIC 0xFAFAFAFA
-#endif
-#ifndef CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS
-#define CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS 0x55561
-#endif
-#ifndef CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING
-#define CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING 0x60010
-#endif
-
-"""
-    if "SUSFS_MAGIC" not in text:
-        if text.count(final_guard) != 1:
-            raise SystemExit("SUSFS definition final guard mismatch")
-        susfs_def.write_text(text.replace(final_guard, command_compat + final_guard, 1))
-
-    proc_namespace = kernel / "fs/proc_namespace.c"
-    replace_once(
-        proc_namespace,
-        "bool susfs_hide_sus_mnts_for_all_procs = true;",
-        "bool susfs_hide_sus_mnts_for_all_procs = false;",
-        "safe SUSFS mount visibility default",
-    )
-
+def patch_host_fstat_hooks(kernel: Path) -> None:
     stat = kernel / "fs/stat.c"
     replace_once(
         stat,
@@ -156,13 +104,73 @@ extern void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr);
         "ReSukiSU SUSFS fstat64 hook",
     )
 
+    stat_text = stat.read_text()
+    required = (
+        "extern void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr);",
+        "ksu_handle_vfs_fstat((int)fd, &stat.size);",
+    )
+    for needle in required:
+        if needle not in stat_text:
+            raise SystemExit(f"SUSFS fstat finalization verification failed: {needle}")
+    if stat_text.count("ksu_handle_vfs_fstat((int)fd, &stat.size);") != 2:
+        raise SystemExit("SUSFS fstat finalization expected two syscall hooks")
+    for forbidden in ("ksu_handle_newfstat_ret", "ksu_handle_fstat64_ret"):
+        if forbidden in stat_text:
+            raise SystemExit(f"obsolete manual-hook symbol remains in fs/stat.c: {forbidden}")
+
+
+def apply_early_compat(kernel: Path, resukisu: Path, compat_source: Path) -> None:
+    if not compat_source.is_file():
+        raise SystemExit(f"compatibility source missing: {compat_source}")
+
+    compat_target = kernel / "fs/susfs_resukisu_compat.c"
+    shutil.copyfile(compat_source, compat_target)
+
+    makefile = kernel / "fs/Makefile"
+    text = makefile.read_text()
+    anchor = "obj-$(CONFIG_KSU_SUSFS) += susfs.o\n"
+    compat_line = "obj-$(CONFIG_KSU_SUSFS) += susfs_resukisu_compat.o\n"
+    if compat_line not in text:
+        if text.count(anchor) != 1:
+            raise SystemExit("SUSFS fs/Makefile anchor mismatch")
+        makefile.write_text(text.replace(anchor, anchor + compat_line, 1))
+
+    susfs_def = kernel / "include/linux/susfs_def.h"
+    text = susfs_def.read_text()
+    final_guard = "#endif // #ifndef KSU_SUSFS_DEF_H\n"
+    command_compat = """
+#ifndef SUSFS_MAGIC
+#define SUSFS_MAGIC 0xFAFAFAFA
+#endif
+#ifndef CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS
+#define CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS 0x55561
+#endif
+#ifndef CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING
+#define CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING 0x60010
+#endif
+
+"""
+    if "SUSFS_MAGIC" not in text:
+        if text.count(final_guard) != 1:
+            raise SystemExit("SUSFS definition final guard mismatch")
+        susfs_def.write_text(text.replace(final_guard, command_compat + final_guard, 1))
+
+    proc_namespace = kernel / "fs/proc_namespace.c"
+    replace_once(
+        proc_namespace,
+        "bool susfs_hide_sus_mnts_for_all_procs = true;",
+        "bool susfs_hide_sus_mnts_for_all_procs = false;",
+        "safe SUSFS mount visibility default",
+    )
+
     fdinfo = kernel / "fs/notify/fdinfo.c"
     text = fdinfo.read_text()
     newer_inotify_helper = "inotify_mark_user_mask(mark)"
-    if text.count(newer_inotify_helper) != 2:
+    helper_count = text.count(newer_inotify_helper)
+    if helper_count != 2:
         raise SystemExit(
             "SUSFS fdinfo inotify helper: expected two matches, "
-            f"found {text.count(newer_inotify_helper)}"
+            f"found {helper_count}"
         )
     text = text.replace(newer_inotify_helper, "(mark->mask & IN_ALL_EVENTS)")
     label = "out_seq_printf:\n#endif"
@@ -253,10 +261,6 @@ void susfs_compat_show_version(void __user **user_info);
             "CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING",
         ],
         proc_namespace: ["susfs_hide_sus_mnts_for_all_procs = false;"],
-        stat: [
-            "extern void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr);",
-            "ksu_handle_vfs_fstat((int)fd, &stat.size);",
-        ],
         fdinfo: ["out_seq_printf:\n\t;", "(mark->mask & IN_ALL_EVENTS)"],
         dispatch: [
             "susfs_compat_add_sus_kstat(arg, false);",
@@ -270,12 +274,21 @@ void susfs_compat_show_version(void __user **user_info);
             if needle not in content:
                 raise SystemExit(f"compatibility verification failed: {path}: {needle}")
 
-    stat_text = stat.read_text()
-    for forbidden in ("ksu_handle_newfstat_ret", "ksu_handle_fstat64_ret"):
-        if forbidden in stat_text:
-            raise SystemExit(f"obsolete manual-hook symbol remains in fs/stat.c: {forbidden}")
     if "inotify_mark_user_mask" in fdinfo.read_text():
         raise SystemExit("newer inotify helper remains in Linux 4.19 fdinfo.c")
+
+
+def main() -> None:
+    if len(sys.argv) == 3 and sys.argv[1] == "--finalize-host-hooks":
+        patch_host_fstat_hooks(Path(sys.argv[2]))
+        return
+    if len(sys.argv) == 4:
+        apply_early_compat(Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]))
+        return
+    raise SystemExit(
+        "usage: 55_apply_susfs_resukisu_compat.py KERNEL_DIR RESUKISU_DIR COMPAT_C\n"
+        "   or: 55_apply_susfs_resukisu_compat.py --finalize-host-hooks KERNEL_DIR"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/55_apply_susfs_resukisu_compat.py
+++ b/scripts/55_apply_susfs_resukisu_compat.py
@@ -167,9 +167,9 @@ def apply_early_compat(kernel: Path, resukisu: Path, compat_source: Path) -> Non
     text = fdinfo.read_text()
     newer_inotify_helper = "inotify_mark_user_mask(mark)"
     helper_count = text.count(newer_inotify_helper)
-    if helper_count != 2:
+    if helper_count not in (1, 2):
         raise SystemExit(
-            "SUSFS fdinfo inotify helper: expected two matches, "
+            "SUSFS fdinfo inotify helper: expected one or two matches, "
             f"found {helper_count}"
         )
     text = text.replace(newer_inotify_helper, "(mark->mask & IN_ALL_EVENTS)")

--- a/scripts/55_apply_susfs_resukisu_compat.py
+++ b/scripts/55_apply_susfs_resukisu_compat.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+
+def replace_once(path: Path, old: str, new: str, label: str) -> None:
+    text = path.read_text()
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    path.write_text(text.replace(old, new, 1))
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        raise SystemExit(
+            "usage: 55_apply_susfs_resukisu_compat.py KERNEL_DIR RESUKISU_DIR COMPAT_C"
+        )
+
+    kernel = Path(sys.argv[1])
+    resukisu = Path(sys.argv[2])
+    compat_source = Path(sys.argv[3])
+
+    if not compat_source.is_file():
+        raise SystemExit(f"compatibility source missing: {compat_source}")
+
+    compat_target = kernel / "fs/susfs_resukisu_compat.c"
+    shutil.copyfile(compat_source, compat_target)
+
+    makefile = kernel / "fs/Makefile"
+    text = makefile.read_text()
+    anchor = "obj-$(CONFIG_KSU_SUSFS) += susfs.o\n"
+    compat_line = "obj-$(CONFIG_KSU_SUSFS) += susfs_resukisu_compat.o\n"
+    if compat_line not in text:
+        if text.count(anchor) != 1:
+            raise SystemExit("SUSFS fs/Makefile anchor mismatch")
+        makefile.write_text(text.replace(anchor, anchor + compat_line, 1))
+
+    susfs_def = kernel / "include/linux/susfs_def.h"
+    text = susfs_def.read_text()
+    final_guard = "#endif // #ifndef KSU_SUSFS_DEF_H\n"
+    command_compat = """
+#ifndef CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS
+#define CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS 0x55561
+#endif
+#ifndef CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING
+#define CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING 0x60010
+#endif
+
+"""
+    if "CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS" not in text:
+        if text.count(final_guard) != 1:
+            raise SystemExit("SUSFS definition final guard mismatch")
+        susfs_def.write_text(text.replace(final_guard, command_compat + final_guard, 1))
+
+    proc_namespace = kernel / "fs/proc_namespace.c"
+    replace_once(
+        proc_namespace,
+        "bool susfs_hide_sus_mnts_for_all_procs = true;",
+        "bool susfs_hide_sus_mnts_for_all_procs = false;",
+        "safe SUSFS mount visibility default",
+    )
+
+    fdinfo = kernel / "fs/notify/fdinfo.c"
+    replace_once(
+        fdinfo,
+        "out_seq_printf:\n#endif",
+        "out_seq_printf:\n\t;\n#endif",
+        "SUSFS fdinfo label statement",
+    )
+
+    dispatch = resukisu / "kernel/supercall/dispatch.c"
+    text = dispatch.read_text()
+    include_anchor = "#include <linux/susfs_def.h>\n"
+    declarations = """#include <linux/susfs_def.h>
+void susfs_compat_set_hide_sus_mnts_for_non_su_procs(void __user **user_info);
+void susfs_compat_add_sus_kstat(void __user **user_info, bool statically);
+void susfs_compat_update_sus_kstat(void __user **user_info);
+void susfs_compat_set_uname(void __user **user_info);
+void susfs_compat_set_avc_log_spoofing(void __user **user_info);
+void susfs_compat_get_enabled_features(void __user **user_info);
+void susfs_compat_show_variant(void __user **user_info);
+void susfs_compat_show_version(void __user **user_info);
+"""
+    if "susfs_compat_show_version" not in text:
+        if text.count(include_anchor) != 1:
+            raise SystemExit("ReSukiSU SUSFS include anchor mismatch")
+        text = text.replace(include_anchor, declarations, 1)
+
+    replacements = [
+        (
+            "        susfs_set_hide_sus_mnts_for_non_su_procs(arg);",
+            "        susfs_compat_set_hide_sus_mnts_for_non_su_procs(arg);",
+            "mount policy command",
+        ),
+        (
+            "    case CMD_SUSFS_ADD_SUS_KSTAT: {\n        susfs_add_sus_kstat(arg);",
+            "    case CMD_SUSFS_ADD_SUS_KSTAT: {\n        susfs_compat_add_sus_kstat(arg, false);",
+            "add kstat command",
+        ),
+        (
+            "        susfs_update_sus_kstat(arg);",
+            "        susfs_compat_update_sus_kstat(arg);",
+            "update kstat command",
+        ),
+        (
+            "    case CMD_SUSFS_ADD_SUS_KSTAT_STATICALLY: {\n        susfs_add_sus_kstat(arg);",
+            "    case CMD_SUSFS_ADD_SUS_KSTAT_STATICALLY: {\n        susfs_compat_add_sus_kstat(arg, true);",
+            "static kstat command",
+        ),
+        (
+            "        susfs_set_uname(arg);",
+            "        susfs_compat_set_uname(arg);",
+            "uname command",
+        ),
+        (
+            "        susfs_set_avc_log_spoofing(arg);",
+            "        susfs_compat_set_avc_log_spoofing(arg);",
+            "AVC policy command",
+        ),
+        (
+            "        susfs_get_enabled_features(arg);",
+            "        susfs_compat_get_enabled_features(arg);",
+            "feature query command",
+        ),
+        (
+            "        susfs_show_variant(arg);",
+            "        susfs_compat_show_variant(arg);",
+            "variant query command",
+        ),
+        (
+            "        susfs_show_version(arg);",
+            "        susfs_compat_show_version(arg);",
+            "version query command",
+        ),
+    ]
+    for old, new, label in replacements:
+        count = text.count(old)
+        if count != 1:
+            raise SystemExit(f"ReSukiSU {label}: expected one match, found {count}")
+        text = text.replace(old, new, 1)
+    dispatch.write_text(text)
+
+    checks = {
+        compat_target: ["susfs_compat_show_version", "compat_call_legacy_kstat"],
+        makefile: [compat_line.strip()],
+        susfs_def: [
+            "CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS",
+            "CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING",
+        ],
+        proc_namespace: ["susfs_hide_sus_mnts_for_all_procs = false;"],
+        fdinfo: ["out_seq_printf:\n\t;"],
+        dispatch: [
+            "susfs_compat_add_sus_kstat(arg, false);",
+            "susfs_compat_add_sus_kstat(arg, true);",
+            "susfs_compat_show_version(arg);",
+        ],
+    }
+    for path, needles in checks.items():
+        content = path.read_text()
+        for needle in needles:
+            if needle not in content:
+                raise SystemExit(f"compatibility verification failed: {path}: {needle}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
+++ b/scripts/55_build_a52_linux_4.19.206_resukisu_susfs_inline.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+source "$SCRIPT_DIR/common.sh"
+
+TARGET_VERSION=4.19.206
+SUSFS_BRANCH=kernel-4.19
+SUSFS_EXPECTED_VERSION=v1.5.9
+LABEL="touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.5.9-safe"
+IMAGE="$ARTIFACTS_DIR/Image-$LABEL"
+CONFIG="$ARTIFACTS_DIR/config-$LABEL"
+STRINGS="$ARTIFACTS_DIR/Image-$LABEL.strings.txt"
+BOOT_OUT="$ARTIFACTS_DIR/a52xq-linux-4.19.206-resukisu-susfs-v1.5.9-inline-boot"
+
+mkdir -p "$ARTIFACTS_DIR" "$BOOT_OUT" intake
+chmod +x scripts/*.sh scripts/*.py
+
+info "Preparing exact touchGrass source through Linux 4.19.200"
+./scripts/01_prepare_source.sh
+./scripts/03_apply_linux_4.19.153.sh
+./scripts/04_apply_linux_4.19.154.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+./scripts/checkpoint_resolve_linux_4.19.159.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+./scripts/checkpoint_resolve_linux_4.19.164.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+./scripts/checkpoint_resolve_linux_4.19.180.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+./scripts/checkpoint_resolve_linux_4.19.200.sh
+test "$(kernel_version)" = 4.19.200 || fail "Expected Linux 4.19.200 before the final merge"
+
+info "Applying official Linux 4.19.206 merge"
+cp scripts/checkpoint_merge_linux_4.19.210.sh scripts/checkpoint_merge_linux_4.19.206.generated.sh
+sed -i \
+  -e 's/TO_TAG=v4.19.210/TO_TAG=v4.19.206/' \
+  -e '/^TARGET_COMMIT=/d' \
+  -e '/test "$to_sha" = "$TARGET_COMMIT"/d' \
+  scripts/checkpoint_merge_linux_4.19.206.generated.sh
+chmod +x scripts/checkpoint_merge_linux_4.19.206.generated.sh
+./scripts/checkpoint_merge_linux_4.19.206.generated.sh
+test "$(kernel_version)" = "$TARGET_VERSION" || fail "Linux 4.19.206 merge did not complete"
+
+info "Applying reviewed Linux 4.19.206 merge-shape repairs"
+cp scripts/checkpoint_fix_linux_4.19.210_compile.sh scripts/checkpoint_fix_linux_4.19.206.generated.sh
+sed -i 's/TARGET_VERSION=4.19.210/TARGET_VERSION=4.19.206/' \
+  scripts/checkpoint_fix_linux_4.19.206.generated.sh
+chmod +x scripts/checkpoint_fix_linux_4.19.206.generated.sh
+./scripts/checkpoint_fix_linux_4.19.206.generated.sh
+
+python3 - "$KERNEL_DIR" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+header = (root / 'include/linux/timerqueue.h').read_text()
+path = root / 'drivers/soc/qcom/event_timer.c'
+text = path.read_text()
+newer = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+\t.rb_root = RB_ROOT_CACHED,
+};
+'''
+older = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+\t.head = RB_ROOT,
+\t.next = NULL,
+};
+'''
+wants_newer = 'struct rb_root_cached rb_root;' in header
+desired = newer if wants_newer else older
+obsolete = older if wants_newer else newer
+if desired not in text:
+    if obsolete not in text:
+        raise SystemExit('event_timer initializer shape is unrecognized')
+    path.write_text(text.replace(obsolete, desired, 1))
+
+path = root / 'kernel/sched/cpufreq_schedutil.c'
+text = path.read_text()
+call = 'sugov_clear_global_tunables();'
+definition = 'static void sugov_clear_global_tunables(void)'
+anchor = 'static void sugov_exit('
+if call in text and definition not in text:
+    if anchor not in text:
+        raise SystemExit('schedutil exit anchor missing')
+    helper = '''static void sugov_clear_global_tunables(void)
+{
+\tif (!have_governor_per_policy())
+\t\tglobal_tunables = NULL;
+}
+
+'''
+    path.write_text(text.replace(anchor, helper + anchor, 1))
+elif call not in text:
+    raise SystemExit('schedutil cleanup call missing after generic repair')
+PY
+
+info "Restoring the working A52 hardware and STM FTS touchscreen configuration"
+DEFCONFIG="$KERNEL_DIR/arch/arm64/configs/a52xq_defconfig"
+"$KERNEL_DIR/scripts/config" --file "$DEFCONFIG" \
+  -e TOUCHSCREEN_STM_FTS5CU56A \
+  -e PRINTK -e PRINTK_TIME -e IKCONFIG -e IKCONFIG_PROC \
+  -e DEBUG_KERNEL -e FRAME_POINTER -e PANIC_ON_OOPS \
+  -e PSTORE -e PSTORE_RAM -e PSTORE_CONSOLE -e PSTORE_PMSG \
+  -e SERIAL_MSM_GENI -e SERIAL_MSM_GENI_CONSOLE \
+  -e ARCH_QCOM -e ARCH_LAGOON \
+  -e QCOM_SCM -e QCOM_RPMH -e QCOM_SMEM -e QCOM_SMP2P \
+  -e QCOM_COMMAND_DB -e COMMON_CLK_QCOM -e SDM_GCC_LAGOON \
+  -e PINCTRL -e PINCTRL_MSM -e PINCTRL_LAGOON \
+  -e REGULATOR -e REGULATOR_QCOM_RPMH \
+  -e IOMMU_SUPPORT -e ARM_SMMU -e QTI_IOMMU_SUPPORT \
+  -e SCSI -e SCSI_UFSHCD -e SCSI_UFSHCD_PLATFORM -e SCSI_UFS_QCOM \
+  -e PHY_QCOM_UFS \
+  -e BLK_DEV_INITRD -e DEVTMPFS -e DEVTMPFS_MOUNT \
+  -e EXT4_FS -e F2FS_FS -e FS_ENCRYPTION \
+  -e SECURITY -e SECURITY_SELINUX -e ANDROID_BINDER_IPC \
+  -e INPUT -e INPUT_TOUCHSCREEN -e INPUT_MISC -e INPUT_QPNP_POWER_ON \
+  -e DRM -e QCOM_KGSL -e QCOM_KGSL_IOMMU \
+  -e MEDIA_SUPPORT -e SOUND -e SND \
+  -e WLAN -e CFG80211 -e MAC80211 -e BT
+"$KERNEL_DIR/scripts/config" --file "$DEFCONFIG" --set-val PANIC_TIMEOUT 10
+
+info "Replacing obsolete touchGrass exec dispatch"
+./scripts/07_patch_resukisu_exec_hook.sh
+
+info "Adapting the ReSukiSU SUSFS wrapper to the maintained Linux 4.19 branch"
+python3 - scripts/08_build_resukisu_safe_checkpoint.sh <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+
+old_clone = r'''info "Integrating pinned SUSFS kernel 4.19 patch"
+SUSFS_DIR="$KERNEL_DIR/../susfs4ksu-$SUSFS_VERSION"
+rm -rf "$SUSFS_DIR"
+git init -q "$SUSFS_DIR"
+git -C "$SUSFS_DIR" remote add origin "$SUSFS_REPO"
+git -C "$SUSFS_DIR" fetch --quiet --depth=1 origin "refs/tags/$SUSFS_TAG"
+git -C "$SUSFS_DIR" checkout --quiet --detach FETCH_HEAD
+cp "$SUSFS_DIR/kernel_patches/fs/susfs.c" "$KERNEL_DIR/fs/susfs.c"
+cp "$SUSFS_DIR/kernel_patches/include/linux/susfs.h" "$KERNEL_DIR/include/linux/susfs.h"
+patch -d "$KERNEL_DIR" -p1 --forward --batch --fuzz=3 < "$SUSFS_DIR/kernel_patches/50_add_susfs_in_kernel-4.19.patch"
+sed -i 's/[[:space:]]\+$//' "$KERNEL_DIR/fs/namespace.c" "$KERNEL_DIR/fs/overlayfs/readdir.c"
+'''
+new_clone = r'''info "Integrating maintained SUSFS v1.5.9 Linux 4.19 patch"
+SUSFS_DIR="$KERNEL_DIR/../susfs4ksu-kernel-4.19"
+rm -rf "$SUSFS_DIR"
+git init -q "$SUSFS_DIR"
+git -C "$SUSFS_DIR" remote add origin "$SUSFS_REPO"
+git -C "$SUSFS_DIR" fetch --quiet --depth=1 origin "refs/heads/kernel-4.19"
+git -C "$SUSFS_DIR" checkout --quiet --detach FETCH_HEAD
+SUSFS_COMMIT="$(git -C "$SUSFS_DIR" rev-parse HEAD)"
+cp "$SUSFS_DIR/kernel_patches/fs/susfs.c" "$KERNEL_DIR/fs/susfs.c"
+cp "$SUSFS_DIR/kernel_patches/include/linux/susfs.h" "$KERNEL_DIR/include/linux/susfs.h"
+cp "$SUSFS_DIR/kernel_patches/include/linux/susfs_def.h" "$KERNEL_DIR/include/linux/susfs_def.h"
+grep -Fq '#define SUSFS_VERSION "v1.5.9"' "$KERNEL_DIR/include/linux/susfs.h" || fail "Unexpected SUSFS branch version"
+patch -d "$KERNEL_DIR" -p1 --forward --batch --fuzz=3 < "$SUSFS_DIR/kernel_patches/50_add_susfs_in_kernel-4.19.patch"
+sed -i 's/[[:space:]]\+$//' "$KERNEL_DIR/fs/namespace.c" "$KERNEL_DIR/fs/overlayfs/readdir.c"
+python3 - "$KERNEL_DIR/include/linux/susfs_def.h" "$RESUKISU_DIR/kernel/feature/kernel_umount.c" <<'SUSFSCOMPATPY'
+from pathlib import Path
+import sys
+
+header = Path(sys.argv[1])
+text = header.read_text()
+anchor = '#endif // #ifndef KSU_SUSFS_DEF_H\n'
+compat = r'''
+
+/* ReSukiSU compatibility names for the maintained 4.19 SUSFS state bit. */
+static inline bool susfs_is_current_proc_umounted(void)
+{
+    return susfs_is_current_non_root_user_app_proc();
+}
+
+static inline void susfs_set_current_proc_umounted(void)
+{
+    susfs_set_current_non_root_user_app_proc();
+}
+
+/* SUS_PATH is disabled in this conservative build, so no monitor is needed. */
+static inline void susfs_start_sdcard_monitor_fn(void)
+{
+}
+
+'''
+if 'susfs_is_current_proc_umounted' not in text:
+    if text.count(anchor) != 1:
+        raise SystemExit('susfs_def.h final guard anchor mismatch')
+    header.write_text(text.replace(anchor, compat + anchor, 1))
+
+umount = Path(sys.argv[2])
+text = umount.read_text()
+line = '    schedule_work(&susfs_extra_works);\n'
+if text.count(line) != 1:
+    raise SystemExit('ReSukiSU susfs_extra_works anchor mismatch')
+umount.write_text(text.replace(line, '', 1))
+SUSFSCOMPATPY
+'''
+if text.count(old_clone) != 1:
+    raise SystemExit('old SUSFS clone block mismatch')
+text = text.replace(old_clone, new_clone, 1)
+
+text, count = re.subn(
+    r'''python3 - "\$KERNEL_DIR/include/linux/sched/user\.h" <<'USERPY'\n.*?\nUSERPY\n''',
+    '',
+    text,
+    count=1,
+    flags=re.S,
+)
+if count != 1:
+    raise SystemExit('legacy SUSFS user_struct compatibility block mismatch')
+text = text.replace(
+    '''grep -Fq 'unsigned long android_kabi_reserved1;' "$KERNEL_DIR/include/linux/sched/user.h" || \\
+  fail "SUSFS user state field is missing"\n''',
+    '',
+    1,
+)
+
+old_config = '''    new_config = ('  -e KSU_MULTI_MANAGER_SUPPORT -d KSU_TRACEPOINT_HOOK -d KSU_MANUAL_HOOK \\\n'
+                  '  -e KSU_SUSFS -d KSU_MANUAL_HOOK_AUTO_SETUID_HOOK \\\n'
+                  '  -d KSU_MANUAL_HOOK_AUTO_INITRC_HOOK -d KSU_MANUAL_HOOK_AUTO_INPUT_HOOK')'''
+new_config = '''    new_config = ('  -e KSU_MULTI_MANAGER_SUPPORT -d KSU_TRACEPOINT_HOOK -d KSU_MANUAL_HOOK \\\n'
+                  '  -e KSU_SUSFS -d KSU_MANUAL_HOOK_AUTO_SETUID_HOOK \\\n'
+                  '  -d KSU_MANUAL_HOOK_AUTO_INITRC_HOOK -d KSU_MANUAL_HOOK_AUTO_INPUT_HOOK \\\n'
+                  '  -d KSU_SUSFS_SUS_PATH -e KSU_SUSFS_SUS_MOUNT -e KSU_SUSFS_SUS_KSTAT \\\n'
+                  '  -e KSU_SUSFS_SPOOF_UNAME -d KSU_SUSFS_ENABLE_LOG \\\n'
+                  '  -d KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS -d KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG \\\n'
+                  '  -d KSU_SUSFS_OPEN_REDIRECT -d KSU_SUSFS_SUS_MAP')'''
+if text.count(old_config) != 1:
+    raise SystemExit('safe SUSFS config block mismatch')
+text = text.replace(old_config, new_config, 1)
+
+text = text.replace('v1.4.2', 'v1.5.9')
+text = text.replace(
+    '''  printf 'susfs_version=%s\\n' "$SUSFS_VERSION"''',
+    '''  printf 'susfs_version=%s\\n' "v1.5.9-kernel-4.19"\n  printf 'susfs_commit=%s\\n' "$SUSFS_COMMIT"''',
+    1,
+)
+path.write_text(text)
+PY
+
+info "Building Linux 4.19.206 with ReSukiSU and SUSFS inline hooks"
+set -o pipefail
+./scripts/08_build_resukisu_safe_checkpoint.sh "$TARGET_VERSION" susfs \
+  2>&1 | tee "$ARTIFACTS_DIR/linux-4.19.206-resukisu-susfs-inline.log"
+
+test -s "$IMAGE" || fail "Rooted kernel image is missing"
+test -s "$CONFIG" || fail "Rooted kernel configuration is missing"
+test -s "$STRINGS" || fail "Kernel strings audit is missing"
+
+info "Enforcing root, inline-hook, hardware, and safety invariants"
+grep -Fxq 'CONFIG_KSU=y' "$CONFIG"
+grep -Fxq 'CONFIG_KSU_SUSFS=y' "$CONFIG"
+grep -Fxq 'CONFIG_KSU_MULTI_MANAGER_SUPPORT=y' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_MANUAL_HOOK is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_TRACEPOINT_HOOK is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KPROBES is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_SUSFS_SUS_PATH is not set' "$CONFIG"
+grep -Fxq 'CONFIG_KSU_SUSFS_SUS_MOUNT=y' "$CONFIG"
+grep -Fxq 'CONFIG_KSU_SUSFS_SUS_KSTAT=y' "$CONFIG"
+grep -Fxq 'CONFIG_KSU_SUSFS_SPOOF_UNAME=y' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_SUSFS_ENABLE_LOG is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_SUSFS_OPEN_REDIRECT is not set' "$CONFIG"
+grep -Fxq '# CONFIG_KSU_SUSFS_SUS_MAP is not set' "$CONFIG"
+grep -Fxq 'CONFIG_TOUCHSCREEN_STM_FTS5CU56A=y' "$CONFIG"
+grep -Fxq 'CONFIG_ARCH_LAGOON=y' "$CONFIG"
+grep -Fxq 'CONFIG_SCSI_UFS_QCOM=y' "$CONFIG"
+grep -Fxq 'CONFIG_QCOM_KGSL=y' "$CONFIG"
+grep -Fq 'ksu_handle_sys_read(fd, &buf, &count);' "$KERNEL_DIR/fs/read_write.c"
+grep -Fq 'ksu_handle_input_handle_event(&type, &code, &value);' "$KERNEL_DIR/drivers/input/input.c"
+grep -Fq 'ksu_handle_setresuid(ruid, euid, suid);' "$KERNEL_DIR/kernel/sys.c"
+grep -Fq 'static bool ksu_kernel_umount_enabled = false;' "$KERNEL_DIR/KernelSU/kernel/feature/kernel_umount.c"
+grep -Fq 'default_non_root_profile.umount_modules = false;' "$KERNEL_DIR/KernelSU/kernel/policy/allowlist.c"
+grep -Fxq 'v4.1.0-2206a7dd-dirty@ReSukiSU' "$STRINGS"
+
+SUSFS_COMMIT="$(git -C "$KERNEL_DIR/../susfs4ksu-kernel-4.19" rev-parse HEAD)"
+{
+  echo 'status=build-passed'
+  echo 'hardware_validated=no'
+  echo 'kernel_version=4.19.206-touchGrassKernel+'
+  echo 'resukisu=v4.1.0-2206a7dd'
+  echo 'susfs=v1.5.9-kernel-4.19'
+  echo "susfs_commit=$SUSFS_COMMIT"
+  echo 'hook_mode=susfs-inline'
+  echo 'manual_hook=off'
+  echo 'tracepoint_hook=off'
+  echo 'kernel_unmount_default=off'
+  echo 'module_unmount_default=off'
+  echo 'sus_path=off'
+  echo 'sus_mount=on'
+  echo 'sus_kstat=on'
+  echo 'spoof_uname=on'
+  echo 'automatic_unmount=off'
+  echo 'open_redirect=off'
+  echo 'cmdline_spoof=off'
+  echo 'symbol_hiding=off'
+  echo 'touchscreen=stm-fts-enabled'
+  echo "image_sha256=$(sha256sum "$IMAGE" | awk '{print $1}')"
+} | tee "$ARTIFACTS_DIR/linux-4.19.206-resukisu-susfs-inline-metadata.txt"
+
+info "Downloading and validating the checksum-locked original boot image"
+: "${GH_TOKEN:?GH_TOKEN is required for boot image download}"
+ASSET_LINE="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=30" \
+  --jq '.[] | .assets[] | select(.name | endswith(".img")) | [.id, .name, .created_at] | @tsv' | head -n 1)"
+test -n "$ASSET_LINE" || fail "No boot image release asset was found"
+IFS=$'\t' read -r ASSET_ID ASSET_NAME ASSET_CREATED <<< "$ASSET_LINE"
+curl --fail --location --retry 3 --silent --show-error \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H 'Accept: application/octet-stream' \
+  "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" \
+  --output intake/boot.img
+python3 scripts/37_validate_a52_p1_boot_source.py intake/boot.img \
+  --lock projects/a52-p1-boot-image/boot-source.lock \
+  --output "$BOOT_OUT/source-validation.json"
+printf 'source_asset=%s\nsource_created=%s\n' "$ASSET_NAME" "$ASSET_CREATED" \
+  > "$BOOT_OUT/source-asset.txt"
+
+info "Repacking and auditing the experimental rooted boot image"
+gzip -n -9 -c "$IMAGE" > "$BOOT_OUT/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source intake/boot.img \
+  --kernel "$BOOT_OUT/Image.gz" \
+  --output "$BOOT_OUT/boot.img" \
+  --report "$BOOT_OUT/repack-report.json"
+cp "$CONFIG" "$BOOT_OUT/final.config"
+cp "$ARTIFACTS_DIR/linux-4.19.206-resukisu-susfs-inline-metadata.txt" "$BOOT_OUT/metadata.txt"
+cat > "$BOOT_OUT/NOTICE.txt" <<'NOTICE'
+EXPERIMENTAL A52XQ LINUX 4.19.206 ROOTED BOOT IMAGE
+
+ReSukiSU v4.1.0 and maintained SUSFS v1.5.9 for Linux 4.19 are enabled.
+Hook mode: SUSFS inline hook. ReSukiSU manual and tracepoint hooks are disabled.
+The STM FTS touchscreen and the working A52 hardware configuration are retained.
+Kernel and module unmount defaults are disabled.
+
+For the first hardware test, SUS path hiding, automatic unmounting, open redirect,
+command-line spoofing, symbol hiding, SUS map, and SUS-SU are disabled. SUS mount
+hiding, kstat spoofing, and uname spoofing remain enabled.
+
+This build passed compilation and repack audits only. It has not been validated on
+physical hardware. Back up boot and data before testing, and keep the known-working
+4.19.206 boot image available for immediate rollback.
+NOTICE
+(
+  cd "$BOOT_OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)
+
+info "Linux 4.19.206 ReSukiSU plus SUSFS inline build and repack passed"

--- a/scripts/55_susfs_resukisu_compat.c
+++ b/scripts/55_susfs_resukisu_compat.c
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Compatibility bridge between ReSukiSU v4.1.0's current SUSFS command ABI
+ * and the maintained SUSFS v1.5.9 implementation for Linux 4.19.
+ *
+ * Keep this bridge deliberately narrow. It translates only the conservative
+ * feature set selected by the A52 build: mount hiding, kstat spoofing, uname
+ * spoofing, and version/feature reporting. Unsupported commands report
+ * -EOPNOTSUPP instead of silently claiming success.
+ */
+
+#include <linux/errno.h>
+#include <linux/fs.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/string.h>
+#include <linux/susfs.h>
+#include <linux/types.h>
+#include <linux/uaccess.h>
+
+#define RESUKISU_SUSFS_FEATURES_SIZE 8192
+#define RESUKISU_SUSFS_TEXT_SIZE 16
+
+struct resukisu_susfs_mount_policy {
+	bool enabled;
+	int err;
+};
+
+struct resukisu_susfs_kstat {
+	int is_statically;
+	unsigned long target_ino;
+	char target_pathname[SUSFS_MAX_LEN_PATHNAME];
+	unsigned long spoofed_ino;
+	unsigned long spoofed_dev;
+	unsigned int spoofed_nlink;
+	long long spoofed_size;
+	long spoofed_atime_tv_sec;
+	unsigned long spoofed_atime_tv_nsec;
+	long spoofed_mtime_tv_sec;
+	unsigned long spoofed_mtime_tv_nsec;
+	long spoofed_ctime_tv_sec;
+	unsigned long spoofed_ctime_tv_nsec;
+	long long spoofed_blocks;
+	long spoofed_blksize;
+	int flags;
+	int err;
+};
+
+struct resukisu_susfs_uname {
+	char release[__NEW_UTS_LEN + 1];
+	char version[__NEW_UTS_LEN + 1];
+	int err;
+};
+
+struct resukisu_susfs_avc_policy {
+	bool enabled;
+	int err;
+};
+
+struct resukisu_susfs_features {
+	char enabled_features[RESUKISU_SUSFS_FEATURES_SIZE];
+	int err;
+};
+
+struct resukisu_susfs_text_result {
+	char text[RESUKISU_SUSFS_TEXT_SIZE];
+	int err;
+};
+
+extern bool susfs_hide_sus_mnts_for_all_procs;
+
+static int compat_copy_err(void __user *field, int err)
+{
+	if (copy_to_user(field, &err, sizeof(err)))
+		return -EFAULT;
+	return err;
+}
+
+static int compat_call_legacy_kstat(struct st_susfs_sus_kstat *legacy,
+				    bool update)
+{
+	mm_segment_t old_fs;
+	int ret;
+
+	old_fs = get_fs();
+	set_fs(KERNEL_DS);
+	if (update)
+		ret = susfs_update_sus_kstat((struct st_susfs_sus_kstat __user *)legacy);
+	else
+		ret = susfs_add_sus_kstat((struct st_susfs_sus_kstat __user *)legacy);
+	set_fs(old_fs);
+
+	return ret;
+}
+
+void susfs_compat_set_hide_sus_mnts_for_non_su_procs(void __user **user_info)
+{
+	struct resukisu_susfs_mount_policy info = { 0 };
+
+	if (!user_info || !*user_info ||
+	    copy_from_user(&info, (void __user *)*user_info, sizeof(info))) {
+		info.err = -EFAULT;
+		goto out;
+	}
+
+	/*
+	 * The old 4.19 implementation has a stronger "hide for all" switch.
+	 * Keep that switch disabled so suspicious mounts remain visible to the
+	 * KernelSU domain and hidden from ordinary processes. This matches the
+	 * safe non-su policy, but does not expose a runtime disable operation.
+	 */
+	WRITE_ONCE(susfs_hide_sus_mnts_for_all_procs, false);
+	info.err = info.enabled ? 0 : -EOPNOTSUPP;
+
+out:
+	if (user_info && *user_info)
+		compat_copy_err(&((struct resukisu_susfs_mount_policy __user *)*user_info)->err,
+				info.err);
+}
+
+void susfs_compat_add_sus_kstat(void __user **user_info, bool statically)
+{
+	struct resukisu_susfs_kstat info = { 0 };
+	struct st_susfs_sus_kstat legacy = { 0 };
+	int ret;
+
+	if (!user_info || !*user_info ||
+	    copy_from_user(&info, (void __user *)*user_info, sizeof(info))) {
+		info.err = -EFAULT;
+		goto out;
+	}
+
+	legacy.is_statically = statically || info.is_statically;
+	legacy.target_ino = info.target_ino;
+	strncpy(legacy.target_pathname, info.target_pathname,
+		SUSFS_MAX_LEN_PATHNAME - 1);
+	legacy.spoofed_ino = info.spoofed_ino;
+	legacy.spoofed_dev = info.spoofed_dev;
+	legacy.spoofed_nlink = info.spoofed_nlink;
+	legacy.spoofed_size = info.spoofed_size;
+	legacy.spoofed_atime_tv_sec = info.spoofed_atime_tv_sec;
+	legacy.spoofed_atime_tv_nsec = (long)info.spoofed_atime_tv_nsec;
+	legacy.spoofed_mtime_tv_sec = info.spoofed_mtime_tv_sec;
+	legacy.spoofed_mtime_tv_nsec = (long)info.spoofed_mtime_tv_nsec;
+	legacy.spoofed_ctime_tv_sec = info.spoofed_ctime_tv_sec;
+	legacy.spoofed_ctime_tv_nsec = (long)info.spoofed_ctime_tv_nsec;
+	legacy.spoofed_blksize = (unsigned long)info.spoofed_blksize;
+	legacy.spoofed_blocks = (unsigned long long)info.spoofed_blocks;
+
+	ret = compat_call_legacy_kstat(&legacy, false);
+	info.err = ret ? -EINVAL : 0;
+
+out:
+	if (user_info && *user_info)
+		compat_copy_err(&((struct resukisu_susfs_kstat __user *)*user_info)->err,
+				info.err);
+}
+
+void susfs_compat_update_sus_kstat(void __user **user_info)
+{
+	struct resukisu_susfs_kstat info = { 0 };
+	struct st_susfs_sus_kstat legacy = { 0 };
+	int ret;
+
+	if (!user_info || !*user_info ||
+	    copy_from_user(&info, (void __user *)*user_info, sizeof(info))) {
+		info.err = -EFAULT;
+		goto out;
+	}
+
+	legacy.is_statically = info.is_statically;
+	legacy.target_ino = info.target_ino;
+	strncpy(legacy.target_pathname, info.target_pathname,
+		SUSFS_MAX_LEN_PATHNAME - 1);
+	legacy.spoofed_size = info.spoofed_size;
+	legacy.spoofed_blocks = (unsigned long long)info.spoofed_blocks;
+
+	ret = compat_call_legacy_kstat(&legacy, true);
+	info.err = ret ? -ENOENT : 0;
+
+out:
+	if (user_info && *user_info)
+		compat_copy_err(&((struct resukisu_susfs_kstat __user *)*user_info)->err,
+				info.err);
+}
+
+void susfs_compat_set_uname(void __user **user_info)
+{
+	struct resukisu_susfs_uname info = { 0 };
+	struct st_susfs_uname legacy = { 0 };
+	mm_segment_t old_fs;
+	int ret;
+
+	if (!user_info || !*user_info ||
+	    copy_from_user(&info, (void __user *)*user_info, sizeof(info))) {
+		info.err = -EFAULT;
+		goto out;
+	}
+
+	strncpy(legacy.release, info.release, __NEW_UTS_LEN);
+	strncpy(legacy.version, info.version, __NEW_UTS_LEN);
+
+	old_fs = get_fs();
+	set_fs(KERNEL_DS);
+	ret = susfs_set_uname((struct st_susfs_uname __user *)&legacy);
+	set_fs(old_fs);
+	info.err = ret ? -EINVAL : 0;
+
+out:
+	if (user_info && *user_info)
+		compat_copy_err(&((struct resukisu_susfs_uname __user *)*user_info)->err,
+				info.err);
+}
+
+void susfs_compat_set_avc_log_spoofing(void __user **user_info)
+{
+	struct resukisu_susfs_avc_policy info = { 0 };
+
+	if (!user_info || !*user_info ||
+	    copy_from_user(&info, (void __user *)*user_info, sizeof(info)))
+		info.err = -EFAULT;
+	else
+		info.err = -EOPNOTSUPP;
+
+	if (user_info && *user_info)
+		compat_copy_err(&((struct resukisu_susfs_avc_policy __user *)*user_info)->err,
+				info.err);
+}
+
+static void compat_append_feature(char *buf, size_t size, size_t *used,
+				  const char *feature)
+{
+	if (*used >= size)
+		return;
+	*used += scnprintf(buf + *used, size - *used, "%s\n", feature);
+}
+
+void susfs_compat_get_enabled_features(void __user **user_info)
+{
+	struct resukisu_susfs_features *info;
+	size_t used = 0;
+
+	if (!user_info || !*user_info)
+		return;
+
+	info = kzalloc(sizeof(*info), GFP_KERNEL);
+	if (!info) {
+		int err = -ENOMEM;
+		compat_copy_err(&((struct resukisu_susfs_features __user *)*user_info)->err,
+				err);
+		return;
+	}
+
+#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_SUS_PATH");
+#endif
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_SUS_MOUNT");
+#endif
+#ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_SUS_KSTAT");
+#endif
+#ifdef CONFIG_KSU_SUSFS_SPOOF_UNAME
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_SPOOF_UNAME");
+#endif
+#ifdef CONFIG_KSU_SUSFS_ENABLE_LOG
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_ENABLE_LOG");
+#endif
+#ifdef CONFIG_KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS");
+#endif
+#ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG");
+#endif
+#ifdef CONFIG_KSU_SUSFS_OPEN_REDIRECT
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_OPEN_REDIRECT");
+#endif
+#ifdef CONFIG_KSU_SUSFS_SUS_MAP
+	compat_append_feature(info->enabled_features, sizeof(info->enabled_features),
+			      &used, "CONFIG_KSU_SUSFS_SUS_MAP");
+#endif
+	info->err = 0;
+
+	if (copy_to_user((void __user *)*user_info, info, sizeof(*info)))
+		info->err = -EFAULT;
+	kfree(info);
+}
+
+static void compat_show_text(void __user **user_info, const char *text)
+{
+	struct resukisu_susfs_text_result info = { { 0 }, 0 };
+
+	if (!user_info || !*user_info)
+		return;
+
+	strncpy(info.text, text, sizeof(info.text) - 1);
+	if (copy_to_user((void __user *)*user_info, &info, sizeof(info)))
+		return;
+}
+
+void susfs_compat_show_variant(void __user **user_info)
+{
+	compat_show_text(user_info, SUSFS_VARIANT);
+}
+
+void susfs_compat_show_version(void __user **user_info)
+{
+	compat_show_text(user_info, SUSFS_VERSION);
+}

--- a/scripts/55_transform_resukisu_susfs_wrapper.py
+++ b/scripts/55_transform_resukisu_susfs_wrapper.py
@@ -26,6 +26,31 @@ cp "$SUSFS_DIR/kernel_patches/include/linux/susfs_def.h" "$KERNEL_DIR/include/li
 grep -Fq '#define SUSFS_VERSION "v1.5.9"' "$KERNEL_DIR/include/linux/susfs.h" || fail "Unexpected SUSFS branch version"
 patch -d "$KERNEL_DIR" -p1 --forward --batch --fuzz=3 < "$SUSFS_DIR/kernel_patches/50_add_susfs_in_kernel-4.19.patch"
 sed -i 's/[[:space:]]\+$//' "$KERNEL_DIR/fs/namespace.c" "$KERNEL_DIR/fs/overlayfs/readdir.c"
+python3 - "$KERNEL_DIR/fs/namei.c" "$KERNEL_DIR/fs/proc_namespace.c" <<'SUSFSWHITESPACEPY'
+from pathlib import Path
+import sys
+
+namei = Path(sys.argv[1])
+text = namei.read_text()
+bad_indent = ' \t\treturn dentry;'
+if text.count(bad_indent) != 1:
+    raise SystemExit('SUSFS namei indentation anchor mismatch')
+text = text.replace(bad_indent, '\t\treturn dentry;', 1)
+text = '\n'.join(line.rstrip(' \t') for line in text.split('\n'))
+namei.write_text(text)
+
+proc_namespace = Path(sys.argv[2])
+text = proc_namespace.read_text()
+bad_continuation = '    \t(susfs_hide_sus_mnts_for_all_procs || !susfs_is_current_ksu_domain()))'
+if text.count(bad_continuation) != 3:
+    raise SystemExit('SUSFS proc_namespace indentation anchor mismatch')
+text = text.replace(
+    bad_continuation,
+    '\t(susfs_hide_sus_mnts_for_all_procs || !susfs_is_current_ksu_domain()))',
+)
+text = '\n'.join(line.rstrip(' \t') for line in text.split('\n'))
+proc_namespace.write_text(text)
+SUSFSWHITESPACEPY
 python3 - "$KERNEL_DIR/include/linux/susfs_def.h" "$RESUKISU_DIR/kernel/feature/kernel_umount.c" <<'SUSFSCOMPATPY'
 from pathlib import Path
 import sys

--- a/scripts/55_transform_resukisu_susfs_wrapper.py
+++ b/scripts/55_transform_resukisu_susfs_wrapper.py
@@ -101,7 +101,7 @@ def patch_wrapper(path: Path) -> None:
         r'(?=python3 - "\$KERNEL_DIR/include/linux/sched/user\.h" <<\'USERPY\')',
         re.S,
     )
-    text, count = clone_pattern.subn(NEW_CLONE, text, count=1)
+    text, count = clone_pattern.subn(lambda _match: NEW_CLONE, text, count=1)
     if count != 1:
         raise SystemExit(f"legacy SUSFS clone block: expected one match, found {count}")
 

--- a/scripts/55_transform_resukisu_susfs_wrapper.py
+++ b/scripts/55_transform_resukisu_susfs_wrapper.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+HELPER_START = "python3 - scripts/08_build_resukisu_safe_checkpoint.sh <<'PY'\n"
+HELPER_END = '\nPY\n\ninfo "Building Linux 4.19.206 with ReSukiSU and SUSFS inline hooks"'
+HELPER_REPLACEMENT = (
+    'python3 scripts/55_transform_resukisu_susfs_wrapper.py '
+    'scripts/08_build_resukisu_safe_checkpoint.sh'
+)
+
+NEW_CLONE = r"""info "Integrating maintained SUSFS v1.5.9 Linux 4.19 patch"
+SUSFS_DIR="$KERNEL_DIR/../susfs4ksu-kernel-4.19"
+rm -rf "$SUSFS_DIR"
+git init -q "$SUSFS_DIR"
+git -C "$SUSFS_DIR" remote add origin "$SUSFS_REPO"
+git -C "$SUSFS_DIR" fetch --quiet --depth=1 origin "refs/heads/kernel-4.19"
+git -C "$SUSFS_DIR" checkout --quiet --detach FETCH_HEAD
+SUSFS_COMMIT="$(git -C "$SUSFS_DIR" rev-parse HEAD)"
+cp "$SUSFS_DIR/kernel_patches/fs/susfs.c" "$KERNEL_DIR/fs/susfs.c"
+cp "$SUSFS_DIR/kernel_patches/include/linux/susfs.h" "$KERNEL_DIR/include/linux/susfs.h"
+cp "$SUSFS_DIR/kernel_patches/include/linux/susfs_def.h" "$KERNEL_DIR/include/linux/susfs_def.h"
+grep -Fq '#define SUSFS_VERSION "v1.5.9"' "$KERNEL_DIR/include/linux/susfs.h" || fail "Unexpected SUSFS branch version"
+patch -d "$KERNEL_DIR" -p1 --forward --batch --fuzz=3 < "$SUSFS_DIR/kernel_patches/50_add_susfs_in_kernel-4.19.patch"
+sed -i 's/[[:space:]]\+$//' "$KERNEL_DIR/fs/namespace.c" "$KERNEL_DIR/fs/overlayfs/readdir.c"
+python3 - "$KERNEL_DIR/include/linux/susfs_def.h" "$RESUKISU_DIR/kernel/feature/kernel_umount.c" <<'SUSFSCOMPATPY'
+from pathlib import Path
+import sys
+
+header = Path(sys.argv[1])
+text = header.read_text()
+anchor = '#endif // #ifndef KSU_SUSFS_DEF_H\n'
+compat = r'''
+
+/* ReSukiSU compatibility names for the maintained 4.19 SUSFS state bit. */
+static inline bool susfs_is_current_proc_umounted(void)
+{
+    return susfs_is_current_non_root_user_app_proc();
+}
+
+static inline void susfs_set_current_proc_umounted(void)
+{
+    susfs_set_current_non_root_user_app_proc();
+}
+
+/* SUS_PATH is disabled in this conservative build, so no monitor is needed. */
+static inline void susfs_start_sdcard_monitor_fn(void)
+{
+}
+
+'''
+if 'susfs_is_current_proc_umounted' not in text:
+    if text.count(anchor) != 1:
+        raise SystemExit('susfs_def.h final guard anchor mismatch')
+    header.write_text(text.replace(anchor, compat + anchor, 1))
+
+umount = Path(sys.argv[2])
+text = umount.read_text()
+line = '    schedule_work(&susfs_extra_works);\n'
+if text.count(line) != 1:
+    raise SystemExit('ReSukiSU susfs_extra_works anchor mismatch')
+umount.write_text(text.replace(line, '', 1))
+SUSFSCOMPATPY
+"""
+
+CONFIG_EXTENSION = r"""    safe_susfs_config = new_config + (' \\\n'
+        '  -d KSU_SUSFS_SUS_PATH -e KSU_SUSFS_SUS_MOUNT -e KSU_SUSFS_SUS_KSTAT \\\n'
+        '  -e KSU_SUSFS_SPOOF_UNAME -d KSU_SUSFS_ENABLE_LOG \\\n'
+        '  -d KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS -d KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG \\\n'
+        '  -d KSU_SUSFS_OPEN_REDIRECT -d KSU_SUSFS_SUS_MAP')
+    text = text.replace(new_config, safe_susfs_config, 1)
+"""
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_helper(path: Path) -> None:
+    text = path.read_text()
+    start = text.find(HELPER_START)
+    if start < 0:
+        if HELPER_REPLACEMENT in text:
+            return
+        raise SystemExit("helper embedded transformer start marker missing")
+    end = text.find(HELPER_END, start)
+    if end < 0:
+        raise SystemExit("helper embedded transformer end marker missing")
+    text = text[:start] + HELPER_REPLACEMENT + text[end + len("\nPY") :]
+    path.write_text(text)
+
+
+def patch_wrapper(path: Path) -> None:
+    text = path.read_text()
+
+    clone_pattern = re.compile(
+        r'info "Integrating pinned SUSFS kernel 4\.19 patch"\n.*?'
+        r'(?=python3 - "\$KERNEL_DIR/include/linux/sched/user\.h" <<\'USERPY\')',
+        re.S,
+    )
+    text, count = clone_pattern.subn(NEW_CLONE, text, count=1)
+    if count != 1:
+        raise SystemExit(f"legacy SUSFS clone block: expected one match, found {count}")
+
+    user_pattern = re.compile(
+        r'python3 - "\$KERNEL_DIR/include/linux/sched/user\.h" <<\'USERPY\'\n.*?\nUSERPY\n',
+        re.S,
+    )
+    text, count = user_pattern.subn("", text, count=1)
+    if count != 1:
+        raise SystemExit(f"legacy SUSFS user_struct block: expected one match, found {count}")
+
+    validation_pattern = re.compile(
+        r'grep -Fq \'unsigned long android_kabi_reserved1;\' '
+        r'"\$KERNEL_DIR/include/linux/sched/user\.h" \|\| \\\n'
+        r'  fail "SUSFS user state field is missing"\n'
+    )
+    text, count = validation_pattern.subn("", text, count=1)
+    if count != 1:
+        raise SystemExit(f"legacy SUSFS user-state validation: expected one match, found {count}")
+
+    replace_anchor = '    text = text.replace(old_config, new_config, 1)\n'
+    text = replace_once(
+        text,
+        replace_anchor,
+        replace_anchor + CONFIG_EXTENSION,
+        "ReSukiSU SUSFS config replacement anchor",
+    )
+
+    text = text.replace("v1.4.2", "v1.5.9")
+    text = text.replace(
+        '''  printf 'susfs_version=%s\\n' "$SUSFS_VERSION"''',
+        '''  printf 'susfs_version=%s\\n' "v1.5.9-kernel-4.19"\n  printf 'susfs_commit=%s\\n' "$SUSFS_COMMIT"''',
+        1,
+    )
+    path.write_text(text)
+
+
+def main() -> None:
+    if len(sys.argv) == 3 and sys.argv[1] == "--patch-helper":
+        patch_helper(Path(sys.argv[2]))
+        return
+    if len(sys.argv) == 2:
+        patch_wrapper(Path(sys.argv[1]))
+        return
+    raise SystemExit(
+        "usage: 55_transform_resukisu_susfs_wrapper.py [--patch-helper] PATH"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/55_transform_resukisu_susfs_wrapper.py
+++ b/scripts/55_transform_resukisu_susfs_wrapper.py
@@ -86,6 +86,8 @@ if text.count(line) != 1:
     raise SystemExit('ReSukiSU susfs_extra_works anchor mismatch')
 umount.write_text(text.replace(line, '', 1))
 SUSFSCOMPATPY
+python3 "$PROJECT_DIR/scripts/55_apply_susfs_resukisu_compat.py" \
+  "$KERNEL_DIR" "$RESUKISU_DIR" "$PROJECT_DIR/scripts/55_susfs_resukisu_compat.c"
 """
 
 CONFIG_EXTENSION = r"""    safe_susfs_config = new_config + (' \\\n'

--- a/scripts/55_transform_resukisu_susfs_wrapper.py
+++ b/scripts/55_transform_resukisu_susfs_wrapper.py
@@ -96,6 +96,23 @@ CONFIG_EXTENSION = r"""    safe_susfs_config = new_config + (' \\\n'
         '  -d KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS -d KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG \\\n'
         '  -d KSU_SUSFS_OPEN_REDIRECT -d KSU_SUSFS_SUS_MAP')
     text = text.replace(new_config, safe_susfs_config, 1)
+
+    host_finalize_anchor = (
+        'stat.write_text(text)\n'
+        'PY\n\n'
+        'info "Adapting ReSukiSU to Linux 4.19 and disabling unmount defaults"\n'
+    )
+    host_finalize_replacement = (
+        'stat.write_text(text)\n'
+        'PY\n\n'
+        'info "Finalizing ReSukiSU SUSFS fstat hooks for Linux 4.19"\n'
+        'python3 "$PROJECT_DIR/scripts/55_apply_susfs_resukisu_compat.py" '
+        '--finalize-host-hooks "$KERNEL_DIR"\n\n'
+        'info "Adapting ReSukiSU to Linux 4.19 and disabling unmount defaults"\n'
+    )
+    if text.count(host_finalize_anchor) != 1:
+        raise SystemExit('ReSukiSU host fstat finalization anchor mismatch')
+    text = text.replace(host_finalize_anchor, host_finalize_replacement, 1)
 """
 
 

--- a/scripts/55_transform_resukisu_susfs_wrapper.py
+++ b/scripts/55_transform_resukisu_susfs_wrapper.py
@@ -33,25 +33,22 @@ import sys
 header = Path(sys.argv[1])
 text = header.read_text()
 anchor = '#endif // #ifndef KSU_SUSFS_DEF_H\n'
-compat = r'''
-
-/* ReSukiSU compatibility names for the maintained 4.19 SUSFS state bit. */
-static inline bool susfs_is_current_proc_umounted(void)
-{
-    return susfs_is_current_non_root_user_app_proc();
-}
-
-static inline void susfs_set_current_proc_umounted(void)
-{
-    susfs_set_current_non_root_user_app_proc();
-}
-
-/* SUS_PATH is disabled in this conservative build, so no monitor is needed. */
-static inline void susfs_start_sdcard_monitor_fn(void)
-{
-}
-
-'''
+compat = (
+    '\n\n'
+    '/* ReSukiSU compatibility names for the maintained 4.19 SUSFS state bit. */\n'
+    'static inline bool susfs_is_current_proc_umounted(void)\n'
+    '{\n'
+    '    return susfs_is_current_non_root_user_app_proc();\n'
+    '}\n\n'
+    'static inline void susfs_set_current_proc_umounted(void)\n'
+    '{\n'
+    '    susfs_set_current_non_root_user_app_proc();\n'
+    '}\n\n'
+    '/* SUS_PATH is disabled in this conservative build, so no monitor is needed. */\n'
+    'static inline void susfs_start_sdcard_monitor_fn(void)\n'
+    '{\n'
+    '}\n\n'
+)
 if 'susfs_is_current_proc_umounted' not in text:
     if text.count(anchor) != 1:
         raise SystemExit('susfs_def.h final guard anchor mismatch')


### PR DESCRIPTION
## What changed

Adds a dedicated Linux 4.19.206 A52XQ build and repack workflow using the pinned ReSukiSU v4.1.0 revision and SUSFS v1.4.2 for kernel 4.19.

## Integration mode

- Uses SUSFS inline hooks
- Disables ReSukiSU manual hooks
- Disables tracepoint hooks and KPROBES
- Retains multi-manager support
- Keeps kernel and module unmount defaults disabled

## Hardware baseline

The workflow reconstructs the same Linux 4.19.206 source path and merge repairs as the working build, then restores the STM FTS touchscreen and full A52/Lagoon hardware configuration before integrating root support.

## Validation

The workflow checks the final kernel configuration, inline read/input/setresuid hooks, pinned ReSukiSU version string, core A52 hardware symbols, boot source checksum lock, and repack report. The produced boot image is explicitly marked experimental and not hardware validated.

## Safety

This does not overwrite or relabel the known-working 4.19.206 image. Keep that image available for rollback and back up boot and data before testing this rooted variant.