### PR TITLE
Add boot-time Volume Up and Power recovery reboot

### DIFF
--- a/.github/workflows/56-a52-linux-4.19.200-resukisu-susfs-manual-core.yml
+++ b/.github/workflows/56-a52-linux-4.19.200-resukisu-susfs-manual-core.yml
@@ -1,4 +1,4 @@
-name: 57 - A52 Linux 4.19.206 ReSukiSU manual hooks plus SUSFS detection
+name: 58 - A52 Linux 4.19.206 recovery keycombo test
 
 on:
   pull_request:
@@ -6,13 +6,14 @@ on:
       - '.github/workflows/56-a52-linux-4.19.200-resukisu-susfs-manual-core.yml'
       - 'scripts/56_*'
       - 'scripts/57_*'
+      - 'scripts/58_*'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: a52-4.19.206-resukisu-susfs-manual-detection-${{ github.ref }}
+  group: a52-4.19.206-recovery-keycombo-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -20,11 +21,11 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 5G
   ANYKERNEL_COMMIT: 1c9a500dd4aa8081952523126e97eb155aed941b
-  LABEL: touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-manual-core
+  LABEL: touchgrass-4.19.206-resukisu-v4.1.0-susfs-v1.4.2-manual-core-recovery-keycombo
 
 jobs:
   build:
-    name: Build Linux 4.19.206 from hardware-tested SUSFS detection baseline
+    name: Build tested 4.19.206 baseline with recovery keycombo
     runs-on: ubuntu-22.04
     timeout-minutes: 300
 
@@ -50,11 +51,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          key: a52xq-4.19.206-manual-susfs-detection-${{ runner.os }}-${{ github.run_id }}
+          key: a52xq-4.19.206-recovery-keycombo-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
+            a52xq-4.19.206-manual-susfs-detection-${{ runner.os }}-
             a52xq-4.19.200-manual-susfs-core-${{ runner.os }}-
             a52xq-linux-4.19.200-susfs-minimal-ccache-${{ runner.os }}-
-            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
 
       - name: Prepare exact touchGrass source
         run: |
@@ -97,18 +98,30 @@ jobs:
       - name: Replace legacy exec dispatch with working manual hook
         run: ./scripts/07_patch_resukisu_exec_hook.sh
 
-      - name: Build ReSukiSU manual hooks plus SUSFS detection API
+      - name: Build ReSukiSU, SUSFS detection, and recovery keycombo
         run: |
           set -o pipefail
           ./scripts/57_build_resukisu_susfs_manual_detection.sh \
-            2>&1 | tee artifacts/linux-4.19.206-resukisu-susfs-manual-detection.log
+            2>&1 | tee artifacts/linux-4.19.206-recovery-keycombo.log
 
-      - name: Compare final config with hardware-tested baseline
+      - name: Compare config with hardware-tested baseline
         run: |
+          FINAL_CONFIG="artifacts/config-${LABEL}"
+          NORMALIZED_CONFIG="artifacts/config-${LABEL}.without-recovery-keycombo"
+          REPORT="artifacts/recovery-keycombo-config-comparison.txt"
+
+          grep -Fxq 'CONFIG_INPUT_RECOVERY_KEYCOMBO=y' "$FINAL_CONFIG"
+          grep -v '^CONFIG_INPUT_RECOVERY_KEYCOMBO=' "$FINAL_CONFIG" > "$NORMALIZED_CONFIG"
+
           python3 scripts/56_compare_config_to_working_baseline.py \
-            "artifacts/config-${LABEL}" \
-            artifacts/manual-detection-config-comparison.txt
-          cat artifacts/manual-detection-config-comparison.txt
+            "$NORMALIZED_CONFIG" \
+            "$REPORT"
+
+          {
+            echo 'allowed_non_baseline_symbol=CONFIG_INPUT_RECOVERY_KEYCOMBO=y'
+            echo "actual_final_config_sha256=$(sha256sum "$FINAL_CONFIG" | awk '{print $1}')"
+          } >> "$REPORT"
+          cat "$REPORT"
 
       - name: Check out pinned AnyKernel3
         uses: actions/checkout@v4
