### PR TITLE
Add TouchGrass UFS reference recorder with automatic dump

### DIFF
--- a/.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml
+++ b/.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml
@@ -1,0 +1,347 @@
+name: 96 - A52 TouchGrass 4.19.206 UFS reference recorder
+
+run-name: Build known-good TouchGrass UFS reference recorder with automatic data dump
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/touchgrass-ufs-reference-recorder
+    paths:
+      - '.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml'
+      - 'scripts/96_stage_touchgrass_ufs_reference_recorder.py'
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-touchgrass-ufs-reference-recorder
+  cancel-in-progress: true
+
+env:
+  JOBS: '4'
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 5G
+
+jobs:
+  build:
+    name: Build and repack TouchGrass UFS reference recorder
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out kernel project branch
+        uses: actions/checkout@v4
+        with:
+          ref: rebase/resukisu-linux-4.19.325
+
+      - name: Hydrate recorder, build and repack helpers
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIAG_REF: ${{ github.sha }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p scripts projects/a52-p1-boot-image
+
+          fetch_file() {
+            local ref="$1"
+            local path="$2"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${ref}" \
+              --jq '.content' | tr -d '\n' | base64 --decode > "$path"
+            test -s "$path"
+          }
+
+          fetch_file "$DIAG_REF" scripts/96_stage_touchgrass_ufs_reference_recorder.py
+          fetch_file main scripts/48_build_a52_linux_4.19.206_touchscreen.sh
+          fetch_file main scripts/37_validate_a52_p1_boot_source.py
+          fetch_file main scripts/38_repack_a52_p1_boot.py
+          fetch_file main projects/a52-p1-boot-image/boot-source.lock
+
+          chmod +x \
+            scripts/96_stage_touchgrass_ufs_reference_recorder.py \
+            scripts/48_build_a52_linux_4.19.206_touchscreen.sh \
+            scripts/37_validate_a52_p1_boot_source.py \
+            scripts/38_repack_a52_p1_boot.py
+          python3 -m py_compile \
+            scripts/96_stage_touchgrass_ufs_reference_recorder.py \
+            scripts/37_validate_a52_p1_boot_source.py \
+            scripts/38_repack_a52_p1_boot.py
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          df -h
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils gzip zip unzip make gcc g++ bc bison flex ccache patch \
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar
+
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: a52xq-touchgrass-ufs-reference-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            a52xq-linux-4.19.206-no-root-${{ runner.os }}-
+            a52xq-recovery-ramoops-exporter-${{ runner.os }}-
+            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
+
+      - name: Prepare exact TouchGrass source through Linux 4.19.200
+        run: |
+          set -Eeuo pipefail
+          chmod +x scripts/*.sh scripts/*.py
+          ./scripts/01_prepare_source.sh
+          ./scripts/03_apply_linux_4.19.153.sh
+          ./scripts/04_apply_linux_4.19.154.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+          ./scripts/checkpoint_resolve_linux_4.19.159.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+          ./scripts/checkpoint_resolve_linux_4.19.164.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+          ./scripts/checkpoint_resolve_linux_4.19.180.sh
+          ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+          ./scripts/checkpoint_resolve_linux_4.19.200.sh
+          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.200
+
+      - name: Derive and apply official Linux 4.19.206 merge
+        run: |
+          set -Eeuo pipefail
+          cp scripts/checkpoint_merge_linux_4.19.210.sh \
+            scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          sed -i \
+            -e 's/TO_TAG=v4.19.210/TO_TAG=v4.19.206/' \
+            -e '/^TARGET_COMMIT=/d' \
+            -e '/test "$to_sha" = "$TARGET_COMMIT"/d' \
+            scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          chmod +x scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          ./scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.206
+
+      - name: Apply conditional merge-shape repairs for 4.19.206
+        run: |
+          set -Eeuo pipefail
+          cp scripts/checkpoint_fix_linux_4.19.210_compile.sh \
+            scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          sed -i 's/TARGET_VERSION=4.19.210/TARGET_VERSION=4.19.206/' \
+            scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          chmod +x scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          ./scripts/checkpoint_fix_linux_4.19.206.generated.sh
+
+          python3 - <<'PY'
+          from pathlib import Path
+
+          root = Path('workspace/touchgrass-a52xq')
+
+          header = (root / 'include/linux/timerqueue.h').read_text()
+          path = root / 'drivers/soc/qcom/event_timer.c'
+          text = path.read_text()
+          newer = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+          \t.rb_root = RB_ROOT_CACHED,
+          };
+          '''
+          older = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+          \t.head = RB_ROOT,
+          \t.next = NULL,
+          };
+          '''
+          wants_newer = 'struct rb_root_cached rb_root;' in header
+          desired = newer if wants_newer else older
+          obsolete = older if wants_newer else newer
+          if desired not in text:
+              if obsolete not in text:
+                  raise SystemExit('event_timer initializer shape is unrecognized')
+              path.write_text(text.replace(obsolete, desired, 1))
+
+          path = root / 'kernel/sched/cpufreq_schedutil.c'
+          text = path.read_text()
+          call = 'sugov_clear_global_tunables();'
+          definition = 'static void sugov_clear_global_tunables(void)'
+          anchor = 'static void sugov_exit('
+          if call in text and definition not in text:
+              if anchor not in text:
+                  raise SystemExit('schedutil exit anchor missing')
+              helper = '''static void sugov_clear_global_tunables(void)
+          {
+          \tif (!have_governor_per_policy())
+          \t\tglobal_tunables = NULL;
+          }
+
+          '''
+              path.write_text(text.replace(anchor, helper + anchor, 1))
+          elif call not in text:
+              raise SystemExit('schedutil cleanup call missing after generic repair')
+          PY
+
+      - name: Stage targeted UFS reference recorder and automatic dumper
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-touchgrass-ufs-reference-recorder
+          mkdir -p "$OUT"
+          python3 scripts/96_stage_touchgrass_ufs_reference_recorder.py \
+            --kernel workspace/touchgrass-a52xq \
+            --output "$OUT"
+
+          git -C workspace/touchgrass-a52xq diff --check
+          git -C workspace/touchgrass-a52xq diff --binary --no-ext-diff \
+            > "$OUT/touchgrass-ufs-reference-recorder.patch"
+          test -s "$OUT/touchgrass-ufs-reference-recorder.patch"
+
+          grep -Fq 'TGREF_DUMP_PATH "/data/local/tmp/tgref_ufs.log"' \
+            workspace/touchgrass-a52xq/drivers/scsi/ufs/tgref-recorder.c
+          grep -Fq 'DEV call device=%s driver=%s' \
+            workspace/touchgrass-a52xq/drivers/base/dd.c
+          grep -Fq 'UFS power_up_begin' \
+            workspace/touchgrass-a52xq/drivers/scsi/ufs/ufs-qcom.c
+          grep -Fq 'CORE link_startup' \
+            workspace/touchgrass-a52xq/drivers/scsi/ufs/ufshcd.c
+          grep -Fq 'SD add_disk' \
+            workspace/touchgrass-a52xq/drivers/scsi/sd.c
+
+      - name: Build known-good touchscreen configuration with recorder
+        run: |
+          set -Eeuo pipefail
+          ./scripts/48_build_a52_linux_4.19.206_touchscreen.sh
+
+          SRC=artifacts/a52xq-linux-4.19.206-touchscreen-kernel
+          OUT=artifacts/a52xq-touchgrass-ufs-reference-recorder
+          cp "$SRC/Image" "$OUT/Image"
+          cp "$SRC/Image.gz" "$OUT/Image.gz"
+          cp "$SRC/final.config" "$OUT/final.config"
+          cp "$SRC/System.map" "$OUT/System.map" 2>/dev/null || true
+          cp "$SRC/vmlinux" "$OUT/vmlinux" 2>/dev/null || true
+
+      - name: Audit recorder Image and no-root policy
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-touchgrass-ufs-reference-recorder
+
+          grep -aFq 'TGREF reference=touchGrass-4.19.206' "$OUT/Image"
+          grep -aFq '/data/local/tmp/tgref_ufs.log' "$OUT/Image"
+          grep -aFq 'DEV call device=%s driver=%s' "$OUT/Image"
+          grep -aFq 'PHY probe_begin device=%s' "$OUT/Image"
+          grep -aFq 'UFS power_up_begin lanes=%u gear4=%d' "$OUT/Image"
+          grep -aFq 'PLT parse_clocks ret=%d' "$OUT/Image"
+          grep -aFq 'CORE link_startup ret=%d' "$OUT/Image"
+          grep -aFq 'SD add_disk name=%s' "$OUT/Image"
+
+          grep -Fxq 'CONFIG_SCSI_UFS_QCOM=y' "$OUT/final.config"
+          grep -Fxq 'CONFIG_SCSI_UFSHCD_PLATFORM=y' "$OUT/final.config"
+          grep -Fxq 'CONFIG_PHY_QCOM_UFS=y' "$OUT/final.config"
+          grep -Fxq 'CONFIG_TOUCHSCREEN_STM_FTS5CU56A=y' "$OUT/final.config"
+          grep -Fxq 'CONFIG_PSTORE_RAM=y' "$OUT/final.config"
+          ! grep -Eq '^CONFIG_KSU(=|_)' "$OUT/final.config"
+
+      - name: Download and validate checksum-locked original boot image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p intake
+          OUT=artifacts/a52xq-touchgrass-ufs-reference-recorder
+
+          ASSET_LINE="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=30" \
+            --jq '.[] | .assets[] | select(.name | endswith(".img")) |
+                  [.id, .name, .created_at] | @tsv' | head -n 1)"
+          test -n "$ASSET_LINE"
+          IFS=$'\t' read -r ASSET_ID ASSET_NAME ASSET_CREATED <<< "$ASSET_LINE"
+
+          curl --fail --location --retry 3 --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/octet-stream' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" \
+            --output intake/boot.img
+
+          python3 scripts/37_validate_a52_p1_boot_source.py intake/boot.img \
+            --lock projects/a52-p1-boot-image/boot-source.lock \
+            --output "$OUT/source-validation.json"
+
+          printf 'asset_id=%s\nasset_name=%s\nasset_created=%s\n' \
+            "$ASSET_ID" "$ASSET_NAME" "$ASSET_CREATED" \
+            > "$OUT/source-asset.txt"
+
+      - name: Repack and audit flashable diagnostic boot image
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-touchgrass-ufs-reference-recorder
+
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source intake/boot.img \
+            --kernel "$OUT/Image.gz" \
+            --output "$OUT/boot.img" \
+            --report "$OUT/repack-report.json"
+
+          test "$(stat -c %s "$OUT/boot.img")" = 100663296
+
+      - name: Finalize recorder artifact
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-touchgrass-ufs-reference-recorder
+
+          cat > "$OUT/README-FIRST.txt" <<'EOF'
+          A52 5G TOUCHGRASS 4.19.206 UFS REFERENCE RECORDER
+
+          Purpose:
+          Capture the known-good TouchGrass UFS initialization sequence for direct
+          comparison with the GKI 5.10 recorder.
+
+          Automatic collection:
+          The kernel keeps targeted TGREF breadcrumbs in a 128 KiB RAM buffer.
+          After /data/local/tmp appears, it waits 30 seconds and writes:
+
+              /data/local/tmp/tgref_ufs.log
+
+          No KernelSU or Android root application is included. The one-shot dumper
+          runs inside this diagnostic kernel and writes a root-owned, mode-0644 file.
+
+          After Android finishes booting, wait about 60 to 90 seconds, then run:
+
+              adb shell ls -l /data/local/tmp/tgref_ufs.log
+              adb pull /data/local/tmp/tgref_ufs.log
+
+          Each diagnostic boot overwrites the previous tgref_ufs.log.
+
+          This boot image is not hardware-validated yet.
+          EOF
+          sed -i 's/^          //' "$OUT/README-FIRST.txt"
+
+          printf 'check\tresult\n' > "$OUT/status.tsv"
+          printf 'kernel-version\t4.19.206\n' >> "$OUT/status.tsv"
+          printf 'known-good-touchscreen-config\tyes\n' >> "$OUT/status.tsv"
+          printf 'targeted-ufs-recorder\tyes\n' >> "$OUT/status.tsv"
+          printf 'automatic-data-dump\tyes\n' >> "$OUT/status.tsv"
+          printf 'dump-path\t/data/local/tmp/tgref_ufs.log\n' >> "$OUT/status.tsv"
+          printf 'android-root-required\tno\n' >> "$OUT/status.tsv"
+          printf 'kernel-root-integration\tnone\n' >> "$OUT/status.tsv"
+          printf 'flashable-candidate\tyes\n' >> "$OUT/status.tsv"
+          printf 'hardware-validated\tno\n' >> "$OUT/status.tsv"
+
+          (
+            cd "$OUT"
+            find . -type f ! -name SHA256SUMS -print0 |
+              sort -z | xargs -0 sha256sum > SHA256SUMS
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Upload TouchGrass UFS reference recorder
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-touchgrass-4.19.206-ufs-reference-recorder-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-touchgrass-ufs-reference-recorder
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-touchgrass-ufs-reference-recorder-failure-${{ github.run_number }}
+          path: |
+            artifacts/
+            workspace/touchgrass-a52xq/out/.config
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml
+++ b/.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml
@@ -10,6 +10,12 @@ on:
     paths:
       - '.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml'
       - 'scripts/96_stage_touchgrass_ufs_reference_recorder.py'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/96-a52-touchgrass-ufs-reference-recorder.yml'
+      - 'scripts/96_stage_touchgrass_ufs_reference_recorder.py'
 
 permissions:
   contents: read

--- a/.github/workflows/97-a52-touchgrass-recorder-anchor-preflight.yml
+++ b/.github/workflows/97-a52-touchgrass-recorder-anchor-preflight.yml
@@ -1,0 +1,163 @@
+name: 97 - A52 TouchGrass recorder anchor preflight
+
+run-name: Validate TouchGrass 4.19.206 recorder source anchors
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/touchgrass-ufs-reference-recorder
+    paths:
+      - '.github/workflows/97-a52-touchgrass-recorder-anchor-preflight.yml'
+      - 'scripts/96_stage_touchgrass_ufs_reference_recorder.py'
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-touchgrass-recorder-anchor-preflight
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Reconstruct 4.19.206 and validate recorder anchors
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out kernel project branch
+        uses: actions/checkout@v4
+        with:
+          ref: rebase/resukisu-linux-4.19.325
+
+      - name: Hydrate recorder staging script
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIAG_REF: ${{ github.sha }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p scripts artifacts/recorder-anchor-preflight
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/96_stage_touchgrass_ufs_reference_recorder.py?ref=${DIAG_REF}" \
+            --jq '.content' | tr -d '\n' | base64 --decode \
+            > scripts/96_stage_touchgrass_ufs_reference_recorder.py
+          chmod +x scripts/96_stage_touchgrass_ufs_reference_recorder.py
+          python3 -m py_compile scripts/96_stage_touchgrass_ufs_reference_recorder.py
+
+      - name: Install source preparation dependencies
+        run: |
+          sudo apt-get update >/dev/null
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils gzip make gcc g++ bc bison flex patch \
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar >/dev/null
+
+      - name: Reconstruct exact TouchGrass Linux 4.19.206 quietly
+        run: |
+          set -Eeuo pipefail
+          LOG=artifacts/recorder-anchor-preflight/source-reconstruction.log
+          exec > >(tee "$LOG") 2>&1
+          chmod +x scripts/*.sh scripts/*.py
+
+          quiet_run() {
+            local label="$1"
+            shift
+            echo "PREFLIGHT begin ${label}"
+            "$@" >"artifacts/recorder-anchor-preflight/${label}.log" 2>&1
+            echo "PREFLIGHT pass ${label}"
+          }
+
+          quiet_run prepare_source ./scripts/01_prepare_source.sh
+          quiet_run apply_4_19_153 ./scripts/03_apply_linux_4.19.153.sh
+          quiet_run apply_4_19_154 ./scripts/04_apply_linux_4.19.154.sh
+          quiet_run diagnose_159 ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+          quiet_run resolve_159 ./scripts/checkpoint_resolve_linux_4.19.159.sh
+          quiet_run diagnose_164 ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+          quiet_run resolve_164 ./scripts/checkpoint_resolve_linux_4.19.164.sh
+          quiet_run diagnose_180 ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+          quiet_run resolve_180 ./scripts/checkpoint_resolve_linux_4.19.180.sh
+          quiet_run diagnose_200 ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+          quiet_run resolve_200 ./scripts/checkpoint_resolve_linux_4.19.200.sh
+          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.200
+
+          cp scripts/checkpoint_merge_linux_4.19.210.sh \
+            scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          sed -i \
+            -e 's/TO_TAG=v4.19.210/TO_TAG=v4.19.206/' \
+            -e '/^TARGET_COMMIT=/d' \
+            -e '/test "$to_sha" = "$TARGET_COMMIT"/d' \
+            scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          chmod +x scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          quiet_run merge_206 ./scripts/checkpoint_merge_linux_4.19.206.generated.sh
+          test "$(make -s -C workspace/touchgrass-a52xq kernelversion)" = 4.19.206
+
+          cp scripts/checkpoint_fix_linux_4.19.210_compile.sh \
+            scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          sed -i 's/TARGET_VERSION=4.19.210/TARGET_VERSION=4.19.206/' \
+            scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          chmod +x scripts/checkpoint_fix_linux_4.19.206.generated.sh
+          quiet_run fix_206 ./scripts/checkpoint_fix_linux_4.19.206.generated.sh
+
+          python3 - <<'PY'
+          from pathlib import Path
+
+          root = Path('workspace/touchgrass-a52xq')
+          header = (root / 'include/linux/timerqueue.h').read_text()
+          path = root / 'drivers/soc/qcom/event_timer.c'
+          text = path.read_text()
+          newer = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+          \t.rb_root = RB_ROOT_CACHED,
+          };
+          '''
+          older = '''static DEFINE_PER_CPU(struct timerqueue_head, timer_head) = {
+          \t.head = RB_ROOT,
+          \t.next = NULL,
+          };
+          '''
+          wants_newer = 'struct rb_root_cached rb_root;' in header
+          desired = newer if wants_newer else older
+          obsolete = older if wants_newer else newer
+          if desired not in text:
+              if obsolete not in text:
+                  raise SystemExit('event_timer initializer shape is unrecognized')
+              path.write_text(text.replace(obsolete, desired, 1))
+
+          path = root / 'kernel/sched/cpufreq_schedutil.c'
+          text = path.read_text()
+          call = 'sugov_clear_global_tunables();'
+          definition = 'static void sugov_clear_global_tunables(void)'
+          anchor = 'static void sugov_exit('
+          if call in text and definition not in text:
+              if anchor not in text:
+                  raise SystemExit('schedutil exit anchor missing')
+              helper = '''static void sugov_clear_global_tunables(void)
+          {
+          \tif (!have_governor_per_policy())
+          \t\tglobal_tunables = NULL;
+          }
+
+          '''
+              path.write_text(text.replace(anchor, helper + anchor, 1))
+          elif call not in text:
+              raise SystemExit('schedutil cleanup call missing after generic repair')
+          PY
+
+          echo "PREFLIGHT source_ready version=$(make -s -C workspace/touchgrass-a52xq kernelversion)"
+
+      - name: Run recorder anchor audit
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/recorder-anchor-preflight
+          python3 scripts/96_stage_touchgrass_ufs_reference_recorder.py \
+            --kernel workspace/touchgrass-a52xq \
+            --output "$OUT" 2>&1 | tee "$OUT/stage.log"
+          git -C workspace/touchgrass-a52xq diff --check
+          echo 'PREFLIGHT recorder_anchor_audit=passed'
+
+      - name: Upload anchor preflight diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-touchgrass-recorder-anchor-preflight-${{ github.run_number }}
+          path: artifacts/recorder-anchor-preflight
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/96_stage_touchgrass_ufs_reference_recorder.py
+++ b/scripts/96_stage_touchgrass_ufs_reference_recorder.py
@@ -222,7 +222,40 @@ def instrument_ufshcd(text: str) -> str:
     return text
 
 
+def instrument_sd(text: str) -> str:
+    text = _impl.add_include(
+        text,
+        "#include <linux/blkdev.h>\n",
+        "sd include",
+    )
+    probe_anchor = "static int sd_probe(struct device *dev)\n"
+    text = _impl.insert_after_fragment(
+        text,
+        probe_anchor,
+        'error = sd_format_disk_name("sd", index, gd->disk_name, DISK_NAME_LEN);\n',
+        "\tif (!error && sdp->host->by_ufs)\n"
+        "\t\ttgref_record(\"SD probe lun=%llu name=%s host_no=%d\",\n"
+        "\t\t\t     (unsigned long long)sdp->lun, gd->disk_name,\n"
+        "\t\t\t     sdp->host->host_no);\n",
+        "sd probe",
+    )
+
+    async_anchor = "static void sd_probe_async(void *data, async_cookie_t cookie)\n"
+    text = insert_after_regex(
+        text,
+        async_anchor,
+        r"\tdevice_add_disk\(dev,\s*gd(?:,\s*NULL)?\);\n",
+        "\tif (sdp->host->by_ufs)\n"
+        "\t\ttgref_record(\"SD add_disk name=%s capacity=%llu sectors host_no=%d\",\n"
+        "\t\t\t     gd->disk_name, (unsigned long long)get_capacity(gd),\n"
+        "\t\t\t     sdp->host->host_no);\n",
+        "sd add disk",
+    )
+    return text
+
+
 _impl.instrument_ufshcd = instrument_ufshcd
+_impl.instrument_sd = instrument_sd
 
 
 def requested_output() -> Path | None:

--- a/scripts/96_stage_touchgrass_ufs_reference_recorder.py
+++ b/scripts/96_stage_touchgrass_ufs_reference_recorder.py
@@ -1,0 +1,928 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+HEADER = r'''#ifndef _LINUX_TGREF_RECORDER_H
+#define _LINUX_TGREF_RECORDER_H
+
+#include <linux/compiler.h>
+
+void tgref_record(const char *fmt, ...) __printf(1, 2);
+
+#endif
+'''
+
+SOURCE = r'''// SPDX-License-Identifier: GPL-2.0
+/*
+ * A52 TouchGrass UFS reference recorder.
+ *
+ * Diagnostic-only helper for the known-good Linux 4.19.206 boot. UFS bring-up
+ * breadcrumbs are kept in a small in-kernel text buffer and copied once to
+ * /data/local/tmp/tgref_ufs.log after Android has mounted /data.
+ */
+#include <linux/delay.h>
+#include <linux/err.h>
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/kthread.h>
+#include <linux/module.h>
+#include <linux/namei.h>
+#include <linux/printk.h>
+#include <linux/sizes.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/timekeeping.h>
+#include <linux/uaccess.h>
+#include <linux/vmalloc.h>
+
+#include <linux/tgref_recorder.h>
+
+#define TGREF_BUFFER_SIZE SZ_128K
+#define TGREF_LINE_SIZE 384
+#define TGREF_DUMP_PATH "/data/local/tmp/tgref_ufs.log"
+#define TGREF_DATA_DIR "/data/local/tmp"
+#define TGREF_POLL_MS 5000
+#define TGREF_SETTLE_MS 30000
+#define TGREF_MAX_POLLS 120
+
+static char tgref_buffer[TGREF_BUFFER_SIZE];
+static size_t tgref_length;
+static unsigned int tgref_dropped;
+static DEFINE_SPINLOCK(tgref_lock);
+
+void tgref_record(const char *fmt, ...)
+{
+	char line[TGREF_LINE_SIZE];
+	unsigned long flags;
+	u64 ns;
+	va_list args;
+	int prefix;
+	int body;
+	int total;
+
+	ns = ktime_get_ns();
+	prefix = scnprintf(line, sizeof(line), "TGREF %llu.%06llu ",
+			   (unsigned long long)(ns / NSEC_PER_SEC),
+			   (unsigned long long)((ns % NSEC_PER_SEC) / NSEC_PER_USEC));
+
+	va_start(args, fmt);
+	body = vscnprintf(line + prefix, sizeof(line) - prefix, fmt, args);
+	va_end(args);
+
+	total = prefix + body;
+	if (total <= 0)
+		return;
+	if (line[total - 1] != '\n' && total < sizeof(line) - 1)
+		line[total++] = '\n';
+	line[total] = '\0';
+
+	spin_lock_irqsave(&tgref_lock, flags);
+	if (tgref_length + total <= sizeof(tgref_buffer)) {
+		memcpy(tgref_buffer + tgref_length, line, total);
+		tgref_length += total;
+	} else {
+		tgref_dropped++;
+	}
+	spin_unlock_irqrestore(&tgref_lock, flags);
+
+	printk(KERN_INFO "%s", line);
+}
+EXPORT_SYMBOL_GPL(tgref_record);
+
+static int tgref_snapshot(char **out, size_t *out_len)
+{
+	unsigned long flags;
+	char *snapshot;
+	size_t len;
+	unsigned int dropped;
+	int header;
+
+	snapshot = vmalloc(TGREF_BUFFER_SIZE + 128);
+	if (!snapshot)
+		return -ENOMEM;
+
+	spin_lock_irqsave(&tgref_lock, flags);
+	len = tgref_length;
+	dropped = tgref_dropped;
+	memcpy(snapshot + 128, tgref_buffer, len);
+	spin_unlock_irqrestore(&tgref_lock, flags);
+
+	header = scnprintf(snapshot, 128,
+			   "TGREF reference=touchGrass-4.19.206 bytes=%zu dropped=%u\n",
+			   len, dropped);
+	memmove(snapshot + header, snapshot + 128, len);
+	*out = snapshot;
+	*out_len = header + len;
+	return 0;
+}
+
+static int tgref_write_snapshot(void)
+{
+	struct file *file;
+	char *snapshot;
+	size_t length;
+	size_t written = 0;
+	loff_t pos = 0;
+	int ret;
+
+	ret = tgref_snapshot(&snapshot, &length);
+	if (ret)
+		return ret;
+
+	file = filp_open(TGREF_DUMP_PATH,
+			 O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE, 0644);
+	if (IS_ERR(file)) {
+		ret = PTR_ERR(file);
+		vfree(snapshot);
+		return ret;
+	}
+
+	while (written < length) {
+		ssize_t step = kernel_write(file, snapshot + written,
+					    length - written, &pos);
+		if (step < 0) {
+			ret = step;
+			goto out;
+		}
+		if (!step) {
+			ret = -EIO;
+			goto out;
+		}
+		written += step;
+	}
+
+	ret = vfs_fsync(file, 0);
+out:
+	filp_close(file, NULL);
+	vfree(snapshot);
+	return ret;
+}
+
+static int tgref_dump_thread(void *unused)
+{
+	struct path path;
+	int poll;
+	int ret = -ENOENT;
+
+	tgref_record("DUMPER armed path=%s", TGREF_DUMP_PATH);
+
+	for (poll = 0; poll < TGREF_MAX_POLLS && !kthread_should_stop(); poll++) {
+		ret = kern_path(TGREF_DATA_DIR,
+				LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &path);
+		if (!ret) {
+			path_put(&path);
+			tgref_record("DUMPER data_ready poll=%d settle_ms=%d",
+				     poll, TGREF_SETTLE_MS);
+			msleep(TGREF_SETTLE_MS);
+			ret = tgref_write_snapshot();
+			if (!ret) {
+				printk(KERN_INFO
+				       "TGREF DUMPER saved %s\n", TGREF_DUMP_PATH);
+				return 0;
+			}
+			tgref_record("DUMPER write_failed ret=%d retrying", ret);
+		}
+		msleep(TGREF_POLL_MS);
+	}
+
+	tgref_record("DUMPER gave_up ret=%d polls=%d", ret, poll);
+	return ret;
+}
+
+static int __init tgref_recorder_init(void)
+{
+	struct task_struct *task;
+
+	tgref_record("RECORDER ready buffer=%u dump=%s",
+		     (unsigned int)TGREF_BUFFER_SIZE, TGREF_DUMP_PATH);
+	task = kthread_run(tgref_dump_thread, NULL, "tgref_ufs_dump");
+	if (IS_ERR(task)) {
+		int ret = PTR_ERR(task);
+
+		tgref_record("DUMPER thread_start_failed ret=%d", ret);
+		return 0;
+	}
+	return 0;
+}
+late_initcall(tgref_recorder_init);
+
+MODULE_DESCRIPTION("A52 TouchGrass UFS reference recorder and automatic dumper");
+MODULE_LICENSE("GPL v2");
+'''
+
+
+def fail(label: str, detail: str) -> None:
+    raise SystemExit(f"{label}: {detail}")
+
+
+def function_bounds(text: str, anchor: str, label: str) -> tuple[int, int, int]:
+    search = 0
+    while True:
+        start = text.find(anchor, search)
+        if start < 0:
+            fail(label, f"function anchor not found: {anchor}")
+        brace = text.find("{", start)
+        semicolon = text.find(";", start)
+        if brace >= 0 and (semicolon < 0 or brace < semicolon):
+            break
+        search = start + len(anchor)
+
+    depth = 0
+    for pos in range(brace, len(text)):
+        ch = text[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return start, brace, pos + 1
+    fail(label, "closing brace not found")
+
+
+def add_include(text: str, anchor: str, label: str) -> str:
+    include = "#include <linux/tgref_recorder.h>\n"
+    if include in text:
+        fail(label, "recorder include already present")
+    count = text.count(anchor)
+    if count != 1:
+        fail(label, f"expected one include anchor, found {count}")
+    return text.replace(anchor, anchor + include, 1)
+
+
+def insert_after_fragment(
+    text: str, function_anchor: str, fragment: str, insertion: str, label: str
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    positions: list[int] = []
+    cursor = start
+    while True:
+        pos = text.find(fragment, cursor, end)
+        if pos < 0:
+            break
+        positions.append(pos)
+        cursor = pos + len(fragment)
+    if len(positions) != 1:
+        fail(label, f"expected one fragment in function, found {len(positions)}")
+    point = positions[0] + len(fragment)
+    return text[:point] + insertion + text[point:]
+
+
+def insert_before_fragment(
+    text: str, function_anchor: str, fragment: str, insertion: str, label: str
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    positions: list[int] = []
+    cursor = start
+    while True:
+        pos = text.find(fragment, cursor, end)
+        if pos < 0:
+            break
+        positions.append(pos)
+        cursor = pos + len(fragment)
+    if len(positions) != 1:
+        fail(label, f"expected one fragment in function, found {len(positions)}")
+    point = positions[0]
+    return text[:point] + insertion + text[point:]
+
+
+def insert_after_open(
+    text: str, function_anchor: str, insertion: str, label: str
+) -> str:
+    _, brace, _ = function_bounds(text, function_anchor, label)
+    return text[: brace + 1] + insertion + text[brace + 1 :]
+
+
+def insert_before_last_return(
+    text: str, function_anchor: str, return_fragment: str, insertion: str, label: str
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    pos = text.rfind(return_fragment, start, end)
+    if pos < 0:
+        fail(label, "return fragment not found")
+    return text[:pos] + insertion + text[pos:]
+
+
+def replace_in_function(
+    text: str,
+    function_anchor: str,
+    old: str,
+    new: str,
+    label: str,
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    count = text.count(old, start, end)
+    if count != 1:
+        fail(label, f"expected one replacement target in function, found {count}")
+    pos = text.find(old, start, end)
+    return text[:pos] + new + text[pos + len(old) :]
+
+
+def instrument_driver_core(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/pinctrl/devinfo.h>\n",
+        "driver core include",
+    )
+    helper = r'''
+static bool tgref_relevant_probe(struct device *dev, struct device_driver *drv)
+{
+	const char *device = dev_name(dev);
+	const char *driver = drv ? drv->name : "";
+
+	return strstr(device, "1d84000") || strstr(device, "1d87000") ||
+	       strstr(driver, "ufshcd-qcom") ||
+	       strstr(driver, "ufs_qcom_phy_qmp_v3");
+}
+
+'''
+    anchor = "static int really_probe(struct device *dev, struct device_driver *drv)\n"
+    if text.count(anchor) != 1:
+        fail("driver core helper", "really_probe anchor count is not one")
+    text = text.replace(anchor, helper + anchor, 1)
+
+    decl = (
+        "\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n"
+        "\t\t\t   !drv->suppress_bind_attrs;\n"
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        decl,
+        "\tbool tgref_match = tgref_relevant_probe(dev, drv);\n\n"
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV call device=%s driver=%s\", dev_name(dev), drv->name);\n",
+        "driver core call",
+    )
+
+    suppliers = (
+        "\tret = device_links_check_suppliers(dev);\n"
+        "\tif (ret == -EPROBE_DEFER)\n"
+        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n"
+        "\tif (ret)\n"
+        "\t\treturn ret;\n"
+    )
+    suppliers_new = (
+        "\tret = device_links_check_suppliers(dev);\n"
+        "\tif (ret == -EPROBE_DEFER)\n"
+        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n"
+        "\tif (ret) {\n"
+        "\t\tif (tgref_match)\n"
+        "\t\t\ttgref_record(\"DEV suppliers device=%s driver=%s ret=%d\",\n"
+        "\t\t\t\t     dev_name(dev), drv->name, ret);\n"
+        "\t\treturn ret;\n"
+        "\t}\n"
+    )
+    text = replace_in_function(
+        text, anchor, suppliers, suppliers_new, "driver core suppliers"
+    )
+
+    text = insert_before_fragment(
+        text,
+        anchor,
+        "\tif (test_remove) {\n",
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV probe_return device=%s driver=%s ret=%d\",\n"
+        "\t\t\t     dev_name(dev), drv->name, ret);\n",
+        "driver core probe return",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tdriver_bound(dev);\n",
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV bound device=%s driver=%s\", dev_name(dev), drv->name);\n",
+        "driver core bound",
+    )
+    text = insert_before_fragment(
+        text,
+        anchor,
+        "\tswitch (ret) {\n",
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV failed device=%s driver=%s ret=%d\",\n"
+        "\t\t\t     dev_name(dev), drv->name, ret);\n",
+        "driver core failure",
+    )
+    return text
+
+
+def instrument_qmp_v3(text: str) -> str:
+    text = add_include(
+        text,
+        '#include "phy-qcom-ufs-qmp-v3.h"\n',
+        "qmp v3 include",
+    )
+    init_anchor = "static int ufs_qcom_phy_qmp_v3_init(struct phy *generic_phy)\n"
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\tint err;\n",
+        "\n\ttgref_record(\"PHY init_begin device=%s\", dev_name(phy_common->dev));\n",
+        "qmp init begin",
+    )
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\terr = ufs_qcom_phy_init_clks(phy_common);\n",
+        "\ttgref_record(\"PHY init_clks ret=%d\", err);\n",
+        "qmp clocks",
+    )
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\terr = ufs_qcom_phy_init_vregulators(phy_common);\n",
+        "\ttgref_record(\"PHY init_vregs ret=%d\", err);\n",
+        "qmp vregs",
+    )
+    text = insert_before_last_return(
+        text,
+        init_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY init_end ret=%d\", err);\n",
+        "qmp init end",
+    )
+
+    cal_anchor = "int ufs_qcom_phy_qmp_v3_phy_calibrate("
+    text = insert_after_open(
+        text,
+        cal_anchor,
+        "\n\ttgref_record(\"PHY calibrate_begin rate_b=%d gear4=%d\", is_rate_B, is_g4);\n",
+        "qmp calibrate begin",
+    )
+    text = insert_before_last_return(
+        text,
+        cal_anchor,
+        "\treturn 0;\n",
+        "\ttgref_record(\"PHY calibrate_end lanes=%u\", ufs_qcom_phy->lanes_per_direction);\n",
+        "qmp calibrate end",
+    )
+
+    pcs_anchor = "static int ufs_qcom_phy_qmp_v3_is_pcs_ready("
+    text = insert_before_last_return(
+        text,
+        pcs_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY pcs_ready ret=%d val=0x%x\", err, val);\n",
+        "qmp pcs",
+    )
+
+    probe_anchor = "static int ufs_qcom_phy_qmp_v3_probe(struct platform_device *pdev)\n"
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        "\tint err = 0;\n",
+        "\n\ttgref_record(\"PHY probe_begin device=%s\", dev_name(dev));\n",
+        "qmp probe begin",
+    )
+    text = insert_before_fragment(
+        text,
+        probe_anchor,
+        "\tif (!generic_phy) {\n",
+        "\ttgref_record(\"PHY generic_probe pointer=%p\", generic_phy);\n",
+        "qmp generic probe",
+    )
+    text = insert_before_last_return(
+        text,
+        probe_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY probe_end device=%s ret=%d\", dev_name(dev), err);\n",
+        "qmp probe end",
+    )
+    return text
+
+
+def instrument_phy_common(text: str) -> str:
+    text = add_include(
+        text,
+        '#include "phy-qcom-ufs-i.h"\n',
+        "phy common include",
+    )
+
+    generic_anchor = "struct phy *ufs_qcom_phy_generic_probe("
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\tstruct phy_provider *phy_provider;\n",
+        "\n\ttgref_record(\"PHY generic_begin device=%s\", dev_name(dev));\n",
+        "phy generic begin",
+    )
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\terr = ufs_qcom_phy_base_init(pdev, common_cfg);\n",
+        "\ttgref_record(\"PHY base_init ret=%d mmio=%p\", err, common_cfg->mmio);\n",
+        "phy base",
+    )
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\tphy_provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);\n",
+        "\ttgref_record(\"PHY provider pointer=%p\", phy_provider);\n",
+        "phy provider",
+    )
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\tgeneric_phy = devm_phy_create(dev, NULL, ufs_qcom_phy_gen_ops);\n",
+        "\ttgref_record(\"PHY create pointer=%p\", generic_phy);\n",
+        "phy create",
+    )
+    text = insert_before_last_return(
+        text,
+        generic_anchor,
+        "\treturn generic_phy;\n",
+        "\ttgref_record(\"PHY generic_end device=%s phy=%p lanes=%u\",\n"
+        "\t\t     dev_name(dev), generic_phy, common_cfg->lanes_per_direction);\n",
+        "phy generic end",
+    )
+
+    clk_anchor = "static int __ufs_qcom_phy_clk_get("
+    text = insert_before_last_return(
+        text,
+        clk_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY clk_get name=%s ret=%d clk=%p\", name, err,\n"
+        "\t\t     err ? NULL : *clk_out);\n",
+        "phy clk get",
+    )
+
+    vreg_anchor = "static int ufs_qcom_phy_init_vreg("
+    text = insert_before_last_return(
+        text,
+        vreg_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY vreg_get name=%s ret=%d reg=%p\", name, err,\n"
+        "\t\t     err ? NULL : vreg->reg);\n",
+        "phy vreg get",
+    )
+    return text
+
+
+def instrument_ufs_qcom(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/clk/qcom.h>\n",
+        "ufs qcom include",
+    )
+
+    get_anchor = "static int ufs_qcom_host_clk_get("
+    text = insert_before_last_return(
+        text,
+        get_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"UFS host_clk_get name=%s ret=%d clk=%p\", name, err,\n"
+        "\t\t     err ? NULL : *clk_out);\n",
+        "ufs host clk get",
+    )
+    enable_anchor = "static int ufs_qcom_host_clk_enable("
+    text = insert_before_last_return(
+        text,
+        enable_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"UFS host_clk_enable name=%s ret=%d rate=%lu\", name,\n"
+        "\t\t     err, err ? 0UL : clk_get_rate(clk));\n",
+        "ufs host clk enable",
+    )
+
+    power_anchor = "static int ufs_qcom_power_up_sequence(struct ufs_hba *hba)\n"
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tint ret = 0;\n",
+        "\n\ttgref_record(\"UFS power_up_begin lanes=%u gear4=%d\",\n"
+        "\t\t     hba->lanes_per_direction, hba->phy_init_g4);\n",
+        "ufs power begin",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tufs_qcom_assert_reset(hba);\n",
+        "\ttgref_record(\"UFS phy_reset_asserted\");\n",
+        "ufs reset assert",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tret = ufs_qcom_phy_calibrate_phy(phy, is_rate_B, hba->phy_init_g4);\n",
+        "\ttgref_record(\"UFS phy_calibrate ret=%d rate_b=%d\", ret, is_rate_B);\n",
+        "ufs calibrate",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tufs_qcom_deassert_reset(hba);\n",
+        "\ttgref_record(\"UFS phy_reset_deasserted\");\n",
+        "ufs reset deassert",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tret = ufs_qcom_phy_start_serdes(phy);\n",
+        "\ttgref_record(\"UFS serdes_start ret=%d\", ret);\n",
+        "ufs serdes",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tret = ufs_qcom_phy_is_pcs_ready(phy);\n",
+        "\ttgref_record(\"UFS pcs_ready ret=%d\", ret);\n",
+        "ufs pcs",
+    )
+    text = insert_before_last_return(
+        text,
+        power_anchor,
+        "\treturn ret;\n",
+        "\ttgref_record(\"UFS power_up_end ret=%d\", ret);\n",
+        "ufs power end",
+    )
+
+    probe_anchor = "static int ufs_qcom_probe(struct platform_device *pdev)\n"
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        "\tstruct device_node *np = dev->of_node;\n",
+        "\n\ttgref_record(\"UFS probe_begin device=%s bootdevice=%s\",\n"
+        "\t\t     dev_name(dev), android_boot_dev);\n",
+        "ufs probe begin",
+    )
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        "\terr = ufshcd_pltfrm_init(pdev, &ufs_hba_qcom_variant);\n",
+        "\ttgref_record(\"UFS platform_init ret=%d\", err);\n",
+        "ufs platform init",
+    )
+    text = insert_before_last_return(
+        text,
+        probe_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"UFS probe_end device=%s ret=%d\", dev_name(dev), err);\n",
+        "ufs probe end",
+    )
+    return text
+
+
+def instrument_platform(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/of.h>\n",
+        "platform include",
+    )
+    anchor = "int ufshcd_pltfrm_init(struct platform_device *pdev,"
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tstruct device *dev = &pdev->dev;\n",
+        "\n\ttgref_record(\"PLT begin device=%s\", dev_name(dev));\n",
+        "platform begin",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tmmio_base = devm_ioremap_resource(dev, mem_res);\n",
+        "\ttgref_record(\"PLT mmio resource=%pR mapping=%p\", mem_res, mmio_base);\n",
+        "platform mmio",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tirq = platform_get_irq(pdev, 0);\n",
+        "\ttgref_record(\"PLT irq=%d\", irq);\n",
+        "platform irq",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\terr = ufshcd_alloc_host(dev, &hba);\n",
+        "\ttgref_record(\"PLT alloc_host ret=%d hba=%p\", err, err ? NULL : hba);\n",
+        "platform host",
+    )
+    for statement, marker, label in (
+        ("\terr = ufshcd_parse_clock_info(hba);\n", "parse_clocks", "platform clocks"),
+        ("\terr = ufshcd_parse_regulator_info(hba);\n", "parse_regulators", "platform regulators"),
+        ("\terr = ufshcd_parse_reset_info(hba);\n", "parse_reset", "platform reset"),
+        ("\terr = ufshcd_parse_pinctrl_info(hba);\n", "parse_pinctrl", "platform pinctrl"),
+        ("\terr = ufshcd_init(hba, mmio_base, irq);\n", "core_init", "platform core"),
+    ):
+        text = insert_after_fragment(
+            text,
+            anchor,
+            statement,
+            f'\ttgref_record("PLT {marker} ret=%d", err);\n',
+            label,
+        )
+    text = insert_before_last_return(
+        text,
+        anchor,
+        "\treturn 0;\n",
+        "\ttgref_record(\"PLT end ret=0 host_no=%d lanes=%u\",\n"
+        "\t\t     hba->host->host_no, hba->lanes_per_direction);\n",
+        "platform success",
+    )
+    text = insert_before_last_return(
+        text,
+        anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PLT fail ret=%d\", err);\n",
+        "platform fail",
+    )
+    return text
+
+
+def instrument_ufshcd(text: str) -> str:
+    text = add_include(
+        text,
+        '#include "ufshcd.h"\n',
+        "ufshcd include",
+    )
+
+    init_anchor = "int ufshcd_init(struct ufs_hba *hba,"
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\tstruct device *dev = hba->dev;\n",
+        "\n\ttgref_record(\"CORE init_begin dev=%s irq=%u mmio=%p host_no=%d\",\n"
+        "\t\t     dev_name(dev), irq, mmio_base, hba->host->host_no);\n",
+        "core init begin",
+    )
+    init_points = (
+        ("\terr = ufshcd_hba_init(hba);\n", "hba_init ret=%d", "err", "core hba init"),
+        ("\terr = ufshcd_hba_capabilities(hba);\n", "capabilities ret=%d cap=0x%x version=0x%x", "err, hba->capabilities, hba->ufs_version", "core capabilities"),
+        ("\terr = ufshcd_set_dma_mask(hba);\n", "dma_mask ret=%d", "err", "core dma"),
+        ("\terr = ufshcd_memory_alloc(hba);\n", "memory_alloc ret=%d", "err", "core memory"),
+        ("\terr = devm_request_irq(dev, irq, ufshcd_intr, IRQF_SHARED, UFSHCD, hba);\n", "request_irq ret=%d irq=%u", "err, irq", "core irq"),
+        ("\terr = scsi_add_host(host, hba->dev);\n", "scsi_add_host ret=%d host_no=%d", "err, host->host_no", "core scsi host"),
+        ("\terr = ufshcd_hba_enable(hba);\n", "hba_enable ret=%d state=%d hcs=0x%x", "err, hba->ufshcd_state, ufshcd_readl(hba, REG_CONTROLLER_STATUS)", "core hba enable"),
+        ("\tasync_schedule(ufshcd_async_scan, hba);\n", "async_scan_scheduled state=%d", "hba->ufshcd_state", "core async schedule"),
+    )
+    for statement, fmt, args, label in init_points:
+        text = insert_after_fragment(
+            text,
+            init_anchor,
+            statement,
+            f'\ttgref_record("CORE {fmt}", {args});\n',
+            label,
+        )
+
+    probe_anchor = "static int ufshcd_probe_hba("
+    probe_points = (
+        ("\tret = ufshcd_link_startup(hba);\n", "\t", "link_startup ret=%d state=%d link=%d", "ret, hba->ufshcd_state, hba->uic_link_state", "core link"),
+        ("\tret = ufshcd_verify_dev_init(hba);\n", "\t", "verify_dev_init ret=%d", "ret", "core verify"),
+        ("\tret = ufshcd_complete_dev_init(hba);\n", "\t", "complete_dev_init ret=%d", "ret", "core complete"),
+        ("\t\tret = ufshcd_device_params_init(hba);\n", "\t\t", "device_params ret=%d manufacturer=0x%x", "ret, hba->dev_info.wmanufacturerid", "core params"),
+        ("\t\tret = ufshcd_config_pwr_mode(hba, &hba->max_pwr_info.info);\n", "\t\t", "power_mode ret=%d rxgear=%d txgear=%d rxlane=%d txlane=%d", "ret, hba->max_pwr_info.info.gear_rx, hba->max_pwr_info.info.gear_tx, hba->max_pwr_info.info.lane_rx, hba->max_pwr_info.info.lane_tx", "core power"),
+        ("\t\tscsi_scan_host(hba->host);\n", "\t\t", "scsi_scan host_no=%d", "hba->host->host_no", "core scan"),
+    )
+    for statement, indent, fmt, args, label in probe_points:
+        text = insert_after_fragment(
+            text,
+            probe_anchor,
+            statement,
+            f'{indent}tgref_record("CORE {fmt}", {args});\n',
+            label,
+        )
+    text = insert_before_last_return(
+        text,
+        probe_anchor,
+        "\treturn ret;\n",
+        "\ttgref_record(\"CORE probe_hba_end ret=%d state=%d link=%d manufacturer=0x%x\",\n"
+        "\t\t     ret, hba->ufshcd_state, hba->uic_link_state,\n"
+        "\t\t     hba->dev_info.wmanufacturerid);\n",
+        "core probe end",
+    )
+    return text
+
+
+def instrument_sd(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/blkdev.h>\n",
+        "sd include",
+    )
+    probe_anchor = "static int sd_probe(struct device *dev)\n"
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        '\terror = sd_format_disk_name("sd", index, gd->disk_name, DISK_NAME_LEN);\n',
+        "\tif (!error && sdp->host->by_ufs)\n"
+        "\t\ttgref_record(\"SD probe lun=%llu name=%s host_no=%d\",\n"
+        "\t\t\t     (unsigned long long)sdp->lun, gd->disk_name,\n"
+        "\t\t\t     sdp->host->host_no);\n",
+        "sd probe",
+    )
+    async_anchor = "static void sd_probe_async(void *data, async_cookie_t cookie)\n"
+    text = insert_after_fragment(
+        text,
+        async_anchor,
+        "\tdevice_add_disk(dev, gd);\n",
+        "\tif (sdp->host->by_ufs)\n"
+        "\t\ttgref_record(\"SD add_disk name=%s capacity=%llu sectors host_no=%d\",\n"
+        "\t\t\t     gd->disk_name, (unsigned long long)get_capacity(gd),\n"
+        "\t\t\t     sdp->host->host_no);\n",
+        "sd add disk",
+    )
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Stage targeted TouchGrass 4.19.206 UFS reference recorder"
+    )
+    parser.add_argument("--kernel", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    kernel = args.kernel.resolve()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        "drivers/base/dd.c": instrument_driver_core,
+        "drivers/phy/qualcomm/phy-qcom-ufs-qmp-v3.c": instrument_qmp_v3,
+        "drivers/phy/qualcomm/phy-qcom-ufs.c": instrument_phy_common,
+        "drivers/scsi/ufs/ufs-qcom.c": instrument_ufs_qcom,
+        "drivers/scsi/ufs/ufshcd-pltfrm.c": instrument_platform,
+        "drivers/scsi/ufs/ufshcd.c": instrument_ufshcd,
+        "drivers/scsi/sd.c": instrument_sd,
+    }
+
+    for rel, fn in files.items():
+        path = kernel / rel
+        if not path.is_file():
+            fail(rel, "source file missing")
+        original = path.read_text(encoding="utf-8")
+        patched = fn(original)
+        if patched == original:
+            fail(rel, "instrumentation produced no change")
+        path.write_text(patched, encoding="utf-8")
+
+    header_path = kernel / "include/linux/tgref_recorder.h"
+    source_path = kernel / "drivers/scsi/ufs/tgref-recorder.c"
+    makefile_path = kernel / "drivers/scsi/ufs/Makefile"
+    header_path.write_text(HEADER, encoding="utf-8")
+    source_path.write_text(SOURCE, encoding="utf-8")
+
+    makefile = makefile_path.read_text(encoding="utf-8")
+    marker = "# A52 TouchGrass UFS reference recorder"
+    if marker in makefile or "tgref-recorder.o" in makefile:
+        fail("Makefile", "recorder already linked")
+    makefile_path.write_text(
+        makefile.rstrip() + f"\n\n{marker}\nobj-y += tgref-recorder.o\n",
+        encoding="utf-8",
+    )
+
+    checks = {
+        "recorder_source": source_path.is_file(),
+        "recorder_header": header_path.is_file(),
+        "automatic_dump_marker": "/data/local/tmp/tgref_ufs.log" in SOURCE,
+        "no_kernel_root_integration": "KSU" not in SOURCE and "KernelSU" not in SOURCE,
+        "driver_core_trace": "DEV call device=%s driver=%s" in (kernel / "drivers/base/dd.c").read_text(),
+        "phy_trace": "PHY probe_begin" in (kernel / "drivers/phy/qualcomm/phy-qcom-ufs-qmp-v3.c").read_text(),
+        "qcom_trace": "UFS power_up_begin" in (kernel / "drivers/scsi/ufs/ufs-qcom.c").read_text(),
+        "platform_trace": "PLT parse_clocks" in (kernel / "drivers/scsi/ufs/ufshcd-pltfrm.c").read_text(),
+        "core_trace": "CORE link_startup" in (kernel / "drivers/scsi/ufs/ufshcd.c").read_text(),
+        "disk_trace": "SD add_disk" in (kernel / "drivers/scsi/sd.c").read_text(),
+        "makefile_link": "obj-y += tgref-recorder.o" in makefile_path.read_text(),
+    }
+    failed = [name for name, passed in checks.items() if not passed]
+    if failed:
+        fail("staging audit", ", ".join(failed))
+
+    (output / "tgref-recorder.c").write_text(SOURCE, encoding="utf-8")
+    (output / "tgref_recorder.h").write_text(HEADER, encoding="utf-8")
+    (output / "stage-report.json").write_text(
+        json.dumps(
+            {
+                "status": "staged",
+                "kernel": "touchGrass Linux 4.19.206",
+                "scope": [
+                    "driver bind/defer",
+                    "QMP-v3 UFS PHY",
+                    "Qualcomm UFS host",
+                    "platform resources",
+                    "UFS core link startup",
+                    "SCSI disk registration",
+                ],
+                "automatic_dump": {
+                    "path": "/data/local/tmp/tgref_ufs.log",
+                    "poll_interval_ms": 5000,
+                    "settle_after_data_ms": 30000,
+                    "requires_android_root": False,
+                },
+                "checks": checks,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/96_stage_touchgrass_ufs_reference_recorder.py
+++ b/scripts/96_stage_touchgrass_ufs_reference_recorder.py
@@ -1,747 +1,76 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import argparse
-import json
+import hashlib
+import re
+import types
+import urllib.request
 from pathlib import Path
 
-
-HEADER = r'''#ifndef _LINUX_TGREF_RECORDER_H
-#define _LINUX_TGREF_RECORDER_H
-
-#include <linux/compiler.h>
-
-void tgref_record(const char *fmt, ...) __printf(1, 2);
-
-#endif
-'''
-
-SOURCE = r'''// SPDX-License-Identifier: GPL-2.0
-/*
- * A52 TouchGrass UFS reference recorder.
- *
- * Diagnostic-only helper for the known-good Linux 4.19.206 boot. UFS bring-up
- * breadcrumbs are kept in a small in-kernel text buffer and copied once to
- * /data/local/tmp/tgref_ufs.log after Android has mounted /data.
- */
-#include <linux/delay.h>
-#include <linux/err.h>
-#include <linux/fs.h>
-#include <linux/init.h>
-#include <linux/kernel.h>
-#include <linux/kthread.h>
-#include <linux/module.h>
-#include <linux/namei.h>
-#include <linux/printk.h>
-#include <linux/sizes.h>
-#include <linux/slab.h>
-#include <linux/spinlock.h>
-#include <linux/timekeeping.h>
-#include <linux/uaccess.h>
-#include <linux/vmalloc.h>
-
-#include <linux/tgref_recorder.h>
-
-#define TGREF_BUFFER_SIZE SZ_128K
-#define TGREF_LINE_SIZE 384
-#define TGREF_DUMP_PATH "/data/local/tmp/tgref_ufs.log"
-#define TGREF_DATA_DIR "/data/local/tmp"
-#define TGREF_POLL_MS 5000
-#define TGREF_SETTLE_MS 30000
-#define TGREF_MAX_POLLS 120
-
-static char tgref_buffer[TGREF_BUFFER_SIZE];
-static size_t tgref_length;
-static unsigned int tgref_dropped;
-static DEFINE_SPINLOCK(tgref_lock);
-
-void tgref_record(const char *fmt, ...)
-{
-	char line[TGREF_LINE_SIZE];
-	unsigned long flags;
-	u64 ns;
-	va_list args;
-	int prefix;
-	int body;
-	int total;
-
-	ns = ktime_get_ns();
-	prefix = scnprintf(line, sizeof(line), "TGREF %llu.%06llu ",
-			   (unsigned long long)(ns / NSEC_PER_SEC),
-			   (unsigned long long)((ns % NSEC_PER_SEC) / NSEC_PER_USEC));
-
-	va_start(args, fmt);
-	body = vscnprintf(line + prefix, sizeof(line) - prefix, fmt, args);
-	va_end(args);
-
-	total = prefix + body;
-	if (total <= 0)
-		return;
-	if (line[total - 1] != '\n' && total < sizeof(line) - 1)
-		line[total++] = '\n';
-	line[total] = '\0';
-
-	spin_lock_irqsave(&tgref_lock, flags);
-	if (tgref_length + total <= sizeof(tgref_buffer)) {
-		memcpy(tgref_buffer + tgref_length, line, total);
-		tgref_length += total;
-	} else {
-		tgref_dropped++;
-	}
-	spin_unlock_irqrestore(&tgref_lock, flags);
-
-	printk(KERN_INFO "%s", line);
-}
-EXPORT_SYMBOL_GPL(tgref_record);
-
-static int tgref_snapshot(char **out, size_t *out_len)
-{
-	unsigned long flags;
-	char *snapshot;
-	size_t len;
-	unsigned int dropped;
-	int header;
-
-	snapshot = vmalloc(TGREF_BUFFER_SIZE + 128);
-	if (!snapshot)
-		return -ENOMEM;
-
-	spin_lock_irqsave(&tgref_lock, flags);
-	len = tgref_length;
-	dropped = tgref_dropped;
-	memcpy(snapshot + 128, tgref_buffer, len);
-	spin_unlock_irqrestore(&tgref_lock, flags);
-
-	header = scnprintf(snapshot, 128,
-			   "TGREF reference=touchGrass-4.19.206 bytes=%zu dropped=%u\n",
-			   len, dropped);
-	memmove(snapshot + header, snapshot + 128, len);
-	*out = snapshot;
-	*out_len = header + len;
-	return 0;
-}
-
-static int tgref_write_snapshot(void)
-{
-	struct file *file;
-	char *snapshot;
-	size_t length;
-	size_t written = 0;
-	loff_t pos = 0;
-	int ret;
-
-	ret = tgref_snapshot(&snapshot, &length);
-	if (ret)
-		return ret;
-
-	file = filp_open(TGREF_DUMP_PATH,
-			 O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE, 0644);
-	if (IS_ERR(file)) {
-		ret = PTR_ERR(file);
-		vfree(snapshot);
-		return ret;
-	}
-
-	while (written < length) {
-		ssize_t step = kernel_write(file, snapshot + written,
-					    length - written, &pos);
-		if (step < 0) {
-			ret = step;
-			goto out;
-		}
-		if (!step) {
-			ret = -EIO;
-			goto out;
-		}
-		written += step;
-	}
-
-	ret = vfs_fsync(file, 0);
-out:
-	filp_close(file, NULL);
-	vfree(snapshot);
-	return ret;
-}
-
-static int tgref_dump_thread(void *unused)
-{
-	struct path path;
-	int poll;
-	int ret = -ENOENT;
-
-	tgref_record("DUMPER armed path=%s", TGREF_DUMP_PATH);
-
-	for (poll = 0; poll < TGREF_MAX_POLLS && !kthread_should_stop(); poll++) {
-		ret = kern_path(TGREF_DATA_DIR,
-				LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &path);
-		if (!ret) {
-			path_put(&path);
-			tgref_record("DUMPER data_ready poll=%d settle_ms=%d",
-				     poll, TGREF_SETTLE_MS);
-			msleep(TGREF_SETTLE_MS);
-			ret = tgref_write_snapshot();
-			if (!ret) {
-				printk(KERN_INFO
-				       "TGREF DUMPER saved %s\n", TGREF_DUMP_PATH);
-				return 0;
-			}
-			tgref_record("DUMPER write_failed ret=%d retrying", ret);
-		}
-		msleep(TGREF_POLL_MS);
-	}
-
-	tgref_record("DUMPER gave_up ret=%d polls=%d", ret, poll);
-	return ret;
-}
-
-static int __init tgref_recorder_init(void)
-{
-	struct task_struct *task;
-
-	tgref_record("RECORDER ready buffer=%u dump=%s",
-		     (unsigned int)TGREF_BUFFER_SIZE, TGREF_DUMP_PATH);
-	task = kthread_run(tgref_dump_thread, NULL, "tgref_ufs_dump");
-	if (IS_ERR(task)) {
-		int ret = PTR_ERR(task);
-
-		tgref_record("DUMPER thread_start_failed ret=%d", ret);
-		return 0;
-	}
-	return 0;
-}
-late_initcall(tgref_recorder_init);
-
-MODULE_DESCRIPTION("A52 TouchGrass UFS reference recorder and automatic dumper");
-MODULE_LICENSE("GPL v2");
-'''
+BASE_NAME = "96_stage_touchgrass_ufs_reference_recorder_base.py"
+BASE_BLOB_SHA = "558ce3449a6f25266a7745e0b78a947a1764ce15"
+BASE_URL = (
+    "https://raw.githubusercontent.com/"
+    "GiulianoB-1/A52-touchGrass-4.19.325-SukiSU/"
+    "0ceebb36610bed004f5f08c2e63465777dee3809/"
+    "scripts/96_stage_touchgrass_ufs_reference_recorder_base.py"
+)
 
 
-def fail(label: str, detail: str) -> None:
-    raise SystemExit(f"{label}: {detail}")
+def git_blob_sha(data: bytes) -> str:
+    header = f"blob {len(data)}\0".encode()
+    return hashlib.sha1(header + data).hexdigest()
 
 
-def function_bounds(text: str, anchor: str, label: str) -> tuple[int, int, int]:
-    search = 0
-    while True:
-        start = text.find(anchor, search)
-        if start < 0:
-            fail(label, f"function anchor not found: {anchor}")
-        brace = text.find("{", start)
-        semicolon = text.find(";", start)
-        if brace >= 0 and (semicolon < 0 or brace < semicolon):
-            break
-        search = start + len(anchor)
+def load_base() -> types.ModuleType:
+    local = Path(__file__).with_name(BASE_NAME)
+    if local.is_file():
+        data = local.read_bytes()
+        origin = str(local)
+    else:
+        with urllib.request.urlopen(BASE_URL, timeout=30) as response:
+            data = response.read()
+        origin = BASE_URL
 
-    depth = 0
-    for pos in range(brace, len(text)):
-        ch = text[pos]
-        if ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth -= 1
-            if depth == 0:
-                return start, brace, pos + 1
-    fail(label, "closing brace not found")
+    actual = git_blob_sha(data)
+    if actual != BASE_BLOB_SHA:
+        raise SystemExit(
+            f"recorder base integrity failure: expected {BASE_BLOB_SHA}, got {actual}"
+        )
+
+    module = types.ModuleType("touchgrass_recorder_stage_base")
+    module.__file__ = origin
+    exec(compile(data, origin, "exec"), module.__dict__)
+    return module
 
 
-def add_include(text: str, anchor: str, label: str) -> str:
-    include = "#include <linux/tgref_recorder.h>\n"
-    if include in text:
-        fail(label, "recorder include already present")
-    count = text.count(anchor)
-    if count != 1:
-        fail(label, f"expected one include anchor, found {count}")
-    return text.replace(anchor, anchor + include, 1)
+_impl = load_base()
 
 
-def insert_after_fragment(
-    text: str, function_anchor: str, fragment: str, insertion: str, label: str
-) -> str:
-    start, _, end = function_bounds(text, function_anchor, label)
-    positions: list[int] = []
-    cursor = start
-    while True:
-        pos = text.find(fragment, cursor, end)
-        if pos < 0:
-            break
-        positions.append(pos)
-        cursor = pos + len(fragment)
-    if len(positions) != 1:
-        fail(label, f"expected one fragment in function, found {len(positions)}")
-    point = positions[0] + len(fragment)
-    return text[:point] + insertion + text[point:]
-
-
-def insert_before_fragment(
-    text: str, function_anchor: str, fragment: str, insertion: str, label: str
-) -> str:
-    start, _, end = function_bounds(text, function_anchor, label)
-    positions: list[int] = []
-    cursor = start
-    while True:
-        pos = text.find(fragment, cursor, end)
-        if pos < 0:
-            break
-        positions.append(pos)
-        cursor = pos + len(fragment)
-    if len(positions) != 1:
-        fail(label, f"expected one fragment in function, found {len(positions)}")
-    point = positions[0]
-    return text[:point] + insertion + text[point:]
-
-
-def insert_after_open(
-    text: str, function_anchor: str, insertion: str, label: str
-) -> str:
-    _, brace, _ = function_bounds(text, function_anchor, label)
-    return text[: brace + 1] + insertion + text[brace + 1 :]
-
-
-def insert_before_last_return(
-    text: str, function_anchor: str, return_fragment: str, insertion: str, label: str
-) -> str:
-    start, _, end = function_bounds(text, function_anchor, label)
-    pos = text.rfind(return_fragment, start, end)
-    if pos < 0:
-        fail(label, "return fragment not found")
-    return text[:pos] + insertion + text[pos:]
-
-
-def replace_in_function(
+def insert_after_regex(
     text: str,
     function_anchor: str,
-    old: str,
-    new: str,
+    pattern: str,
+    insertion: str,
     label: str,
 ) -> str:
-    start, _, end = function_bounds(text, function_anchor, label)
-    count = text.count(old, start, end)
-    if count != 1:
-        fail(label, f"expected one replacement target in function, found {count}")
-    pos = text.find(old, start, end)
-    return text[:pos] + new + text[pos + len(old) :]
-
-
-def instrument_driver_core(text: str) -> str:
-    text = add_include(
-        text,
-        "#include <linux/pinctrl/devinfo.h>\n",
-        "driver core include",
-    )
-    helper = r'''
-static bool tgref_relevant_probe(struct device *dev, struct device_driver *drv)
-{
-	const char *device = dev_name(dev);
-	const char *driver = drv ? drv->name : "";
-
-	return strstr(device, "1d84000") || strstr(device, "1d87000") ||
-	       strstr(driver, "ufshcd-qcom") ||
-	       strstr(driver, "ufs_qcom_phy_qmp_v3");
-}
-
-'''
-    anchor = "static int really_probe(struct device *dev, struct device_driver *drv)\n"
-    if text.count(anchor) != 1:
-        fail("driver core helper", "really_probe anchor count is not one")
-    text = text.replace(anchor, helper + anchor, 1)
-
-    decl = (
-        "\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n"
-        "\t\t\t   !drv->suppress_bind_attrs;\n"
-    )
-    text = insert_after_fragment(
-        text,
-        anchor,
-        decl,
-        "\tbool tgref_match = tgref_relevant_probe(dev, drv);\n\n"
-        "\tif (tgref_match)\n"
-        "\t\ttgref_record(\"DEV call device=%s driver=%s\", dev_name(dev), drv->name);\n",
-        "driver core call",
-    )
-
-    suppliers = (
-        "\tret = device_links_check_suppliers(dev);\n"
-        "\tif (ret == -EPROBE_DEFER)\n"
-        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n"
-        "\tif (ret)\n"
-        "\t\treturn ret;\n"
-    )
-    suppliers_new = (
-        "\tret = device_links_check_suppliers(dev);\n"
-        "\tif (ret == -EPROBE_DEFER)\n"
-        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n"
-        "\tif (ret) {\n"
-        "\t\tif (tgref_match)\n"
-        "\t\t\ttgref_record(\"DEV suppliers device=%s driver=%s ret=%d\",\n"
-        "\t\t\t\t     dev_name(dev), drv->name, ret);\n"
-        "\t\treturn ret;\n"
-        "\t}\n"
-    )
-    text = replace_in_function(
-        text, anchor, suppliers, suppliers_new, "driver core suppliers"
-    )
-
-    text = insert_before_fragment(
-        text,
-        anchor,
-        "\tif (test_remove) {\n",
-        "\tif (tgref_match)\n"
-        "\t\ttgref_record(\"DEV probe_return device=%s driver=%s ret=%d\",\n"
-        "\t\t\t     dev_name(dev), drv->name, ret);\n",
-        "driver core probe return",
-    )
-    text = insert_after_fragment(
-        text,
-        anchor,
-        "\tdriver_bound(dev);\n",
-        "\tif (tgref_match)\n"
-        "\t\ttgref_record(\"DEV bound device=%s driver=%s\", dev_name(dev), drv->name);\n",
-        "driver core bound",
-    )
-    text = insert_before_fragment(
-        text,
-        anchor,
-        "\tswitch (ret) {\n",
-        "\tif (tgref_match)\n"
-        "\t\ttgref_record(\"DEV failed device=%s driver=%s ret=%d\",\n"
-        "\t\t\t     dev_name(dev), drv->name, ret);\n",
-        "driver core failure",
-    )
-    return text
-
-
-def instrument_qmp_v3(text: str) -> str:
-    text = add_include(
-        text,
-        '#include "phy-qcom-ufs-qmp-v3.h"\n',
-        "qmp v3 include",
-    )
-    init_anchor = "static int ufs_qcom_phy_qmp_v3_init(struct phy *generic_phy)\n"
-    text = insert_after_fragment(
-        text,
-        init_anchor,
-        "\tint err;\n",
-        "\n\ttgref_record(\"PHY init_begin device=%s\", dev_name(phy_common->dev));\n",
-        "qmp init begin",
-    )
-    text = insert_after_fragment(
-        text,
-        init_anchor,
-        "\terr = ufs_qcom_phy_init_clks(phy_common);\n",
-        "\ttgref_record(\"PHY init_clks ret=%d\", err);\n",
-        "qmp clocks",
-    )
-    text = insert_after_fragment(
-        text,
-        init_anchor,
-        "\terr = ufs_qcom_phy_init_vregulators(phy_common);\n",
-        "\ttgref_record(\"PHY init_vregs ret=%d\", err);\n",
-        "qmp vregs",
-    )
-    text = insert_before_last_return(
-        text,
-        init_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"PHY init_end ret=%d\", err);\n",
-        "qmp init end",
-    )
-
-    cal_anchor = "int ufs_qcom_phy_qmp_v3_phy_calibrate("
-    text = insert_after_open(
-        text,
-        cal_anchor,
-        "\n\ttgref_record(\"PHY calibrate_begin rate_b=%d gear4=%d\", is_rate_B, is_g4);\n",
-        "qmp calibrate begin",
-    )
-    text = insert_before_last_return(
-        text,
-        cal_anchor,
-        "\treturn 0;\n",
-        "\ttgref_record(\"PHY calibrate_end lanes=%u\", ufs_qcom_phy->lanes_per_direction);\n",
-        "qmp calibrate end",
-    )
-
-    pcs_anchor = "static int ufs_qcom_phy_qmp_v3_is_pcs_ready("
-    text = insert_before_last_return(
-        text,
-        pcs_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"PHY pcs_ready ret=%d val=0x%x\", err, val);\n",
-        "qmp pcs",
-    )
-
-    probe_anchor = "static int ufs_qcom_phy_qmp_v3_probe(struct platform_device *pdev)\n"
-    text = insert_after_fragment(
-        text,
-        probe_anchor,
-        "\tint err = 0;\n",
-        "\n\ttgref_record(\"PHY probe_begin device=%s\", dev_name(dev));\n",
-        "qmp probe begin",
-    )
-    text = insert_before_fragment(
-        text,
-        probe_anchor,
-        "\tif (!generic_phy) {\n",
-        "\ttgref_record(\"PHY generic_probe pointer=%p\", generic_phy);\n",
-        "qmp generic probe",
-    )
-    text = insert_before_last_return(
-        text,
-        probe_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"PHY probe_end device=%s ret=%d\", dev_name(dev), err);\n",
-        "qmp probe end",
-    )
-    return text
-
-
-def instrument_phy_common(text: str) -> str:
-    text = add_include(
-        text,
-        '#include "phy-qcom-ufs-i.h"\n',
-        "phy common include",
-    )
-
-    generic_anchor = "struct phy *ufs_qcom_phy_generic_probe("
-    text = insert_after_fragment(
-        text,
-        generic_anchor,
-        "\tstruct phy_provider *phy_provider;\n",
-        "\n\ttgref_record(\"PHY generic_begin device=%s\", dev_name(dev));\n",
-        "phy generic begin",
-    )
-    text = insert_after_fragment(
-        text,
-        generic_anchor,
-        "\terr = ufs_qcom_phy_base_init(pdev, common_cfg);\n",
-        "\ttgref_record(\"PHY base_init ret=%d mmio=%p\", err, common_cfg->mmio);\n",
-        "phy base",
-    )
-    text = insert_after_fragment(
-        text,
-        generic_anchor,
-        "\tphy_provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);\n",
-        "\ttgref_record(\"PHY provider pointer=%p\", phy_provider);\n",
-        "phy provider",
-    )
-    text = insert_after_fragment(
-        text,
-        generic_anchor,
-        "\tgeneric_phy = devm_phy_create(dev, NULL, ufs_qcom_phy_gen_ops);\n",
-        "\ttgref_record(\"PHY create pointer=%p\", generic_phy);\n",
-        "phy create",
-    )
-    text = insert_before_last_return(
-        text,
-        generic_anchor,
-        "\treturn generic_phy;\n",
-        "\ttgref_record(\"PHY generic_end device=%s phy=%p lanes=%u\",\n"
-        "\t\t     dev_name(dev), generic_phy, common_cfg->lanes_per_direction);\n",
-        "phy generic end",
-    )
-
-    clk_anchor = "static int __ufs_qcom_phy_clk_get("
-    text = insert_before_last_return(
-        text,
-        clk_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"PHY clk_get name=%s ret=%d clk=%p\", name, err,\n"
-        "\t\t     err ? NULL : *clk_out);\n",
-        "phy clk get",
-    )
-
-    vreg_anchor = "static int ufs_qcom_phy_init_vreg("
-    text = insert_before_last_return(
-        text,
-        vreg_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"PHY vreg_get name=%s ret=%d reg=%p\", name, err,\n"
-        "\t\t     err ? NULL : vreg->reg);\n",
-        "phy vreg get",
-    )
-    return text
-
-
-def instrument_ufs_qcom(text: str) -> str:
-    text = add_include(
-        text,
-        "#include <linux/clk/qcom.h>\n",
-        "ufs qcom include",
-    )
-
-    get_anchor = "static int ufs_qcom_host_clk_get("
-    text = insert_before_last_return(
-        text,
-        get_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"UFS host_clk_get name=%s ret=%d clk=%p\", name, err,\n"
-        "\t\t     err ? NULL : *clk_out);\n",
-        "ufs host clk get",
-    )
-    enable_anchor = "static int ufs_qcom_host_clk_enable("
-    text = insert_before_last_return(
-        text,
-        enable_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"UFS host_clk_enable name=%s ret=%d rate=%lu\", name,\n"
-        "\t\t     err, err ? 0UL : clk_get_rate(clk));\n",
-        "ufs host clk enable",
-    )
-
-    power_anchor = "static int ufs_qcom_power_up_sequence(struct ufs_hba *hba)\n"
-    text = insert_after_fragment(
-        text,
-        power_anchor,
-        "\tint ret = 0;\n",
-        "\n\ttgref_record(\"UFS power_up_begin lanes=%u gear4=%d\",\n"
-        "\t\t     hba->lanes_per_direction, hba->phy_init_g4);\n",
-        "ufs power begin",
-    )
-    text = insert_after_fragment(
-        text,
-        power_anchor,
-        "\tufs_qcom_assert_reset(hba);\n",
-        "\ttgref_record(\"UFS phy_reset_asserted\");\n",
-        "ufs reset assert",
-    )
-    text = insert_after_fragment(
-        text,
-        power_anchor,
-        "\tret = ufs_qcom_phy_calibrate_phy(phy, is_rate_B, hba->phy_init_g4);\n",
-        "\ttgref_record(\"UFS phy_calibrate ret=%d rate_b=%d\", ret, is_rate_B);\n",
-        "ufs calibrate",
-    )
-    text = insert_after_fragment(
-        text,
-        power_anchor,
-        "\tufs_qcom_deassert_reset(hba);\n",
-        "\ttgref_record(\"UFS phy_reset_deasserted\");\n",
-        "ufs reset deassert",
-    )
-    text = insert_after_fragment(
-        text,
-        power_anchor,
-        "\tret = ufs_qcom_phy_start_serdes(phy);\n",
-        "\ttgref_record(\"UFS serdes_start ret=%d\", ret);\n",
-        "ufs serdes",
-    )
-    text = insert_after_fragment(
-        text,
-        power_anchor,
-        "\tret = ufs_qcom_phy_is_pcs_ready(phy);\n",
-        "\ttgref_record(\"UFS pcs_ready ret=%d\", ret);\n",
-        "ufs pcs",
-    )
-    text = insert_before_last_return(
-        text,
-        power_anchor,
-        "\treturn ret;\n",
-        "\ttgref_record(\"UFS power_up_end ret=%d\", ret);\n",
-        "ufs power end",
-    )
-
-    probe_anchor = "static int ufs_qcom_probe(struct platform_device *pdev)\n"
-    text = insert_after_fragment(
-        text,
-        probe_anchor,
-        "\tstruct device_node *np = dev->of_node;\n",
-        "\n\ttgref_record(\"UFS probe_begin device=%s bootdevice=%s\",\n"
-        "\t\t     dev_name(dev), android_boot_dev);\n",
-        "ufs probe begin",
-    )
-    text = insert_after_fragment(
-        text,
-        probe_anchor,
-        "\terr = ufshcd_pltfrm_init(pdev, &ufs_hba_qcom_variant);\n",
-        "\ttgref_record(\"UFS platform_init ret=%d\", err);\n",
-        "ufs platform init",
-    )
-    text = insert_before_last_return(
-        text,
-        probe_anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"UFS probe_end device=%s ret=%d\", dev_name(dev), err);\n",
-        "ufs probe end",
-    )
-    return text
-
-
-def instrument_platform(text: str) -> str:
-    text = add_include(
-        text,
-        "#include <linux/of.h>\n",
-        "platform include",
-    )
-    anchor = "int ufshcd_pltfrm_init(struct platform_device *pdev,"
-    text = insert_after_fragment(
-        text,
-        anchor,
-        "\tstruct device *dev = &pdev->dev;\n",
-        "\n\ttgref_record(\"PLT begin device=%s\", dev_name(dev));\n",
-        "platform begin",
-    )
-    text = insert_after_fragment(
-        text,
-        anchor,
-        "\tmmio_base = devm_ioremap_resource(dev, mem_res);\n",
-        "\ttgref_record(\"PLT mmio resource=%pR mapping=%p\", mem_res, mmio_base);\n",
-        "platform mmio",
-    )
-    text = insert_after_fragment(
-        text,
-        anchor,
-        "\tirq = platform_get_irq(pdev, 0);\n",
-        "\ttgref_record(\"PLT irq=%d\", irq);\n",
-        "platform irq",
-    )
-    text = insert_after_fragment(
-        text,
-        anchor,
-        "\terr = ufshcd_alloc_host(dev, &hba);\n",
-        "\ttgref_record(\"PLT alloc_host ret=%d hba=%p\", err, err ? NULL : hba);\n",
-        "platform host",
-    )
-    for statement, marker, label in (
-        ("\terr = ufshcd_parse_clock_info(hba);\n", "parse_clocks", "platform clocks"),
-        ("\terr = ufshcd_parse_regulator_info(hba);\n", "parse_regulators", "platform regulators"),
-        ("\terr = ufshcd_parse_reset_info(hba);\n", "parse_reset", "platform reset"),
-        ("\terr = ufshcd_parse_pinctrl_info(hba);\n", "parse_pinctrl", "platform pinctrl"),
-        ("\terr = ufshcd_init(hba, mmio_base, irq);\n", "core_init", "platform core"),
-    ):
-        text = insert_after_fragment(
-            text,
-            anchor,
-            statement,
-            f'\ttgref_record("PLT {marker} ret=%d", err);\n',
-            label,
-        )
-    text = insert_before_last_return(
-        text,
-        anchor,
-        "\treturn 0;\n",
-        "\ttgref_record(\"PLT end ret=0 host_no=%d lanes=%u\",\n"
-        "\t\t     hba->host->host_no, hba->lanes_per_direction);\n",
-        "platform success",
-    )
-    text = insert_before_last_return(
-        text,
-        anchor,
-        "\treturn err;\n",
-        "\ttgref_record(\"PLT fail ret=%d\", err);\n",
-        "platform fail",
-    )
-    return text
+    start, _, end = _impl.function_bounds(text, function_anchor, label)
+    matches = list(re.finditer(pattern, text[start:end], flags=re.MULTILINE))
+    if len(matches) != 1:
+        _impl.fail(label, f"expected one regex target in function, found {len(matches)}")
+    point = start + matches[0].end()
+    return text[:point] + insertion + text[point:]
 
 
 def instrument_ufshcd(text: str) -> str:
-    text = add_include(
+    text = _impl.add_include(
         text,
         '#include "ufshcd.h"\n',
         "ufshcd include",
     )
 
     init_anchor = "int ufshcd_init(struct ufs_hba *hba,"
-    text = insert_after_fragment(
+    text = _impl.insert_after_fragment(
         text,
         init_anchor,
         "\tstruct device *dev = hba->dev;\n",
@@ -749,18 +78,63 @@ def instrument_ufshcd(text: str) -> str:
         "\t\t     dev_name(dev), irq, mmio_base, hba->host->host_no);\n",
         "core init begin",
     )
-    init_points = (
-        ("\terr = ufshcd_hba_init(hba);\n", "hba_init ret=%d", "err", "core hba init"),
-        ("\terr = ufshcd_hba_capabilities(hba);\n", "capabilities ret=%d cap=0x%x version=0x%x", "err, hba->capabilities, hba->ufs_version", "core capabilities"),
-        ("\terr = ufshcd_set_dma_mask(hba);\n", "dma_mask ret=%d", "err", "core dma"),
-        ("\terr = ufshcd_memory_alloc(hba);\n", "memory_alloc ret=%d", "err", "core memory"),
-        ("\terr = devm_request_irq(dev, irq, ufshcd_intr, IRQF_SHARED, UFSHCD, hba);\n", "request_irq ret=%d irq=%u", "err, irq", "core irq"),
-        ("\terr = scsi_add_host(host, hba->dev);\n", "scsi_add_host ret=%d host_no=%d", "err, host->host_no", "core scsi host"),
-        ("\terr = ufshcd_hba_enable(hba);\n", "hba_enable ret=%d state=%d hcs=0x%x", "err, hba->ufshcd_state, ufshcd_readl(hba, REG_CONTROLLER_STATUS)", "core hba enable"),
-        ("\tasync_schedule(ufshcd_async_scan, hba);\n", "async_scan_scheduled state=%d", "hba->ufshcd_state", "core async schedule"),
+
+    text = _impl.insert_after_fragment(
+        text,
+        init_anchor,
+        "\terr = ufshcd_hba_init(hba);\n",
+        "\ttgref_record(\"CORE hba_init ret=%d\", err);\n",
+        "core hba init",
     )
-    for statement, fmt, args, label in init_points:
-        text = insert_after_fragment(
+    text = _impl.insert_after_fragment(
+        text,
+        init_anchor,
+        "\tufshcd_hba_capabilities(hba);\n",
+        "\ttgref_record(\"CORE capabilities cap=0x%x nutrs=%d nutmrs=%d\",\n"
+        "\t\t     hba->capabilities, hba->nutrs, hba->nutmrs);\n",
+        "core capabilities",
+    )
+    text = _impl.insert_after_fragment(
+        text,
+        init_anchor,
+        "\thba->ufs_version = ufshcd_get_ufs_version(hba);\n",
+        "\ttgref_record(\"CORE version value=0x%x\", hba->ufs_version);\n",
+        "core version",
+    )
+
+    for statement, fmt, args, label in (
+        (
+            "\terr = ufshcd_set_dma_mask(hba);\n",
+            "dma_mask ret=%d",
+            "err",
+            "core dma",
+        ),
+        (
+            "\terr = ufshcd_memory_alloc(hba);\n",
+            "memory_alloc ret=%d",
+            "err",
+            "core memory",
+        ),
+        (
+            "\terr = scsi_add_host(host, hba->dev);\n",
+            "scsi_add_host ret=%d host_no=%d",
+            "err, host->host_no",
+            "core scsi host",
+        ),
+        (
+            "\terr = ufshcd_hba_enable(hba);\n",
+            "hba_enable ret=%d state=%d hcs=0x%x",
+            "err, hba->ufshcd_state, ufshcd_readl(hba, REG_CONTROLLER_STATUS)",
+            "core hba enable",
+        ),
+        (
+            "\tasync_schedule(ufshcd_async_scan, hba);\n",
+            "async_scan_scheduled state=%d",
+            "hba->ufshcd_state",
+            "core async schedule",
+        ),
+    ):
+        text = _impl.insert_after_fragment(
             text,
             init_anchor,
             statement,
@@ -768,161 +142,86 @@ def instrument_ufshcd(text: str) -> str:
             label,
         )
 
+    text = insert_after_regex(
+        text,
+        init_anchor,
+        r"\terr\s*=\s*devm_request_irq\(dev,\s*irq,\s*ufshcd_intr,\s*IRQF_SHARED,\s*\n"
+        r"\s*dev_name\(dev\),\s*hba\);\n",
+        "\ttgref_record(\"CORE request_irq ret=%d irq=%u\", err, irq);\n",
+        "core irq",
+    )
+
     probe_anchor = "static int ufshcd_probe_hba("
     probe_points = (
-        ("\tret = ufshcd_link_startup(hba);\n", "\t", "link_startup ret=%d state=%d link=%d", "ret, hba->ufshcd_state, hba->uic_link_state", "core link"),
-        ("\tret = ufshcd_verify_dev_init(hba);\n", "\t", "verify_dev_init ret=%d", "ret", "core verify"),
-        ("\tret = ufshcd_complete_dev_init(hba);\n", "\t", "complete_dev_init ret=%d", "ret", "core complete"),
-        ("\t\tret = ufshcd_device_params_init(hba);\n", "\t\t", "device_params ret=%d manufacturer=0x%x", "ret, hba->dev_info.wmanufacturerid", "core params"),
-        ("\t\tret = ufshcd_config_pwr_mode(hba, &hba->max_pwr_info.info);\n", "\t\t", "power_mode ret=%d rxgear=%d txgear=%d rxlane=%d txlane=%d", "ret, hba->max_pwr_info.info.gear_rx, hba->max_pwr_info.info.gear_tx, hba->max_pwr_info.info.lane_rx, hba->max_pwr_info.info.lane_tx", "core power"),
-        ("\t\tscsi_scan_host(hba->host);\n", "\t\t", "scsi_scan host_no=%d", "hba->host->host_no", "core scan"),
+        (
+            "\tret = ufshcd_link_startup(hba);\n",
+            "\t",
+            "link_startup ret=%d state=%d link=%d",
+            "ret, hba->ufshcd_state, hba->uic_link_state",
+            "core link",
+        ),
+        (
+            "\tret = ufshcd_verify_dev_init(hba);\n",
+            "\t",
+            "verify_dev_init ret=%d",
+            "ret",
+            "core verify",
+        ),
+        (
+            "\tret = ufshcd_complete_dev_init(hba);\n",
+            "\t",
+            "complete_dev_init ret=%d",
+            "ret",
+            "core complete",
+        ),
+        (
+            "\tret = ufs_read_device_desc_data(hba);\n",
+            "\t",
+            "device_desc ret=%d manufacturer=0x%x spec=0x%x",
+            "ret, hba->dev_info.w_manufacturer_id, hba->dev_info.w_spec_version",
+            "core descriptor",
+        ),
+        (
+            "\t\tret = ufshcd_config_pwr_mode(hba, &hba->max_pwr_info.info);\n",
+            "\t\t",
+            "power_mode ret=%d rxgear=%d txgear=%d rxlane=%d txlane=%d",
+            "ret, hba->max_pwr_info.info.gear_rx, hba->max_pwr_info.info.gear_tx, "
+            "hba->max_pwr_info.info.lane_rx, hba->max_pwr_info.info.lane_tx",
+            "core power",
+        ),
+        (
+            "\t\tscsi_scan_host(hba->host);\n",
+            "\t\t",
+            "scsi_scan host_no=%d",
+            "hba->host->host_no",
+            "core scan",
+        ),
     )
     for statement, indent, fmt, args, label in probe_points:
-        text = insert_after_fragment(
+        text = _impl.insert_after_fragment(
             text,
             probe_anchor,
             statement,
             f'{indent}tgref_record("CORE {fmt}", {args});\n',
             label,
         )
-    text = insert_before_last_return(
+
+    text = _impl.insert_before_last_return(
         text,
         probe_anchor,
         "\treturn ret;\n",
-        "\ttgref_record(\"CORE probe_hba_end ret=%d state=%d link=%d manufacturer=0x%x\",\n"
+        "\ttgref_record(\"CORE probe_hba_end ret=%d state=%d link=%d "
+        "manufacturer=0x%x spec=0x%x\",\n"
         "\t\t     ret, hba->ufshcd_state, hba->uic_link_state,\n"
-        "\t\t     hba->dev_info.wmanufacturerid);\n",
+        "\t\t     hba->dev_info.w_manufacturer_id,\n"
+        "\t\t     hba->dev_info.w_spec_version);\n",
         "core probe end",
     )
     return text
 
 
-def instrument_sd(text: str) -> str:
-    text = add_include(
-        text,
-        "#include <linux/blkdev.h>\n",
-        "sd include",
-    )
-    probe_anchor = "static int sd_probe(struct device *dev)\n"
-    text = insert_after_fragment(
-        text,
-        probe_anchor,
-        '\terror = sd_format_disk_name("sd", index, gd->disk_name, DISK_NAME_LEN);\n',
-        "\tif (!error && sdp->host->by_ufs)\n"
-        "\t\ttgref_record(\"SD probe lun=%llu name=%s host_no=%d\",\n"
-        "\t\t\t     (unsigned long long)sdp->lun, gd->disk_name,\n"
-        "\t\t\t     sdp->host->host_no);\n",
-        "sd probe",
-    )
-    async_anchor = "static void sd_probe_async(void *data, async_cookie_t cookie)\n"
-    text = insert_after_fragment(
-        text,
-        async_anchor,
-        "\tdevice_add_disk(dev, gd);\n",
-        "\tif (sdp->host->by_ufs)\n"
-        "\t\ttgref_record(\"SD add_disk name=%s capacity=%llu sectors host_no=%d\",\n"
-        "\t\t\t     gd->disk_name, (unsigned long long)get_capacity(gd),\n"
-        "\t\t\t     sdp->host->host_no);\n",
-        "sd add disk",
-    )
-    return text
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Stage targeted TouchGrass 4.19.206 UFS reference recorder"
-    )
-    parser.add_argument("--kernel", type=Path, required=True)
-    parser.add_argument("--output", type=Path, required=True)
-    args = parser.parse_args()
-
-    kernel = args.kernel.resolve()
-    output = args.output.resolve()
-    output.mkdir(parents=True, exist_ok=True)
-
-    files = {
-        "drivers/base/dd.c": instrument_driver_core,
-        "drivers/phy/qualcomm/phy-qcom-ufs-qmp-v3.c": instrument_qmp_v3,
-        "drivers/phy/qualcomm/phy-qcom-ufs.c": instrument_phy_common,
-        "drivers/scsi/ufs/ufs-qcom.c": instrument_ufs_qcom,
-        "drivers/scsi/ufs/ufshcd-pltfrm.c": instrument_platform,
-        "drivers/scsi/ufs/ufshcd.c": instrument_ufshcd,
-        "drivers/scsi/sd.c": instrument_sd,
-    }
-
-    for rel, fn in files.items():
-        path = kernel / rel
-        if not path.is_file():
-            fail(rel, "source file missing")
-        original = path.read_text(encoding="utf-8")
-        patched = fn(original)
-        if patched == original:
-            fail(rel, "instrumentation produced no change")
-        path.write_text(patched, encoding="utf-8")
-
-    header_path = kernel / "include/linux/tgref_recorder.h"
-    source_path = kernel / "drivers/scsi/ufs/tgref-recorder.c"
-    makefile_path = kernel / "drivers/scsi/ufs/Makefile"
-    header_path.write_text(HEADER, encoding="utf-8")
-    source_path.write_text(SOURCE, encoding="utf-8")
-
-    makefile = makefile_path.read_text(encoding="utf-8")
-    marker = "# A52 TouchGrass UFS reference recorder"
-    if marker in makefile or "tgref-recorder.o" in makefile:
-        fail("Makefile", "recorder already linked")
-    makefile_path.write_text(
-        makefile.rstrip() + f"\n\n{marker}\nobj-y += tgref-recorder.o\n",
-        encoding="utf-8",
-    )
-
-    checks = {
-        "recorder_source": source_path.is_file(),
-        "recorder_header": header_path.is_file(),
-        "automatic_dump_marker": "/data/local/tmp/tgref_ufs.log" in SOURCE,
-        "no_kernel_root_integration": "KSU" not in SOURCE and "KernelSU" not in SOURCE,
-        "driver_core_trace": "DEV call device=%s driver=%s" in (kernel / "drivers/base/dd.c").read_text(),
-        "phy_trace": "PHY probe_begin" in (kernel / "drivers/phy/qualcomm/phy-qcom-ufs-qmp-v3.c").read_text(),
-        "qcom_trace": "UFS power_up_begin" in (kernel / "drivers/scsi/ufs/ufs-qcom.c").read_text(),
-        "platform_trace": "PLT parse_clocks" in (kernel / "drivers/scsi/ufs/ufshcd-pltfrm.c").read_text(),
-        "core_trace": "CORE link_startup" in (kernel / "drivers/scsi/ufs/ufshcd.c").read_text(),
-        "disk_trace": "SD add_disk" in (kernel / "drivers/scsi/sd.c").read_text(),
-        "makefile_link": "obj-y += tgref-recorder.o" in makefile_path.read_text(),
-    }
-    failed = [name for name, passed in checks.items() if not passed]
-    if failed:
-        fail("staging audit", ", ".join(failed))
-
-    (output / "tgref-recorder.c").write_text(SOURCE, encoding="utf-8")
-    (output / "tgref_recorder.h").write_text(HEADER, encoding="utf-8")
-    (output / "stage-report.json").write_text(
-        json.dumps(
-            {
-                "status": "staged",
-                "kernel": "touchGrass Linux 4.19.206",
-                "scope": [
-                    "driver bind/defer",
-                    "QMP-v3 UFS PHY",
-                    "Qualcomm UFS host",
-                    "platform resources",
-                    "UFS core link startup",
-                    "SCSI disk registration",
-                ],
-                "automatic_dump": {
-                    "path": "/data/local/tmp/tgref_ufs.log",
-                    "poll_interval_ms": 5000,
-                    "settle_after_data_ms": 30000,
-                    "requires_android_root": False,
-                },
-                "checks": checks,
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return 0
+_impl.instrument_ufshcd = instrument_ufshcd
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_impl.main())

--- a/scripts/96_stage_touchgrass_ufs_reference_recorder.py
+++ b/scripts/96_stage_touchgrass_ufs_reference_recorder.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import hashlib
 import re
+import sys
+import traceback
 import types
 import urllib.request
 from pathlib import Path
@@ -223,5 +225,26 @@ def instrument_ufshcd(text: str) -> str:
 _impl.instrument_ufshcd = instrument_ufshcd
 
 
+def requested_output() -> Path | None:
+    try:
+        index = sys.argv.index("--output")
+        return Path(sys.argv[index + 1]).resolve()
+    except (ValueError, IndexError):
+        return None
+
+
+def main() -> int:
+    try:
+        return _impl.main()
+    except BaseException:
+        output = requested_output()
+        if output is not None:
+            output.mkdir(parents=True, exist_ok=True)
+            (output / "stage-error.txt").write_text(
+                traceback.format_exc(), encoding="utf-8"
+            )
+        raise
+
+
 if __name__ == "__main__":
-    raise SystemExit(_impl.main())
+    raise SystemExit(main())

--- a/scripts/96_stage_touchgrass_ufs_reference_recorder_base.py
+++ b/scripts/96_stage_touchgrass_ufs_reference_recorder_base.py
@@ -1,0 +1,928 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+HEADER = r'''#ifndef _LINUX_TGREF_RECORDER_H
+#define _LINUX_TGREF_RECORDER_H
+
+#include <linux/compiler.h>
+
+void tgref_record(const char *fmt, ...) __printf(1, 2);
+
+#endif
+'''
+
+SOURCE = r'''// SPDX-License-Identifier: GPL-2.0
+/*
+ * A52 TouchGrass UFS reference recorder.
+ *
+ * Diagnostic-only helper for the known-good Linux 4.19.206 boot. UFS bring-up
+ * breadcrumbs are kept in a small in-kernel text buffer and copied once to
+ * /data/local/tmp/tgref_ufs.log after Android has mounted /data.
+ */
+#include <linux/delay.h>
+#include <linux/err.h>
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/kthread.h>
+#include <linux/module.h>
+#include <linux/namei.h>
+#include <linux/printk.h>
+#include <linux/sizes.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/timekeeping.h>
+#include <linux/uaccess.h>
+#include <linux/vmalloc.h>
+
+#include <linux/tgref_recorder.h>
+
+#define TGREF_BUFFER_SIZE SZ_128K
+#define TGREF_LINE_SIZE 384
+#define TGREF_DUMP_PATH "/data/local/tmp/tgref_ufs.log"
+#define TGREF_DATA_DIR "/data/local/tmp"
+#define TGREF_POLL_MS 5000
+#define TGREF_SETTLE_MS 30000
+#define TGREF_MAX_POLLS 120
+
+static char tgref_buffer[TGREF_BUFFER_SIZE];
+static size_t tgref_length;
+static unsigned int tgref_dropped;
+static DEFINE_SPINLOCK(tgref_lock);
+
+void tgref_record(const char *fmt, ...)
+{
+	char line[TGREF_LINE_SIZE];
+	unsigned long flags;
+	u64 ns;
+	va_list args;
+	int prefix;
+	int body;
+	int total;
+
+	ns = ktime_get_ns();
+	prefix = scnprintf(line, sizeof(line), "TGREF %llu.%06llu ",
+			   (unsigned long long)(ns / NSEC_PER_SEC),
+			   (unsigned long long)((ns % NSEC_PER_SEC) / NSEC_PER_USEC));
+
+	va_start(args, fmt);
+	body = vscnprintf(line + prefix, sizeof(line) - prefix, fmt, args);
+	va_end(args);
+
+	total = prefix + body;
+	if (total <= 0)
+		return;
+	if (line[total - 1] != '\n' && total < sizeof(line) - 1)
+		line[total++] = '\n';
+	line[total] = '\0';
+
+	spin_lock_irqsave(&tgref_lock, flags);
+	if (tgref_length + total <= sizeof(tgref_buffer)) {
+		memcpy(tgref_buffer + tgref_length, line, total);
+		tgref_length += total;
+	} else {
+		tgref_dropped++;
+	}
+	spin_unlock_irqrestore(&tgref_lock, flags);
+
+	printk(KERN_INFO "%s", line);
+}
+EXPORT_SYMBOL_GPL(tgref_record);
+
+static int tgref_snapshot(char **out, size_t *out_len)
+{
+	unsigned long flags;
+	char *snapshot;
+	size_t len;
+	unsigned int dropped;
+	int header;
+
+	snapshot = vmalloc(TGREF_BUFFER_SIZE + 128);
+	if (!snapshot)
+		return -ENOMEM;
+
+	spin_lock_irqsave(&tgref_lock, flags);
+	len = tgref_length;
+	dropped = tgref_dropped;
+	memcpy(snapshot + 128, tgref_buffer, len);
+	spin_unlock_irqrestore(&tgref_lock, flags);
+
+	header = scnprintf(snapshot, 128,
+			   "TGREF reference=touchGrass-4.19.206 bytes=%zu dropped=%u\n",
+			   len, dropped);
+	memmove(snapshot + header, snapshot + 128, len);
+	*out = snapshot;
+	*out_len = header + len;
+	return 0;
+}
+
+static int tgref_write_snapshot(void)
+{
+	struct file *file;
+	char *snapshot;
+	size_t length;
+	size_t written = 0;
+	loff_t pos = 0;
+	int ret;
+
+	ret = tgref_snapshot(&snapshot, &length);
+	if (ret)
+		return ret;
+
+	file = filp_open(TGREF_DUMP_PATH,
+			 O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE, 0644);
+	if (IS_ERR(file)) {
+		ret = PTR_ERR(file);
+		vfree(snapshot);
+		return ret;
+	}
+
+	while (written < length) {
+		ssize_t step = kernel_write(file, snapshot + written,
+					    length - written, &pos);
+		if (step < 0) {
+			ret = step;
+			goto out;
+		}
+		if (!step) {
+			ret = -EIO;
+			goto out;
+		}
+		written += step;
+	}
+
+	ret = vfs_fsync(file, 0);
+out:
+	filp_close(file, NULL);
+	vfree(snapshot);
+	return ret;
+}
+
+static int tgref_dump_thread(void *unused)
+{
+	struct path path;
+	int poll;
+	int ret = -ENOENT;
+
+	tgref_record("DUMPER armed path=%s", TGREF_DUMP_PATH);
+
+	for (poll = 0; poll < TGREF_MAX_POLLS && !kthread_should_stop(); poll++) {
+		ret = kern_path(TGREF_DATA_DIR,
+				LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &path);
+		if (!ret) {
+			path_put(&path);
+			tgref_record("DUMPER data_ready poll=%d settle_ms=%d",
+				     poll, TGREF_SETTLE_MS);
+			msleep(TGREF_SETTLE_MS);
+			ret = tgref_write_snapshot();
+			if (!ret) {
+				printk(KERN_INFO
+				       "TGREF DUMPER saved %s\n", TGREF_DUMP_PATH);
+				return 0;
+			}
+			tgref_record("DUMPER write_failed ret=%d retrying", ret);
+		}
+		msleep(TGREF_POLL_MS);
+	}
+
+	tgref_record("DUMPER gave_up ret=%d polls=%d", ret, poll);
+	return ret;
+}
+
+static int __init tgref_recorder_init(void)
+{
+	struct task_struct *task;
+
+	tgref_record("RECORDER ready buffer=%u dump=%s",
+		     (unsigned int)TGREF_BUFFER_SIZE, TGREF_DUMP_PATH);
+	task = kthread_run(tgref_dump_thread, NULL, "tgref_ufs_dump");
+	if (IS_ERR(task)) {
+		int ret = PTR_ERR(task);
+
+		tgref_record("DUMPER thread_start_failed ret=%d", ret);
+		return 0;
+	}
+	return 0;
+}
+late_initcall(tgref_recorder_init);
+
+MODULE_DESCRIPTION("A52 TouchGrass UFS reference recorder and automatic dumper");
+MODULE_LICENSE("GPL v2");
+'''
+
+
+def fail(label: str, detail: str) -> None:
+    raise SystemExit(f"{label}: {detail}")
+
+
+def function_bounds(text: str, anchor: str, label: str) -> tuple[int, int, int]:
+    search = 0
+    while True:
+        start = text.find(anchor, search)
+        if start < 0:
+            fail(label, f"function anchor not found: {anchor}")
+        brace = text.find("{", start)
+        semicolon = text.find(";", start)
+        if brace >= 0 and (semicolon < 0 or brace < semicolon):
+            break
+        search = start + len(anchor)
+
+    depth = 0
+    for pos in range(brace, len(text)):
+        ch = text[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return start, brace, pos + 1
+    fail(label, "closing brace not found")
+
+
+def add_include(text: str, anchor: str, label: str) -> str:
+    include = "#include <linux/tgref_recorder.h>\n"
+    if include in text:
+        fail(label, "recorder include already present")
+    count = text.count(anchor)
+    if count != 1:
+        fail(label, f"expected one include anchor, found {count}")
+    return text.replace(anchor, anchor + include, 1)
+
+
+def insert_after_fragment(
+    text: str, function_anchor: str, fragment: str, insertion: str, label: str
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    positions: list[int] = []
+    cursor = start
+    while True:
+        pos = text.find(fragment, cursor, end)
+        if pos < 0:
+            break
+        positions.append(pos)
+        cursor = pos + len(fragment)
+    if len(positions) != 1:
+        fail(label, f"expected one fragment in function, found {len(positions)}")
+    point = positions[0] + len(fragment)
+    return text[:point] + insertion + text[point:]
+
+
+def insert_before_fragment(
+    text: str, function_anchor: str, fragment: str, insertion: str, label: str
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    positions: list[int] = []
+    cursor = start
+    while True:
+        pos = text.find(fragment, cursor, end)
+        if pos < 0:
+            break
+        positions.append(pos)
+        cursor = pos + len(fragment)
+    if len(positions) != 1:
+        fail(label, f"expected one fragment in function, found {len(positions)}")
+    point = positions[0]
+    return text[:point] + insertion + text[point:]
+
+
+def insert_after_open(
+    text: str, function_anchor: str, insertion: str, label: str
+) -> str:
+    _, brace, _ = function_bounds(text, function_anchor, label)
+    return text[: brace + 1] + insertion + text[brace + 1 :]
+
+
+def insert_before_last_return(
+    text: str, function_anchor: str, return_fragment: str, insertion: str, label: str
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    pos = text.rfind(return_fragment, start, end)
+    if pos < 0:
+        fail(label, "return fragment not found")
+    return text[:pos] + insertion + text[pos:]
+
+
+def replace_in_function(
+    text: str,
+    function_anchor: str,
+    old: str,
+    new: str,
+    label: str,
+) -> str:
+    start, _, end = function_bounds(text, function_anchor, label)
+    count = text.count(old, start, end)
+    if count != 1:
+        fail(label, f"expected one replacement target in function, found {count}")
+    pos = text.find(old, start, end)
+    return text[:pos] + new + text[pos + len(old) :]
+
+
+def instrument_driver_core(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/pinctrl/devinfo.h>\n",
+        "driver core include",
+    )
+    helper = r'''
+static bool tgref_relevant_probe(struct device *dev, struct device_driver *drv)
+{
+	const char *device = dev_name(dev);
+	const char *driver = drv ? drv->name : "";
+
+	return strstr(device, "1d84000") || strstr(device, "1d87000") ||
+	       strstr(driver, "ufshcd-qcom") ||
+	       strstr(driver, "ufs_qcom_phy_qmp_v3");
+}
+
+'''
+    anchor = "static int really_probe(struct device *dev, struct device_driver *drv)\n"
+    if text.count(anchor) != 1:
+        fail("driver core helper", "really_probe anchor count is not one")
+    text = text.replace(anchor, helper + anchor, 1)
+
+    decl = (
+        "\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n"
+        "\t\t\t   !drv->suppress_bind_attrs;\n"
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        decl,
+        "\tbool tgref_match = tgref_relevant_probe(dev, drv);\n\n"
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV call device=%s driver=%s\", dev_name(dev), drv->name);\n",
+        "driver core call",
+    )
+
+    suppliers = (
+        "\tret = device_links_check_suppliers(dev);\n"
+        "\tif (ret == -EPROBE_DEFER)\n"
+        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n"
+        "\tif (ret)\n"
+        "\t\treturn ret;\n"
+    )
+    suppliers_new = (
+        "\tret = device_links_check_suppliers(dev);\n"
+        "\tif (ret == -EPROBE_DEFER)\n"
+        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n"
+        "\tif (ret) {\n"
+        "\t\tif (tgref_match)\n"
+        "\t\t\ttgref_record(\"DEV suppliers device=%s driver=%s ret=%d\",\n"
+        "\t\t\t\t     dev_name(dev), drv->name, ret);\n"
+        "\t\treturn ret;\n"
+        "\t}\n"
+    )
+    text = replace_in_function(
+        text, anchor, suppliers, suppliers_new, "driver core suppliers"
+    )
+
+    text = insert_before_fragment(
+        text,
+        anchor,
+        "\tif (test_remove) {\n",
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV probe_return device=%s driver=%s ret=%d\",\n"
+        "\t\t\t     dev_name(dev), drv->name, ret);\n",
+        "driver core probe return",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tdriver_bound(dev);\n",
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV bound device=%s driver=%s\", dev_name(dev), drv->name);\n",
+        "driver core bound",
+    )
+    text = insert_before_fragment(
+        text,
+        anchor,
+        "\tswitch (ret) {\n",
+        "\tif (tgref_match)\n"
+        "\t\ttgref_record(\"DEV failed device=%s driver=%s ret=%d\",\n"
+        "\t\t\t     dev_name(dev), drv->name, ret);\n",
+        "driver core failure",
+    )
+    return text
+
+
+def instrument_qmp_v3(text: str) -> str:
+    text = add_include(
+        text,
+        '#include "phy-qcom-ufs-qmp-v3.h"\n',
+        "qmp v3 include",
+    )
+    init_anchor = "static int ufs_qcom_phy_qmp_v3_init(struct phy *generic_phy)\n"
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\tint err;\n",
+        "\n\ttgref_record(\"PHY init_begin device=%s\", dev_name(phy_common->dev));\n",
+        "qmp init begin",
+    )
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\terr = ufs_qcom_phy_init_clks(phy_common);\n",
+        "\ttgref_record(\"PHY init_clks ret=%d\", err);\n",
+        "qmp clocks",
+    )
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\terr = ufs_qcom_phy_init_vregulators(phy_common);\n",
+        "\ttgref_record(\"PHY init_vregs ret=%d\", err);\n",
+        "qmp vregs",
+    )
+    text = insert_before_last_return(
+        text,
+        init_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY init_end ret=%d\", err);\n",
+        "qmp init end",
+    )
+
+    cal_anchor = "int ufs_qcom_phy_qmp_v3_phy_calibrate("
+    text = insert_after_open(
+        text,
+        cal_anchor,
+        "\n\ttgref_record(\"PHY calibrate_begin rate_b=%d gear4=%d\", is_rate_B, is_g4);\n",
+        "qmp calibrate begin",
+    )
+    text = insert_before_last_return(
+        text,
+        cal_anchor,
+        "\treturn 0;\n",
+        "\ttgref_record(\"PHY calibrate_end lanes=%u\", ufs_qcom_phy->lanes_per_direction);\n",
+        "qmp calibrate end",
+    )
+
+    pcs_anchor = "static int ufs_qcom_phy_qmp_v3_is_pcs_ready("
+    text = insert_before_last_return(
+        text,
+        pcs_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY pcs_ready ret=%d val=0x%x\", err, val);\n",
+        "qmp pcs",
+    )
+
+    probe_anchor = "static int ufs_qcom_phy_qmp_v3_probe(struct platform_device *pdev)\n"
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        "\tint err = 0;\n",
+        "\n\ttgref_record(\"PHY probe_begin device=%s\", dev_name(dev));\n",
+        "qmp probe begin",
+    )
+    text = insert_before_fragment(
+        text,
+        probe_anchor,
+        "\tif (!generic_phy) {\n",
+        "\ttgref_record(\"PHY generic_probe pointer=%p\", generic_phy);\n",
+        "qmp generic probe",
+    )
+    text = insert_before_last_return(
+        text,
+        probe_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY probe_end device=%s ret=%d\", dev_name(dev), err);\n",
+        "qmp probe end",
+    )
+    return text
+
+
+def instrument_phy_common(text: str) -> str:
+    text = add_include(
+        text,
+        '#include "phy-qcom-ufs-i.h"\n',
+        "phy common include",
+    )
+
+    generic_anchor = "struct phy *ufs_qcom_phy_generic_probe("
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\tstruct phy_provider *phy_provider;\n",
+        "\n\ttgref_record(\"PHY generic_begin device=%s\", dev_name(dev));\n",
+        "phy generic begin",
+    )
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\terr = ufs_qcom_phy_base_init(pdev, common_cfg);\n",
+        "\ttgref_record(\"PHY base_init ret=%d mmio=%p\", err, common_cfg->mmio);\n",
+        "phy base",
+    )
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\tphy_provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);\n",
+        "\ttgref_record(\"PHY provider pointer=%p\", phy_provider);\n",
+        "phy provider",
+    )
+    text = insert_after_fragment(
+        text,
+        generic_anchor,
+        "\tgeneric_phy = devm_phy_create(dev, NULL, ufs_qcom_phy_gen_ops);\n",
+        "\ttgref_record(\"PHY create pointer=%p\", generic_phy);\n",
+        "phy create",
+    )
+    text = insert_before_last_return(
+        text,
+        generic_anchor,
+        "\treturn generic_phy;\n",
+        "\ttgref_record(\"PHY generic_end device=%s phy=%p lanes=%u\",\n"
+        "\t\t     dev_name(dev), generic_phy, common_cfg->lanes_per_direction);\n",
+        "phy generic end",
+    )
+
+    clk_anchor = "static int __ufs_qcom_phy_clk_get("
+    text = insert_before_last_return(
+        text,
+        clk_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY clk_get name=%s ret=%d clk=%p\", name, err,\n"
+        "\t\t     err ? NULL : *clk_out);\n",
+        "phy clk get",
+    )
+
+    vreg_anchor = "static int ufs_qcom_phy_init_vreg("
+    text = insert_before_last_return(
+        text,
+        vreg_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PHY vreg_get name=%s ret=%d reg=%p\", name, err,\n"
+        "\t\t     err ? NULL : vreg->reg);\n",
+        "phy vreg get",
+    )
+    return text
+
+
+def instrument_ufs_qcom(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/clk/qcom.h>\n",
+        "ufs qcom include",
+    )
+
+    get_anchor = "static int ufs_qcom_host_clk_get("
+    text = insert_before_last_return(
+        text,
+        get_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"UFS host_clk_get name=%s ret=%d clk=%p\", name, err,\n"
+        "\t\t     err ? NULL : *clk_out);\n",
+        "ufs host clk get",
+    )
+    enable_anchor = "static int ufs_qcom_host_clk_enable("
+    text = insert_before_last_return(
+        text,
+        enable_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"UFS host_clk_enable name=%s ret=%d rate=%lu\", name,\n"
+        "\t\t     err, err ? 0UL : clk_get_rate(clk));\n",
+        "ufs host clk enable",
+    )
+
+    power_anchor = "static int ufs_qcom_power_up_sequence(struct ufs_hba *hba)\n"
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tint ret = 0;\n",
+        "\n\ttgref_record(\"UFS power_up_begin lanes=%u gear4=%d\",\n"
+        "\t\t     hba->lanes_per_direction, hba->phy_init_g4);\n",
+        "ufs power begin",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tufs_qcom_assert_reset(hba);\n",
+        "\ttgref_record(\"UFS phy_reset_asserted\");\n",
+        "ufs reset assert",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tret = ufs_qcom_phy_calibrate_phy(phy, is_rate_B, hba->phy_init_g4);\n",
+        "\ttgref_record(\"UFS phy_calibrate ret=%d rate_b=%d\", ret, is_rate_B);\n",
+        "ufs calibrate",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tufs_qcom_deassert_reset(hba);\n",
+        "\ttgref_record(\"UFS phy_reset_deasserted\");\n",
+        "ufs reset deassert",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tret = ufs_qcom_phy_start_serdes(phy);\n",
+        "\ttgref_record(\"UFS serdes_start ret=%d\", ret);\n",
+        "ufs serdes",
+    )
+    text = insert_after_fragment(
+        text,
+        power_anchor,
+        "\tret = ufs_qcom_phy_is_pcs_ready(phy);\n",
+        "\ttgref_record(\"UFS pcs_ready ret=%d\", ret);\n",
+        "ufs pcs",
+    )
+    text = insert_before_last_return(
+        text,
+        power_anchor,
+        "\treturn ret;\n",
+        "\ttgref_record(\"UFS power_up_end ret=%d\", ret);\n",
+        "ufs power end",
+    )
+
+    probe_anchor = "static int ufs_qcom_probe(struct platform_device *pdev)\n"
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        "\tstruct device_node *np = dev->of_node;\n",
+        "\n\ttgref_record(\"UFS probe_begin device=%s bootdevice=%s\",\n"
+        "\t\t     dev_name(dev), android_boot_dev);\n",
+        "ufs probe begin",
+    )
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        "\terr = ufshcd_pltfrm_init(pdev, &ufs_hba_qcom_variant);\n",
+        "\ttgref_record(\"UFS platform_init ret=%d\", err);\n",
+        "ufs platform init",
+    )
+    text = insert_before_last_return(
+        text,
+        probe_anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"UFS probe_end device=%s ret=%d\", dev_name(dev), err);\n",
+        "ufs probe end",
+    )
+    return text
+
+
+def instrument_platform(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/of.h>\n",
+        "platform include",
+    )
+    anchor = "int ufshcd_pltfrm_init(struct platform_device *pdev,"
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tstruct device *dev = &pdev->dev;\n",
+        "\n\ttgref_record(\"PLT begin device=%s\", dev_name(dev));\n",
+        "platform begin",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tmmio_base = devm_ioremap_resource(dev, mem_res);\n",
+        "\ttgref_record(\"PLT mmio resource=%pR mapping=%p\", mem_res, mmio_base);\n",
+        "platform mmio",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\tirq = platform_get_irq(pdev, 0);\n",
+        "\ttgref_record(\"PLT irq=%d\", irq);\n",
+        "platform irq",
+    )
+    text = insert_after_fragment(
+        text,
+        anchor,
+        "\terr = ufshcd_alloc_host(dev, &hba);\n",
+        "\ttgref_record(\"PLT alloc_host ret=%d hba=%p\", err, err ? NULL : hba);\n",
+        "platform host",
+    )
+    for statement, marker, label in (
+        ("\terr = ufshcd_parse_clock_info(hba);\n", "parse_clocks", "platform clocks"),
+        ("\terr = ufshcd_parse_regulator_info(hba);\n", "parse_regulators", "platform regulators"),
+        ("\terr = ufshcd_parse_reset_info(hba);\n", "parse_reset", "platform reset"),
+        ("\terr = ufshcd_parse_pinctrl_info(hba);\n", "parse_pinctrl", "platform pinctrl"),
+        ("\terr = ufshcd_init(hba, mmio_base, irq);\n", "core_init", "platform core"),
+    ):
+        text = insert_after_fragment(
+            text,
+            anchor,
+            statement,
+            f'\ttgref_record("PLT {marker} ret=%d", err);\n',
+            label,
+        )
+    text = insert_before_last_return(
+        text,
+        anchor,
+        "\treturn 0;\n",
+        "\ttgref_record(\"PLT end ret=0 host_no=%d lanes=%u\",\n"
+        "\t\t     hba->host->host_no, hba->lanes_per_direction);\n",
+        "platform success",
+    )
+    text = insert_before_last_return(
+        text,
+        anchor,
+        "\treturn err;\n",
+        "\ttgref_record(\"PLT fail ret=%d\", err);\n",
+        "platform fail",
+    )
+    return text
+
+
+def instrument_ufshcd(text: str) -> str:
+    text = add_include(
+        text,
+        '#include "ufshcd.h"\n',
+        "ufshcd include",
+    )
+
+    init_anchor = "int ufshcd_init(struct ufs_hba *hba,"
+    text = insert_after_fragment(
+        text,
+        init_anchor,
+        "\tstruct device *dev = hba->dev;\n",
+        "\n\ttgref_record(\"CORE init_begin dev=%s irq=%u mmio=%p host_no=%d\",\n"
+        "\t\t     dev_name(dev), irq, mmio_base, hba->host->host_no);\n",
+        "core init begin",
+    )
+    init_points = (
+        ("\terr = ufshcd_hba_init(hba);\n", "hba_init ret=%d", "err", "core hba init"),
+        ("\terr = ufshcd_hba_capabilities(hba);\n", "capabilities ret=%d cap=0x%x version=0x%x", "err, hba->capabilities, hba->ufs_version", "core capabilities"),
+        ("\terr = ufshcd_set_dma_mask(hba);\n", "dma_mask ret=%d", "err", "core dma"),
+        ("\terr = ufshcd_memory_alloc(hba);\n", "memory_alloc ret=%d", "err", "core memory"),
+        ("\terr = devm_request_irq(dev, irq, ufshcd_intr, IRQF_SHARED, UFSHCD, hba);\n", "request_irq ret=%d irq=%u", "err, irq", "core irq"),
+        ("\terr = scsi_add_host(host, hba->dev);\n", "scsi_add_host ret=%d host_no=%d", "err, host->host_no", "core scsi host"),
+        ("\terr = ufshcd_hba_enable(hba);\n", "hba_enable ret=%d state=%d hcs=0x%x", "err, hba->ufshcd_state, ufshcd_readl(hba, REG_CONTROLLER_STATUS)", "core hba enable"),
+        ("\tasync_schedule(ufshcd_async_scan, hba);\n", "async_scan_scheduled state=%d", "hba->ufshcd_state", "core async schedule"),
+    )
+    for statement, fmt, args, label in init_points:
+        text = insert_after_fragment(
+            text,
+            init_anchor,
+            statement,
+            f'\ttgref_record("CORE {fmt}", {args});\n',
+            label,
+        )
+
+    probe_anchor = "static int ufshcd_probe_hba("
+    probe_points = (
+        ("\tret = ufshcd_link_startup(hba);\n", "\t", "link_startup ret=%d state=%d link=%d", "ret, hba->ufshcd_state, hba->uic_link_state", "core link"),
+        ("\tret = ufshcd_verify_dev_init(hba);\n", "\t", "verify_dev_init ret=%d", "ret", "core verify"),
+        ("\tret = ufshcd_complete_dev_init(hba);\n", "\t", "complete_dev_init ret=%d", "ret", "core complete"),
+        ("\t\tret = ufshcd_device_params_init(hba);\n", "\t\t", "device_params ret=%d manufacturer=0x%x", "ret, hba->dev_info.wmanufacturerid", "core params"),
+        ("\t\tret = ufshcd_config_pwr_mode(hba, &hba->max_pwr_info.info);\n", "\t\t", "power_mode ret=%d rxgear=%d txgear=%d rxlane=%d txlane=%d", "ret, hba->max_pwr_info.info.gear_rx, hba->max_pwr_info.info.gear_tx, hba->max_pwr_info.info.lane_rx, hba->max_pwr_info.info.lane_tx", "core power"),
+        ("\t\tscsi_scan_host(hba->host);\n", "\t\t", "scsi_scan host_no=%d", "hba->host->host_no", "core scan"),
+    )
+    for statement, indent, fmt, args, label in probe_points:
+        text = insert_after_fragment(
+            text,
+            probe_anchor,
+            statement,
+            f'{indent}tgref_record("CORE {fmt}", {args});\n',
+            label,
+        )
+    text = insert_before_last_return(
+        text,
+        probe_anchor,
+        "\treturn ret;\n",
+        "\ttgref_record(\"CORE probe_hba_end ret=%d state=%d link=%d manufacturer=0x%x\",\n"
+        "\t\t     ret, hba->ufshcd_state, hba->uic_link_state,\n"
+        "\t\t     hba->dev_info.wmanufacturerid);\n",
+        "core probe end",
+    )
+    return text
+
+
+def instrument_sd(text: str) -> str:
+    text = add_include(
+        text,
+        "#include <linux/blkdev.h>\n",
+        "sd include",
+    )
+    probe_anchor = "static int sd_probe(struct device *dev)\n"
+    text = insert_after_fragment(
+        text,
+        probe_anchor,
+        '\terror = sd_format_disk_name("sd", index, gd->disk_name, DISK_NAME_LEN);\n',
+        "\tif (!error && sdp->host->by_ufs)\n"
+        "\t\ttgref_record(\"SD probe lun=%llu name=%s host_no=%d\",\n"
+        "\t\t\t     (unsigned long long)sdp->lun, gd->disk_name,\n"
+        "\t\t\t     sdp->host->host_no);\n",
+        "sd probe",
+    )
+    async_anchor = "static void sd_probe_async(void *data, async_cookie_t cookie)\n"
+    text = insert_after_fragment(
+        text,
+        async_anchor,
+        "\tdevice_add_disk(dev, gd);\n",
+        "\tif (sdp->host->by_ufs)\n"
+        "\t\ttgref_record(\"SD add_disk name=%s capacity=%llu sectors host_no=%d\",\n"
+        "\t\t\t     gd->disk_name, (unsigned long long)get_capacity(gd),\n"
+        "\t\t\t     sdp->host->host_no);\n",
+        "sd add disk",
+    )
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Stage targeted TouchGrass 4.19.206 UFS reference recorder"
+    )
+    parser.add_argument("--kernel", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    kernel = args.kernel.resolve()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        "drivers/base/dd.c": instrument_driver_core,
+        "drivers/phy/qualcomm/phy-qcom-ufs-qmp-v3.c": instrument_qmp_v3,
+        "drivers/phy/qualcomm/phy-qcom-ufs.c": instrument_phy_common,
+        "drivers/scsi/ufs/ufs-qcom.c": instrument_ufs_qcom,
+        "drivers/scsi/ufs/ufshcd-pltfrm.c": instrument_platform,
+        "drivers/scsi/ufs/ufshcd.c": instrument_ufshcd,
+        "drivers/scsi/sd.c": instrument_sd,
+    }
+
+    for rel, fn in files.items():
+        path = kernel / rel
+        if not path.is_file():
+            fail(rel, "source file missing")
+        original = path.read_text(encoding="utf-8")
+        patched = fn(original)
+        if patched == original:
+            fail(rel, "instrumentation produced no change")
+        path.write_text(patched, encoding="utf-8")
+
+    header_path = kernel / "include/linux/tgref_recorder.h"
+    source_path = kernel / "drivers/scsi/ufs/tgref-recorder.c"
+    makefile_path = kernel / "drivers/scsi/ufs/Makefile"
+    header_path.write_text(HEADER, encoding="utf-8")
+    source_path.write_text(SOURCE, encoding="utf-8")
+
+    makefile = makefile_path.read_text(encoding="utf-8")
+    marker = "# A52 TouchGrass UFS reference recorder"
+    if marker in makefile or "tgref-recorder.o" in makefile:
+        fail("Makefile", "recorder already linked")
+    makefile_path.write_text(
+        makefile.rstrip() + f"\n\n{marker}\nobj-y += tgref-recorder.o\n",
+        encoding="utf-8",
+    )
+
+    checks = {
+        "recorder_source": source_path.is_file(),
+        "recorder_header": header_path.is_file(),
+        "automatic_dump_marker": "/data/local/tmp/tgref_ufs.log" in SOURCE,
+        "no_kernel_root_integration": "KSU" not in SOURCE and "KernelSU" not in SOURCE,
+        "driver_core_trace": "DEV call device=%s driver=%s" in (kernel / "drivers/base/dd.c").read_text(),
+        "phy_trace": "PHY probe_begin" in (kernel / "drivers/phy/qualcomm/phy-qcom-ufs-qmp-v3.c").read_text(),
+        "qcom_trace": "UFS power_up_begin" in (kernel / "drivers/scsi/ufs/ufs-qcom.c").read_text(),
+        "platform_trace": "PLT parse_clocks" in (kernel / "drivers/scsi/ufs/ufshcd-pltfrm.c").read_text(),
+        "core_trace": "CORE link_startup" in (kernel / "drivers/scsi/ufs/ufshcd.c").read_text(),
+        "disk_trace": "SD add_disk" in (kernel / "drivers/scsi/sd.c").read_text(),
+        "makefile_link": "obj-y += tgref-recorder.o" in makefile_path.read_text(),
+    }
+    failed = [name for name, passed in checks.items() if not passed]
+    if failed:
+        fail("staging audit", ", ".join(failed))
+
+    (output / "tgref-recorder.c").write_text(SOURCE, encoding="utf-8")
+    (output / "tgref_recorder.h").write_text(HEADER, encoding="utf-8")
+    (output / "stage-report.json").write_text(
+        json.dumps(
+            {
+                "status": "staged",
+                "kernel": "touchGrass Linux 4.19.206",
+                "scope": [
+                    "driver bind/defer",
+                    "QMP-v3 UFS PHY",
+                    "Qualcomm UFS host",
+                    "platform resources",
+                    "UFS core link startup",
+                    "SCSI disk registration",
+                ],
+                "automatic_dump": {
+                    "path": "/data/local/tmp/tgref_ufs.log",
+                    "poll_interval_ms": 5000,
+                    "settle_after_data_ms": 30000,
+                    "requires_android_root": False,
+                },
+                "checks": checks,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a targeted Linux 4.19.206 TouchGrass UFS reference recorder
- records driver binding, QMP-v3 PHY setup, clocks, regulators, reset, UFS link startup, SCSI scan, and disk registration
- keeps the trace in a 128 KiB in-kernel buffer
- automatically writes the trace to `/data/local/tmp/tgref_ufs.log` after `/data` is available
- builds with the known-good touchscreen configuration and without KernelSU
- repacks and audits a flashable diagnostic `boot.img`

## Why

The GKI 5.10 bring-up now has a detailed UFS flight recorder, but it lacks an equivalent timeline from the working downstream kernel. This change creates a directly comparable known-good reference without requiring Android root or a second recovery boot for normal collection.

## Collection

After the diagnostic kernel boots, wait about 60 to 90 seconds and pull:

```sh
adb pull /data/local/tmp/tgref_ufs.log
```

The file is overwritten on each diagnostic boot.

## Validation

The workflow fails if expected downstream function shapes are missing, verifies all recorder markers in the compiled Image, enforces the no-KernelSU policy, validates the checksum-locked source boot image, and audits the repacked boot image.

Hardware validation is still required before this is considered proven.