### PR TITLE
Trigger clean Workflow 156 failure-window build

### DIFF
--- a/diagnostics/workflow156-clean-trigger.txt
+++ b/diagnostics/workflow156-clean-trigger.txt
@@ -1,0 +1,1 @@
+Trigger Workflow 156 against the recorder branch using a clean one-file pull request.

--- a/diagnostics/workflow156-clean-trigger.txt
+++ b/diagnostics/workflow156-clean-trigger.txt
@@ -1,1 +1,1 @@
-Trigger Workflow 156 after adding the __maybe_unused scope fix and the full QSEECOM heaps 19 and 27 build pipeline.
+Trigger Workflow 158 to compare the active ACK drivers/a52_display initialization path against the exact working TouchGrass 4.19 source.

--- a/diagnostics/workflow156-clean-trigger.txt
+++ b/diagnostics/workflow156-clean-trigger.txt
@@ -1,1 +1,1 @@
-Trigger Workflow 156 against the recorder branch using a clean one-file pull request.
+Trigger Workflow 156 after adding the __maybe_unused scope fix and the full QSEECOM heaps 19 and 27 build pipeline.

--- a/diagnostics/workflow156-clean-trigger.txt
+++ b/diagnostics/workflow156-clean-trigger.txt
@@ -1,1 +1,1 @@
-Trigger Workflow 158 to compare the active ACK drivers/a52_display initialization path against the exact working TouchGrass 4.19 source.
+Trigger Workflow 158 extended audit for active display source, device tree, clocks, regulators, continuous splash and configuration parity.


### PR DESCRIPTION
Closed as an obsolete clean Workflow 156 trigger. The recorder result has been superseded by the finalized REFGEN candidate and hardware-validation gate in PR #62.