@@ -120,20 +133,20 @@ jobs:
 
       - name: Package kernel-only rollback-friendly test ZIP
         run: |
-          cp scripts/09_package_a52xq_anykernel.sh scripts/.package-manual-susfs-detection.sh
-          sed -i "s/grep -Fxq '# CONFIG_KSU_SUSFS is not set'/grep -Fxq 'CONFIG_KSU_SUSFS=y'/" scripts/.package-manual-susfs-detection.sh
-          sed -i 's/SUSFS must remain disabled for this package/Kernel config does not enable SUSFS core/' scripts/.package-manual-susfs-detection.sh
-          sed -i 's/susfs=disabled/susfs=core-only-manual-hooks-detection-api/' scripts/.package-manual-susfs-detection.sh
-          sed -i 's/SUSFS: disabled/SUSFS: v1.4.2 core with detection API, manual hooks retained/' scripts/.package-manual-susfs-detection.sh
-          sed -i 's/ReSukiSU-v4.1.0-BUILD-VERIFIED-FLASHABLE.zip/ReSukiSU-v4.1.0-SUSFS-v1.4.2-MANUAL-DETECTION-TEST.zip/' scripts/.package-manual-susfs-detection.sh
-          sed -i 's/kernel.string=touchGrass A52xq Linux \$TARGET_VERSION + ReSukiSU v4.1.0/kernel.string=touchGrass A52xq Linux \$TARGET_VERSION + ReSukiSU v4.1.0 + SUSFS detection/' scripts/.package-manual-susfs-detection.sh
-          chmod +x scripts/.package-manual-susfs-detection.sh
-          ./scripts/.package-manual-susfs-detection.sh \
+          cp scripts/09_package_a52xq_anykernel.sh scripts/.package-recovery-keycombo.sh
+          sed -i "s/grep -Fxq '# CONFIG_KSU_SUSFS is not set'/grep -Fxq 'CONFIG_KSU_SUSFS=y'/" scripts/.package-recovery-keycombo.sh
+          sed -i 's/SUSFS must remain disabled for this package/Kernel config does not enable SUSFS core/' scripts/.package-recovery-keycombo.sh
+          sed -i 's/susfs=disabled/susfs=core-only-manual-hooks-detection-api/' scripts/.package-recovery-keycombo.sh
+          sed -i 's/SUSFS: disabled/SUSFS: v1.4.2 core with detection API, manual hooks retained/' scripts/.package-recovery-keycombo.sh
+          sed -i 's/ReSukiSU-v4.1.0-BUILD-VERIFIED-FLASHABLE.zip/ReSukiSU-v4.1.0-SUSFS-v1.4.2-RECOVERY-KEYCOMBO-TEST.zip/' scripts/.package-recovery-keycombo.sh
+          sed -i 's/kernel.string=touchGrass A52xq Linux $TARGET_VERSION + ReSukiSU v4.1.0/kernel.string=touchGrass A52xq Linux $TARGET_VERSION + ReSukiSU v4.1.0 + SUSFS detection + recovery keycombo/' scripts/.package-recovery-keycombo.sh
+          chmod +x scripts/.package-recovery-keycombo.sh
+          ./scripts/.package-recovery-keycombo.sh \
             4.19.206 \
             "artifacts/Image-${LABEL}" \
             packaging/AnyKernel3 \
             release
-          rm -f scripts/.package-manual-susfs-detection.sh
+          rm -f scripts/.package-recovery-keycombo.sh
 
       - name: Record source diagnostics
         if: always()
@@ -148,6 +161,7 @@ jobs:
           non_susfs_canonical_sha256=494a12a758bec9a7500b3370c4059c989254a468aaf895d43a8e6ea9a0441b92
           non_susfs_symbol_count=5427
           source=hardware-tested-linux-4.19.200-manual-susfs-detection
+          allowed_delta=CONFIG_INPUT_RECOVERY_KEYCOMBO=y
           EOF
           if [ -d workspace/touchgrass-a52xq/.git ]; then
             git -C workspace/touchgrass-a52xq status --short \
