### PR TITLE
Superseded: A52 REFGEN hardware validation moved to issue #68

### DIFF
--- a/diagnostics/refgen-build-trigger.txt
+++ b/diagnostics/refgen-build-trigger.txt
@@ -1,1 +1,1 @@
-Trigger Workflow 160 against the audited ACK 5.10 source with the Kona REFGEN regulator and persistent display diagnostics.
+Trigger Workflow 160 against the audited ACK 5.10 source with the Kona REFGEN regulator, persistent display diagnostics, and the recorder __maybe_unused compile fix.

--- a/diagnostics/refgen-build-trigger.txt
+++ b/diagnostics/refgen-build-trigger.txt
@@ -1,0 +1,1 @@
+Trigger Workflow 160 against the audited ACK 5.10 source with the Kona REFGEN regulator and persistent display diagnostics.

--- a/diagnostics/refgen-finalize-trigger.txt
+++ b/diagnostics/refgen-finalize-trigger.txt
@@ -1,0 +1,1 @@
+Finalize Workflow 160 artifact 8646194609 with make return code 0 using Workflow 161.


### PR DESCRIPTION
## Active hardware-validation gate

This draft PR tracks the single remaining device test for the Galaxy A52 5G ACK 5.10 REFGEN display-supply candidate. It is a CI launcher and evidence tracker, not a merge request.

## Audited candidate

- successful finalization run: `30250912889`
- artifact: `a52xq-refgen-display-fix-final-1-NOT-HARDWARE-VALIDATED`
- artifact ID: `8646929814`
- `boot.img` SHA-256: `d7959b3c917a22966d39b12e799ca1cee10bcb090632ec9ab8930d716166809a`
- `boot.img` size: `100663296` bytes
- kernel compile return code: `0`
- REFGEN built in and instrumented
- stock DTB, ramdisk and recovery DTBO preserved
- watchdog disarmed and registration bypassed
- persistent five-minute heartbeat and display failure-window recorder retained

## REFGEN implementation

The candidate ports the downstream Qualcomm Kona REFGEN provider required by the stock DSI `refgen-supply` relationship and records registration, probe, MMIO mapping, ready state, enable, disable and state checks.

Exact A52 source audit found an inherited resource-span inconsistency: the Lagoon node declares `reg = <0x88e7000 0x60>`, while the downstream driver accesses control register offset `0x80`. The working downstream kernel uses the same combination. The candidate therefore preserves that behaviour for the first hardware test instead of introducing an unproven DT change.

## Analysis, intake, and evidence tooling

Metadata-only tooling is merged into `agent/a52-keymaster-real-ion`:

- PR #64, commit `9b95fa6e58482ef7e9670c1a43b6714ab000b60a`: REFGEN and display verdict engine, exact versus mirrored recovery, resource-span warning and Workflow 162
- PR #65, commit `f48f68923b49e4d78aa271229d5f489ed33a433c`: task-aware display scope pairing using PID/TGID with task-name fallback
- PR #66, commit `9f82eb1c8c2178b6c165377bb60fcb36290d34df`: non-destructive candidate preflight, collector ZIP and raw-image intake validation, Windows wrappers and safety tests
- PR #67, commit `a51d9b5107821176950cb9a235ba953b95cd6e7c`: candidate-to-capture session binding, deterministic evidence ZIPs, external receipts, and receiver-side verification
- Workflow 162 run `30257125567`: validator, corruption, ZIP-safety, REFGEN verdict, exact A52 layout, task-pairing, and privacy tests passed
- Workflow 163 run `30258528832`: evidence-session compilation plus start, finish, and verify self-tests passed

The preflight verifies the exact audited boot image size and hash plus the complete kit manifest. Capture intake verifies the 1 MiB raw image, recovery context, exporter identity, and collector checksums before diagnosis. The evidence-session workflow revalidates the candidate after collection, preserves the original capture, records the screen result and verdict, and creates a checksum-locked handoff bundle.

CPU is intentionally excluded from display-scope identity because a task may migrate while a display function is running. This prevents one task's exit marker from closing another task's entry marker.

## Binding hardware procedure

1. Extract the v6 hardware-test kit.
2. Run `tools\preflight_a52_refgen_candidate.bat` and require a PASS result.
3. Run `tools\start_a52_refgen_test_session.bat` and preserve the generated session directory.
4. Keep a known-working boot image ready and back up the current `boot` partition.
5. Flash only the candidate `package/boot.img` to `boot` using the proven Run 32 method.
6. Do not flash DTBO, vendor boot, recovery or data.
7. Boot normally and observe whether the lock screen appears and remains usable.
8. If the screen is black, leave the phone running for at least 15 seconds.
9. Enter OrangeFox directly without flashing another kernel first.
10. Run `tools\collect_a52_raw_ramoops_exporter_FIXED.bat`.
11. Preserve the untouched collector ZIP and raw 1 MiB file even if a later step fails.
12. Run `tools\finish_a52_refgen_test_session.bat <session-directory> <collector.zip> black`, or use `stable` when the display remained usable.
13. Preserve the evidence ZIP together with its matching `.sha256` and `.receipt.json` files.
14. Verify the handoff with `tools\verify_a52_refgen_evidence_bundle.bat <evidence.zip>`.

Minimum evidence to preserve:

- untouched collector ZIP
- `ramoops-raw-1MiB.bin`
- `exporter-status.txt`
- `recovery-identity.txt`
- `recovery-dmesg.txt`
- `pstore-list.txt`
- `SHA256SUMS.txt`
- `a52-refgen-test-session.json`
- `capture-intake.json`
- `diagnosis.json`
- `A52_REFGEN_EVIDENCE_<session-id>.zip`
- matching `.sha256` and `.receipt.json` files

## Decision rule

- stable display plus successful REFGEN enable supports the missing-provider hypothesis
- REFGEN probe failure moves work to the recorded probe stage
- successful REFGEN enable followed by an unmatched display function moves instrumentation only inside that function and recorded task context
- checksum, size, collection-context, or bundle-verification failure triggers a collection retry, not another speculative kernel patch

The image remains explicitly not hardware validated until this device test is completed.