@@ -165,7 +179,7 @@ jobs:
       - name: Upload kernel-only test ZIP
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-4.19.206-ReSukiSU-v4.1.0-SUSFS-v1.4.2-MANUAL-DETECTION-TEST-${{ github.run_number }}
+          name: A52XQ-4.19.206-ReSukiSU-SUSFS-RECOVERY-KEYCOMBO-TEST-${{ github.run_number }}
           path: release/
           if-no-files-found: error
           retention-days: 14
@@ -174,7 +188,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-4.19.206-resukisu-susfs-manual-detection-${{ github.run_number }}-diagnostics
+          name: a52xq-4.19.206-recovery-keycombo-${{ github.run_number }}-diagnostics
           path: artifacts/
           if-no-files-found: error
           retention-days: 14

--- a/scripts/56_patch_and_run_resukisu_susfs_manual_core.sh
+++ b/scripts/56_patch_and_run_resukisu_susfs_manual_core.sh
@@ -10,5 +10,6 @@ test -f "$FINAL_SCRIPT" || { echo "ERROR: generated build script not found: $FIN
 python3 "$SCRIPT_DIR/56_patch_resukisu_susfs_manual_core.py" "$FINAL_SCRIPT"
 python3 "$SCRIPT_DIR/56_patch_manage_mark_for_manual_susfs.py" "$FINAL_SCRIPT"
 python3 "$SCRIPT_DIR/56_patch_susfs_detection_api.py" "$FINAL_SCRIPT"
+python3 "$SCRIPT_DIR/58_patch_recovery_keycombo.py" "$FINAL_SCRIPT"
 bash -n "$FINAL_SCRIPT"
 exec bash "$FINAL_SCRIPT"

--- a/scripts/58_patch_recovery_keycombo.py
+++ b/scripts/58_patch_recovery_keycombo.py
@@ -22,7 +22,7 @@ def main() -> None:
     config_anchor = '"$KERNEL_DIR/scripts/config" --file "$DEFCONFIG" \\\n'
     install_block = r"""
 info "Adding boot-time physical recovery key combination"
-install -m 0644 "$SCRIPT_DIR/58_recovery_keycombo.c" \
+install -m 0644 "$(dirname "$0")/58_recovery_keycombo.c" \
   "$KERNEL_DIR/drivers/input/recovery_keycombo.c"
 
 python3 - "$KERNEL_DIR/drivers/input/Kconfig" "$KERNEL_DIR/drivers/input/Makefile" <<'RECOVERYKEYPY'

--- a/scripts/58_patch_recovery_keycombo.py
+++ b/scripts/58_patch_recovery_keycombo.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: 58_patch_recovery_keycombo.py GENERATED_BUILD_SCRIPT")
+
+    path = Path(sys.argv[1])
+    text = path.read_text()
+
+    config_anchor = '"$KERNEL_DIR/scripts/config" --file "$DEFCONFIG" \\\n'
+    install_block = r"""
+info "Adding boot-time physical recovery key combination"
+install -m 0644 "$SCRIPT_DIR/58_recovery_keycombo.c" \
+  "$KERNEL_DIR/drivers/input/recovery_keycombo.c"
+
+python3 - "$KERNEL_DIR/drivers/input/Kconfig" "$KERNEL_DIR/drivers/input/Makefile" <<'RECOVERYKEYPY'
+from pathlib import Path
+import sys
+
+kconfig = Path(sys.argv[1])
+makefile = Path(sys.argv[2])
+
+config_anchor = '''config INPUT_KEYCOMBO
+	bool "Key combo"
+	depends on INPUT
+	---help---
+	  Say Y here if you want to take action when some keys are pressed;
+'''
+config_block = '''
+config INPUT_RECOVERY_KEYCOMBO
+	bool "A52 boot-time Volume Up + Power recovery combination"
+	depends on INPUT
+	help
+	  Reboot into Android recovery when the physical Volume Up and Power
+	  buttons are held together during the early kernel boot window.
+
+	  This is specific to the Galaxy A52 input device names gpio_keys and
+	  qpnp_pon and is intended to be built into the kernel.
+'''
+text = kconfig.read_text()
+if 'config INPUT_RECOVERY_KEYCOMBO\n' not in text:
+    if text.count(config_anchor) != 1:
+        raise SystemExit('drivers/input/Kconfig keycombo anchor mismatch')
+    kconfig.write_text(text.replace(config_anchor, config_anchor + config_block, 1))
+
+make_anchor = 'obj-$(CONFIG_INPUT_KEYCOMBO)\t+= keycombo.o\n'
+make_line = 'obj-$(CONFIG_INPUT_RECOVERY_KEYCOMBO) += recovery_keycombo.o\n'
+text = makefile.read_text()
+if make_line not in text:
+    if text.count(make_anchor) != 1:
+        raise SystemExit('drivers/input/Makefile keycombo anchor mismatch')
+    makefile.write_text(text.replace(make_anchor, make_anchor + make_line, 1))
+RECOVERYKEYPY
+
+"$KERNEL_DIR/scripts/config" --file "$DEFCONFIG" -e INPUT_RECOVERY_KEYCOMBO
+git -C "$KERNEL_DIR" add -N drivers/input/recovery_keycombo.c
+require_line "$DEFCONFIG" 'CONFIG_INPUT_RECOVERY_KEYCOMBO=y'
+grep -Fq 'config INPUT_RECOVERY_KEYCOMBO' "$KERNEL_DIR/drivers/input/Kconfig" || \
+  fail "Recovery keycombo Kconfig entry is missing"
+grep -Fq 'obj-$(CONFIG_INPUT_RECOVERY_KEYCOMBO) += recovery_keycombo.o' \
+  "$KERNEL_DIR/drivers/input/Makefile" || fail "Recovery keycombo Makefile entry is missing"
+grep -Fq 'androidboot.boot_recovery=1' "$KERNEL_DIR/drivers/input/recovery_keycombo.c" || \
+  fail "Recovery-mode loop guard is missing"
+grep -Fq 'strcmp(input_device->name, "qpnp_pon")' \
+  "$KERNEL_DIR/drivers/input/recovery_keycombo.c" || fail "Physical power-key filter is missing"
+grep -Fq 'strcmp(input_device->name, "gpio_keys")' \
+  "$KERNEL_DIR/drivers/input/recovery_keycombo.c" || fail "Physical volume-key filter is missing"
+
+"""
+    text = replace_once(
+        text,
+        config_anchor,
+        install_block + config_anchor,
+        "kernel config command anchor",
+    )
+
+    text = replace_once(
+        text,
+        "resukisu-v4.1.0-susfs-v1.4.2-manual-core",
+        "resukisu-v4.1.0-susfs-v1.4.2-manual-core-recovery-keycombo",
+        "build label",
+    )
+
+    image_anchor = (
+        'grep -Fxq "$RESUKISU_VERSION_FULL" "$ARTIFACTS_DIR/Image-$LABEL.strings.txt" '
+        '|| fail "Expected ReSukiSU version string is missing"\n'
+    )
+    image_check = (
+        'grep -Fq \'recovery-keycombo\' "$ARTIFACTS_DIR/Image-$LABEL.strings.txt" || '
+        'fail "Recovery keycombo marker is missing from the compiled Image"\n'
+    )
+    text = replace_once(
+        text,
+        image_anchor,
+        image_anchor + image_check,
+        "compiled Image marker anchor",
+    )
+
+    config_assert_anchor = 'require_line "$FINAL_CONFIG" \'CONFIG_KSU_SUSFS=y\'\n'
+    text = replace_once(
+        text,
+        config_assert_anchor,
+        config_assert_anchor
+        + 'require_line "$FINAL_CONFIG" \'CONFIG_INPUT_RECOVERY_KEYCOMBO=y\'\n',
+        "final recovery config assertion",
+    )
+
+    report_anchor = "  printf 'susfs_profile=core-only-all-features-off\\n'\n"
+    report_extension = (
+        "  printf 'recovery_keycombo=enabled\\n'\n"
+        "  printf 'recovery_keycombo_hold_ms=800\\n'\n"
+        "  printf 'recovery_keycombo_boot_window_ms=30000\\n'\n"
+        "  printf 'recovery_keycombo_devices=gpio_keys+qpnp_pon\\n'\n"
+    )
+    text = replace_once(
+        text,
+        report_anchor,
+        report_anchor + report_extension,
+        "build report recovery anchor",
+    )
+
+    old_diff = (
+        'git -C "$KERNEL_DIR" diff --binary -- arch/arm64/configs/a52xq_defconfig '
+        'drivers/Makefile drivers/Kconfig drivers/input/input.c fs/read_write.c '
+        'fs/stat.c kernel/reboot.c > "$HOST_PATCH"'
+    )
+    new_diff = (
+        'git -C "$KERNEL_DIR" diff --binary -- arch/arm64/configs/a52xq_defconfig '
+        'drivers/Makefile drivers/Kconfig drivers/input/Makefile drivers/input/Kconfig '
+        'drivers/input/input.c drivers/input/recovery_keycombo.c fs/read_write.c '
+        'fs/stat.c kernel/reboot.c > "$HOST_PATCH"'
+    )
+    text = replace_once(text, old_diff, new_diff, "host diagnostic diff list")
+
+    path.write_text(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/58_recovery_keycombo.c
+++ b/scripts/58_recovery_keycombo.c
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Boot-time recovery key combination for Samsung Galaxy A52 5G.
+ *
+ * Reboot into Android recovery when the physical Volume Up and Power
+ * buttons are held together during the early boot window.
+ */
+
+#include <linux/input.h>
+#include <linux/init.h>
+#include <linux/jiffies.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/reboot.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/string.h>
+#include <linux/workqueue.h>
+
+#define DRIVER_NAME             "recovery-keycombo"
+#define RECOVERY_HOLD_MS        800
+#define RECOVERY_BOOT_WINDOW_MS 30000
+
+struct recovery_key_handle {
+	struct input_handle handle;
+	bool tracks_power;
+	bool tracks_volume_up;
+	bool power_down;
+	bool volume_up_down;
+};
+
+static DEFINE_SPINLOCK(recovery_state_lock);
+static int power_down_count;
+static int volume_up_down_count;
+static bool recovery_triggered;
+static unsigned long recovery_boot_deadline;
+static char recovery_reboot_command[] = "recovery";
+
+extern char *saved_command_line;
+
+static bool recovery_combo_is_down_locked(void)
+{
+	return power_down_count > 0 && volume_up_down_count > 0;
+}
+
+static bool recovery_already_booting(void)
+{
+	if (strstr(saved_command_line, "androidboot.boot_recovery=1"))
+		return true;
+	if (strstr(saved_command_line, "androidboot.mode=recovery"))
+		return true;
+	if (strstr(saved_command_line, "androidboot.bootmode=recovery"))
+		return true;
+	return false;
+}
+
+static void recovery_reboot_work_function(struct work_struct *work)
+{
+	unsigned long flags;
+	bool should_reboot = false;
+
+	(void)work;
+	spin_lock_irqsave(&recovery_state_lock, flags);
+	if (!recovery_triggered && recovery_combo_is_down_locked() &&
+	    time_before(jiffies, recovery_boot_deadline)) {
+		recovery_triggered = true;
+		should_reboot = true;
+	}
+	spin_unlock_irqrestore(&recovery_state_lock, flags);
+
+	if (!should_reboot)
+		return;
+
+	pr_emerg(DRIVER_NAME
+		 ": physical Volume Up + Power held during boot, rebooting to recovery\n");
+	kernel_restart(recovery_reboot_command);
+	pr_emerg(DRIVER_NAME ": kernel_restart() unexpectedly returned\n");
+}
+
+static DECLARE_DELAYED_WORK(recovery_reboot_work,
+			    recovery_reboot_work_function);
+
+static void recovery_update_delayed_work(bool arm)
+{
+	if (arm)
+		mod_delayed_work(system_wq, &recovery_reboot_work,
+				 msecs_to_jiffies(RECOVERY_HOLD_MS));
+	else
+		cancel_delayed_work(&recovery_reboot_work);
+}
+
+static void recovery_key_event(struct input_handle *handle,
+			       unsigned int type,
+			       unsigned int code,
+			       int value)
+{
+	struct recovery_key_handle *key_handle = handle->private;
+	unsigned long flags;
+	bool pressed;
+	bool arm_work;
+	bool state_changed = false;
+
+	if (type != EV_KEY)
+		return;
+	if (code == KEY_POWER && !key_handle->tracks_power)
+		return;
+	if (code == KEY_VOLUMEUP && !key_handle->tracks_volume_up)
+		return;
+	if (code != KEY_POWER && code != KEY_VOLUMEUP)
+		return;
+
+	pressed = value != 0;
+	spin_lock_irqsave(&recovery_state_lock, flags);
+
+	if (code == KEY_POWER) {
+		if (key_handle->power_down != pressed) {
+			key_handle->power_down = pressed;
+			if (pressed)
+				power_down_count++;
+			else if (power_down_count > 0)
+				power_down_count--;
+			state_changed = true;
+		}
+	} else if (key_handle->volume_up_down != pressed) {
+		key_handle->volume_up_down = pressed;
+		if (pressed)
+			volume_up_down_count++;
+		else if (volume_up_down_count > 0)
+			volume_up_down_count--;
+		state_changed = true;
+	}
+
+	arm_work = state_changed && !recovery_triggered &&
+		   time_before(jiffies, recovery_boot_deadline) &&
+		   recovery_combo_is_down_locked();
+	spin_unlock_irqrestore(&recovery_state_lock, flags);
+
+	if (state_changed)
+		recovery_update_delayed_work(arm_work);
+}
+
+static int recovery_key_connect(struct input_handler *handler,
+				struct input_dev *input_device,
+				const struct input_device_id *id)
+{
+	struct recovery_key_handle *key_handle;
+	unsigned long flags;
+	bool is_power_device;
+	bool is_volume_device;
+	bool arm_work;
+	int error;
+
+	(void)id;
+	if (!input_device->name)
+		return -ENODEV;
+
+	is_power_device = !strcmp(input_device->name, "qpnp_pon") &&
+		test_bit(KEY_POWER, input_device->keybit);
+	is_volume_device = !strcmp(input_device->name, "gpio_keys") &&
+		test_bit(KEY_VOLUMEUP, input_device->keybit);
+	if (!is_power_device && !is_volume_device)
+		return -ENODEV;
+
+	key_handle = kzalloc(sizeof(*key_handle), GFP_KERNEL);
+	if (!key_handle)
+		return -ENOMEM;
+
+	key_handle->tracks_power = is_power_device;
+	key_handle->tracks_volume_up = is_volume_device;
+	key_handle->handle.dev = input_device;
+	key_handle->handle.handler = handler;
+	key_handle->handle.name = DRIVER_NAME;
+	key_handle->handle.private = key_handle;
+
+	error = input_register_handle(&key_handle->handle);
+	if (error)
+		goto error_free_handle;
+	error = input_open_device(&key_handle->handle);
+	if (error)
+		goto error_unregister_handle;
+
+	spin_lock_irqsave(&recovery_state_lock, flags);
+	if (key_handle->tracks_power && test_bit(KEY_POWER, input_device->key)) {
+		key_handle->power_down = true;
+		power_down_count++;
+	}
+	if (key_handle->tracks_volume_up &&
+	    test_bit(KEY_VOLUMEUP, input_device->key)) {
+		key_handle->volume_up_down = true;
+		volume_up_down_count++;
+	}
+	arm_work = !recovery_triggered &&
+		   time_before(jiffies, recovery_boot_deadline) &&
+		   recovery_combo_is_down_locked();
+	spin_unlock_irqrestore(&recovery_state_lock, flags);
+
+	recovery_update_delayed_work(arm_work);
+	pr_info(DRIVER_NAME ": attached to physical input device \"%s\"\n",
+		input_device->name);
+	return 0;
+
+error_unregister_handle:
+	input_unregister_handle(&key_handle->handle);
+error_free_handle:
+	kfree(key_handle);
+	return error;
+}
+
+static void recovery_key_disconnect(struct input_handle *handle)
+{
+	struct recovery_key_handle *key_handle = handle->private;
+	unsigned long flags;
+	bool combo_still_down;
+
+	spin_lock_irqsave(&recovery_state_lock, flags);
+	if (key_handle->power_down && power_down_count > 0)
+		power_down_count--;
+	if (key_handle->volume_up_down && volume_up_down_count > 0)
+		volume_up_down_count--;
+	combo_still_down = recovery_combo_is_down_locked();
+	spin_unlock_irqrestore(&recovery_state_lock, flags);
+
+	if (!combo_still_down)
+		cancel_delayed_work(&recovery_reboot_work);
+	input_close_device(handle);
+	input_unregister_handle(handle);
+	kfree(key_handle);
+}
+
+static const struct input_device_id recovery_key_ids[] = {
+	{
+		.flags = INPUT_DEVICE_ID_MATCH_EVBIT,
+		.evbit = { BIT_MASK(EV_KEY) },
+	},
+	{ },
+};
+
+static struct input_handler recovery_key_handler = {
+	.event = recovery_key_event,
+	.connect = recovery_key_connect,
+	.disconnect = recovery_key_disconnect,
+	.name = DRIVER_NAME,
+	.id_table = recovery_key_ids,
+};
+
+static int __init recovery_keycombo_init(void)
+{
+	int error;
+
+	if (recovery_already_booting()) {
+		pr_info(DRIVER_NAME
+			": recovery boot detected, key combination disabled\n");
+		return 0;
+	}
+
+	recovery_boot_deadline =
+		jiffies + msecs_to_jiffies(RECOVERY_BOOT_WINDOW_MS);
+	error = input_register_handler(&recovery_key_handler);
+	if (error) {
+		pr_err(DRIVER_NAME ": input handler registration failed: %d\n",
+		       error);
+		return error;
+	}
+
+	pr_info(DRIVER_NAME
+		": enabled for %u ms, hold physical Volume Up + Power for %u ms\n",
+		RECOVERY_BOOT_WINDOW_MS, RECOVERY_HOLD_MS);
+	return 0;
+}
+
+device_initcall(recovery_keycombo_init);
+
+MODULE_DESCRIPTION("A52 boot-time physical key recovery reboot");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
## What changed

- adds a built-in A52-specific input handler for the physical `gpio_keys` Volume Up key and `qpnp_pon` Power key
- requires both keys to remain pressed for 800 ms
- limits activation to the first 30 seconds after the handler initializes
- calls `kernel_restart("recovery")`, using the existing Qualcomm recovery restart-reason path
- disables the shortcut when the kernel command line contains `androidboot.boot_recovery=1`
- ignores headset and other virtual Volume Up input devices by matching the physical input-device names collected from the target phone

## Build integration

The change is layered on the hardware-tested Linux 4.19.206 ReSukiSU manual-hook and SUSFS detection branch from PR #47. The build injector adds:

- `drivers/input/recovery_keycombo.c`
- `CONFIG_INPUT_RECOVERY_KEYCOMBO=y`
- the corresponding input Kconfig and Makefile entries

The workflow permits exactly one non-baseline configuration delta: `CONFIG_INPUT_RECOVERY_KEYCOMBO=y`. It also verifies that the compiled `Image` contains the recovery-keycombo marker and packages a separately named kernel-only AnyKernel test ZIP.

## Device-specific evidence

The device dump identified:

- physical Volume Up: `gpio_keys`, `KEY_VOLUMEUP`
- physical Power: `qpnp_pon`, `KEY_POWER`
- normal boot marker: `androidboot.boot_recovery=0`

The Qualcomm restart driver recognizes the `recovery` command and writes the recovery restart reason.

## Safety and validation

- remains a draft until the GitHub Actions build passes and the ZIP is tested on the Galaxy A52 5G
- preserves the tested ReSukiSU and SUSFS profile
- does not modify the ramdisk, DTBO, vendor boot, or recovery partition
- keep the currently working 4.19.206 kernel available for rollback before flashing

## Hardware test

1. Flash the generated recovery-keycombo test ZIP.
2. Power on normally without holding the buttons and verify Android boots.
3. Reboot again and hold physical Volume Up plus Power during early boot.
4. Keep both held for at least 800 ms and verify the device restarts into recovery.
5. Verify holding the combination after the 30-second boot window does not trigger a restart.