### PR TITLE
Add A52 REFGEN postmortem analyzer

### DIFF
--- a/.github/workflows/162-a52-refgen-postmortem-analyzer.yml
+++ b/.github/workflows/162-a52-refgen-postmortem-analyzer.yml
@@ -1,0 +1,88 @@
+name: 162 - A52 REFGEN postmortem analyzer
+
+run-name: Validate metadata-only REFGEN and display diagnosis tooling
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - agent/a52-keymaster-real-ion
+    paths:
+      - tools/a52-refgen/diagnose-a52-refgen-display.py
+      - docs/A52-REFGEN-POSTMORTEM.md
+      - .github/workflows/162-a52-refgen-postmortem-analyzer.yml
+  push:
+    branches:
+      - agent/a52-refgen-postmortem-analyzer
+    paths:
+      - tools/a52-refgen/diagnose-a52-refgen-display.py
+      - docs/A52-REFGEN-POSTMORTEM.md
+      - .github/workflows/162-a52-refgen-postmortem-analyzer.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a52-refgen-postmortem-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyzer-self-test:
+    name: Compile and self-test REFGEN diagnosis
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out tooling branch
+        uses: actions/checkout@v4
+
+      - name: Compile analyzer
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile tools/a52-refgen/diagnose-a52-refgen-display.py
+
+      - name: Run built-in verdict tests
+        run: |
+          set -Eeuo pipefail
+          python3 tools/a52-refgen/diagnose-a52-refgen-display.py --self-test \
+            | tee analyzer-self-test.json
+          grep -Fq '"status": "self-test-passed"' analyzer-self-test.json
+
+      - name: Run decoded-CSV integration test
+        run: |
+          set -Eeuo pipefail
+          mkdir -p fixture output
+          cat > fixture/standard.csv <<'EOF'
+          seq,monotonic_ns,message
+          1,1000000,WDT disarm before=1 after=0
+          2,2000000,REFGEN driver_register rc=0
+          3,3000000,"REFGEN probe enter compat=qcom,refgen-kona-regulator"
+          4,4000000,REFGEN mapped start=0x88e7000 size=132 raw=0x0
+          5,5000000,REFGEN probe ready initial_enabled=0
+          6,6000000,REFGEN kona_enable raw=0x0->0x1 enabled=1
+          7,7000000,DISP enter fn=dsi_display_enable
+          8,8000000,HB tick=1 online=8 run=2 j=100
+          EOF
+          sed -i 's/^          //' fixture/standard.csv
+          python3 tools/a52-refgen/diagnose-a52-refgen-display.py \
+            --standard-csv fixture/standard.csv \
+            --screen-result black \
+            --output output \
+            | tee integration-result.json
+          grep -Fq '"verdict": "refgen_operational_display_scope_stalled"' \
+            integration-result.json
+          grep -Fq '"code": "refgen_operational_display_scope_stalled"' \
+            output/diagnosis.json
+          test -s output/diagnosis.md
+          test -s output/critical-timeline.csv
+
+      - name: Enforce metadata-only contract
+        run: |
+          set -Eeuo pipefail
+          grep -Fq 'metadata-only; no secure payloads' \
+            tools/a52-refgen/diagnose-a52-refgen-display.py
+          if grep -nE 'command buffer|response buffer|key material|process memory dump' \
+              tools/a52-refgen/diagnose-a52-refgen-display.py; then
+            echo 'Unexpected payload-capture language found' >&2
+            exit 1
+          fi

--- a/.github/workflows/162-a52-refgen-postmortem-analyzer.yml
+++ b/.github/workflows/162-a52-refgen-postmortem-analyzer.yml
@@ -57,7 +57,7 @@ jobs:
           1,1000000,WDT disarm before=1 after=0
           2,2000000,REFGEN driver_register rc=0
           3,3000000,"REFGEN probe enter compat=qcom,refgen-kona-regulator"
-          4,4000000,REFGEN mapped start=0x88e7000 size=132 raw=0x0
+          4,4000000,REFGEN mapped start=0x88e7000 size=96 raw=0x0
           5,5000000,REFGEN probe ready initial_enabled=0
           6,6000000,REFGEN kona_enable raw=0x0->0x1 enabled=1
           7,7000000,DISP enter fn=dsi_display_enable
@@ -75,6 +75,9 @@ jobs:
             output/diagnosis.json
           test -s output/diagnosis.md
           test -s output/critical-timeline.csv
+          grep -Fq '"stock_lagoon_0x60_layout": true' output/diagnosis.json
+          grep -Fq '"resource_covers_ctrl5": false' output/diagnosis.json
+          grep -Fq 'outside the declared resource span' output/diagnosis.json
 
       - name: Enforce metadata-only contract
         run: |

--- a/docs/A52-REFGEN-POSTMORTEM.md
+++ b/docs/A52-REFGEN-POSTMORTEM.md
@@ -1,0 +1,70 @@
+# A52 REFGEN postmortem analysis
+
+## Scope
+
+This tooling classifies the next hardware capture from the audited ACK 5.10
+REFGEN candidate. It does not modify the kernel, boot image, device tree,
+regulator driver, recorder, watchdog policy, or display sequence.
+
+The analyzer consumes two independent metadata-only decoder views:
+
+- exact A52USR2 records from the standard decoder
+- high and medium confidence recovery from the mirrored console and ftrace banks
+
+Exact records take priority. Mirrored records fill sequence gaps only when an
+exact copy is unavailable. Low-confidence recovered records are excluded from
+verdict decisions.
+
+## REFGEN parity result
+
+The Kona downstream implementation uses register offset `0x80`, bit 0 as the
+enable mask, writes 1 to enable, writes 0 to disable, and reads the same bit for
+`is_enabled`. The stock node maps `0x84` bytes, so the final 32-bit register at
+`0x80` is inside the resource. The diagnostic port preserves that behaviour and
+adds metadata-only before/after records.
+
+No further speculative REFGEN change should be made before the device test.
+
+## Inputs
+
+The preferred input is the untouched `ramoops-raw-1MiB.bin` capture. Place the
+analyzer beside these existing tools from the v2 test kit:
+
+- `decode-a52-unified-secure-recorder.py`
+- `decode-a52-mirrored-ramoops-v2.py`
+
+Then run:
+
+```bash
+python3 diagnose-a52-refgen-display.py ramoops-raw-1MiB.bin \
+  --screen-result black \
+  --output a52-refgen-display-diagnosis
+```
+
+It can also consume decoder CSVs directly:
+
+```bash
+python3 diagnose-a52-refgen-display.py \
+  --standard-csv decoded-standard/secure-events.csv \
+  --mirrored-csv decoded-mirrored/recovered-events.csv \
+  --screen-result black \
+  --output a52-refgen-display-diagnosis
+```
+
+## Outputs
+
+- `diagnosis.md`: readable verdict and next action
+- `diagnosis.json`: complete structured evidence
+- `critical-timeline.csv`: ordered REFGEN, display, heartbeat, and watchdog events
+
+## Decision boundary
+
+A stable screen after a successful REFGEN enable supports the missing-provider
+hypothesis. A black screen with an unmatched display scope moves the next patch
+to that one function. A REFGEN probe failure moves the patch to the recorded
+probe stage. Missing recorder evidence triggers a collection retry, not another
+kernel change.
+
+The analyzer processes recorder metadata only. It does not recover secure
+payloads, keys, authentication tokens, command buffers, response buffers, or
+process memory.

--- a/docs/A52-REFGEN-POSTMORTEM.md
+++ b/docs/A52-REFGEN-POSTMORTEM.md
@@ -19,9 +19,12 @@ verdict decisions.
 
 The Kona downstream implementation uses register offset `0x80`, bit 0 as the
 enable mask, writes 1 to enable, writes 0 to disable, and reads the same bit for
-`is_enabled`. The stock node maps `0x84` bytes, so the final 32-bit register at
-`0x80` is inside the resource. The diagnostic port preserves that behaviour and
-adds metadata-only before/after records.
+`is_enabled`. The exact A52 Lagoon node declares only `0x60` bytes at
+`0x88e7000`, while the working downstream driver still accesses offset `0x80`.
+This is an inherited DT/driver resource-span inconsistency, not a different
+register choice introduced by the ACK candidate. The diagnostic port preserves
+the working downstream behaviour and the analyzer reports the inconsistency as
+a warning.
 
 No further speculative REFGEN change should be made before the device test.
 

--- a/tools/a52-refgen/diagnose-a52-refgen-display.py
+++ b/tools/a52-refgen/diagnose-a52-refgen-display.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Diagnose Galaxy A52 REFGEN/display RAMOOPS recorder evidence.
-
-The tool consumes the CSV output from the standard A52USR2 decoder and the
-corruption-tolerant mirrored decoder. When a raw capture is supplied it can run
-both sibling decoders automatically. It never reads secure payload contents.
-"""
+"""Diagnose metadata-only A52 REFGEN and display RAMOOPS evidence."""
 from __future__ import annotations
 
 import argparse
@@ -16,20 +11,16 @@ import sys
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Iterable
 
-CONFIDENCE = {"exact": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
+RANK = {"exact": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
 CRITICAL = ("REFGEN ", "DISP ", "HB ", "WDT ")
-
-PATTERNS = {
+RX = {
     "register": re.compile(r"REFGEN driver_register rc=(-?\d+)$"),
     "probe": re.compile(r"REFGEN probe enter compat=(\S+)$"),
     "failure": re.compile(r"REFGEN probe fail stage=(\S+) rc=(-?\d+)$"),
     "mapped": re.compile(r"REFGEN mapped start=0x([0-9a-fA-F]+) size=(\d+) raw=0x([0-9a-fA-F]+)$"),
     "ready": re.compile(r"REFGEN probe ready initial_enabled=(-?\d+)$"),
-    "state": re.compile(r"REFGEN kona_state raw=0x([0-9a-fA-F]+) enabled=([01])$"),
     "enable": re.compile(r"REFGEN kona_enable raw=0x([0-9a-fA-F]+)->0x([0-9a-fA-F]+) enabled=([01])$"),
-    "disable": re.compile(r"REFGEN kona_disable raw=0x([0-9a-fA-F]+)->0x([0-9a-fA-F]+) enabled=([01])$"),
     "heartbeat": re.compile(r"HB tick=(\d+) online=(\d+) run=(\d+) j=(\d+)$"),
     "watchdog": re.compile(r"WDT disarm before=([01]) after=([01])$"),
     "enter": re.compile(r"DISP enter fn=(\S+)$"),
@@ -41,22 +32,22 @@ PATTERNS = {
 class Event:
     order: int
     seq: int | None
-    monotonic_ns: int | None
+    ns: int | None
     message: str
     confidence: str
     source: str
     offset: int | None = None
 
-    def key(self) -> tuple[int, int, int]:
-        if self.monotonic_ns is not None:
-            return (0, self.monotonic_ns, self.order)
+    def sort_key(self) -> tuple[int, int, int]:
+        if self.ns is not None:
+            return 0, self.ns, self.order
         if self.seq is not None:
-            return (1, self.seq, self.order)
-        return (2, self.order, self.order)
+            return 1, self.seq, self.order
+        return 2, self.order, self.order
 
 
-def integer(value: str | None) -> int | None:
-    if value in (None, ""):
+def number(value: str | None) -> int | None:
+    if not value:
         return None
     try:
         return int(value, 0)
@@ -64,287 +55,242 @@ def integer(value: str | None) -> int | None:
         return None
 
 
-def read_events(path: Path, source: str, default_confidence: str) -> list[Event]:
+def read_csv(path: Path, source: str, default_confidence: str) -> list[Event]:
     if not path.is_file():
         return []
-    rows: list[Event] = []
+    events = []
     with path.open(newline="", encoding="utf-8", errors="replace") as handle:
         for order, row in enumerate(csv.DictReader(handle)):
             message = (row.get("message") or "").strip()
             if not message:
                 continue
-            confidence_value = (row.get("confidence") or default_confidence).lower()
-            rows.append(Event(
-                order=order,
-                seq=integer(row.get("seq")),
-                monotonic_ns=integer(row.get("monotonic_ns")),
-                message=message,
-                confidence=confidence_value if confidence_value in CONFIDENCE else "unknown",
-                source=source,
-                offset=integer(row.get("offset")),
-            ))
-    return rows
+            confidence = (row.get("confidence") or default_confidence).lower()
+            events.append(Event(order, number(row.get("seq")), number(row.get("monotonic_ns")),
+                                message, confidence if confidence in RANK else "unknown",
+                                source, number(row.get("offset"))))
+    return events
 
 
-def merge_events(standard_csv: Path, mirrored_csv: Path) -> tuple[list[Event], dict[str, int]]:
-    exact = read_events(standard_csv, "standard", "exact")
-    mirrored = read_events(mirrored_csv, "mirrored", "high")
+def merge(standard: Path, mirrored: Path) -> tuple[list[Event], dict[str, int]]:
+    exact = read_csv(standard, "standard", "exact")
+    recovered = read_csv(mirrored, "mirrored", "high")
     selected = list(exact)
+    exact_seq = {item.seq for item in exact if item.seq is not None}
     exact_pairs = {(item.seq, item.message) for item in exact}
-    exact_sequences = {item.seq for item in exact if item.seq is not None}
     exact_messages = {item.message for item in exact}
-    for item in mirrored:
-        if item.confidence == "low":
+    for item in recovered:
+        if item.confidence == "low" or (item.seq, item.message) in exact_pairs:
             continue
-        if (item.seq, item.message) in exact_pairs:
-            continue
-        if item.seq is not None and item.seq in exact_sequences:
+        if item.seq is not None and item.seq in exact_seq:
             continue
         if item.seq is None and item.message in exact_messages:
             continue
         selected.append(item)
-    selected.sort(key=Event.key)
-    ordered = [Event(index, item.seq, item.monotonic_ns, item.message,
-                     item.confidence, item.source, item.offset)
-               for index, item in enumerate(selected)]
-    return ordered, {
-        "standard_events": len(exact),
-        "mirrored_events": len(mirrored),
-        "mirrored_high": sum(item.confidence == "high" for item in mirrored),
-        "mirrored_medium": sum(item.confidence == "medium" for item in mirrored),
-        "mirrored_low": sum(item.confidence == "low" for item in mirrored),
-        "selected_events": len(ordered),
+    selected.sort(key=Event.sort_key)
+    selected = [Event(i, e.seq, e.ns, e.message, e.confidence, e.source, e.offset)
+                for i, e in enumerate(selected)]
+    return selected, {
+        "standard_events": len(exact), "mirrored_events": len(recovered),
+        "mirrored_high": sum(e.confidence == "high" for e in recovered),
+        "mirrored_medium": sum(e.confidence == "medium" for e in recovered),
+        "mirrored_low": sum(e.confidence == "low" for e in recovered),
+        "selected_events": len(selected),
     }
 
 
-def found(events: Iterable[Event], name: str) -> list[tuple[Event, re.Match[str]]]:
-    pattern = PATTERNS[name]
-    answer = []
-    for event in events:
-        match = pattern.fullmatch(event.message)
-        if match:
-            answer.append((event, match))
-    return answer
+def matches(events: list[Event], key: str) -> list[tuple[Event, re.Match[str]]]:
+    return [(event, match) for event in events if (match := RX[key].fullmatch(event.message))]
 
 
-def event_dict(item: tuple[Event, re.Match[str]] | None) -> dict[str, object] | None:
-    return asdict(item[0]) if item else None
-
-
-def confidence(events: Iterable[Event]) -> str:
-    values = [item.confidence for item in events]
-    return min(values, key=lambda value: CONFIDENCE.get(value, 99)) if values else "none"
+def best_confidence(events: list[Event]) -> str:
+    return min((e.confidence for e in events), key=lambda x: RANK.get(x, 99), default="none")
 
 
 def display_summary(events: list[Event]) -> dict[str, object]:
-    stack: list[tuple[str, Event]] = []
+    open_scopes: list[tuple[str, Event]] = []
     completed: list[dict[str, object]] = []
-    last: Event | None = None
+    last = None
     for event in events:
-        enter = PATTERNS["enter"].fullmatch(event.message)
-        exit_match = PATTERNS["exit"].fullmatch(event.message)
+        enter, exit_match = RX["enter"].fullmatch(event.message), RX["exit"].fullmatch(event.message)
         if enter:
             last = event
-            stack.append((enter.group(1), event))
-            continue
-        if not exit_match:
-            continue
-        last = event
-        function = exit_match.group(1)
-        index = next((i for i in range(len(stack) - 1, -1, -1)
-                      if stack[i][0] == function), None)
-        if index is None:
-            completed.append({"function": function, "orphan_exit": True,
-                              "duration_us": int(exit_match.group(2)),
-                              "exit_order": event.order})
-            continue
-        _, entered = stack.pop(index)
-        completed.append({"function": function, "orphan_exit": False,
-                          "duration_us": int(exit_match.group(2)),
-                          "enter_order": entered.order, "exit_order": event.order})
-    unmatched = [{"function": function, **asdict(event)} for function, event in stack]
+            open_scopes.append((enter.group(1), event))
+        elif exit_match:
+            last = event
+            function = exit_match.group(1)
+            index = next((i for i in range(len(open_scopes) - 1, -1, -1)
+                          if open_scopes[i][0] == function), None)
+            if index is None:
+                completed.append({"function": function, "orphan_exit": True,
+                                  "duration_us": int(exit_match.group(2)), "exit_order": event.order})
+            else:
+                _, entered = open_scopes.pop(index)
+                completed.append({"function": function, "orphan_exit": False,
+                                  "duration_us": int(exit_match.group(2)),
+                                  "enter_order": entered.order, "exit_order": event.order})
     return {
-        "event_count": sum(item.message.startswith("DISP ") for item in events),
+        "event_count": sum(e.message.startswith("DISP ") for e in events),
         "completed": completed,
-        "unmatched_entries": unmatched,
+        "unmatched_entries": [{"function": fn, **asdict(event)} for fn, event in open_scopes],
         "last_event": asdict(last) if last else None,
     }
 
 
-def summaries(events: list[Event]) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
-    refgen_events = [item for item in events if item.message.startswith("REFGEN ")]
-    register = found(events, "register")
-    probe = found(events, "probe")
-    failure = found(events, "failure")
-    mapped = found(events, "mapped")
-    ready = found(events, "ready")
-    states = found(events, "state")
-    enables = found(events, "enable")
-    disables = found(events, "disable")
-    refgen = {
-        "event_count": len(refgen_events),
-        "confidence": confidence(refgen_events),
-        "driver_register": {"observed": bool(register), "rc": int(register[-1][1].group(1)) if register else None,
-                            "event": event_dict(register[-1] if register else None)},
-        "probe_enter": {"observed": bool(probe), "compat": probe[-1][1].group(1) if probe else None,
-                        "event": event_dict(probe[-1] if probe else None)},
-        "probe_failure": {"observed": bool(failure), "stage": failure[-1][1].group(1) if failure else None,
+def refgen_summary(events: list[Event]) -> dict[str, object]:
+    register, probe = matches(events, "register"), matches(events, "probe")
+    failure, mapped = matches(events, "failure"), matches(events, "mapped")
+    ready, enables = matches(events, "ready"), matches(events, "enable")
+    size = int(mapped[-1][1].group(2)) if mapped else None
+    return {
+        "event_count": sum(e.message.startswith("REFGEN ") for e in events),
+        "confidence": best_confidence([e for e in events if e.message.startswith("REFGEN ")]),
+        "driver_register": {"observed": bool(register),
+                            "rc": int(register[-1][1].group(1)) if register else None,
+                            "event": asdict(register[-1][0]) if register else None},
+        "probe_enter": {"observed": bool(probe),
+                        "compat": probe[-1][1].group(1) if probe else None,
+                        "event": asdict(probe[-1][0]) if probe else None},
+        "probe_failure": {"observed": bool(failure),
+                          "stage": failure[-1][1].group(1) if failure else None,
                           "rc": int(failure[-1][1].group(2)) if failure else None,
-                          "event": event_dict(failure[-1] if failure else None)},
+                          "event": asdict(failure[-1][0]) if failure else None},
         "mapping": {"observed": bool(mapped),
                     "start": int(mapped[-1][1].group(1), 16) if mapped else None,
-                    "size": int(mapped[-1][1].group(2)) if mapped else None,
-                    "raw": int(mapped[-1][1].group(3), 16) if mapped else None},
-        "probe_ready": {"observed": bool(ready), "initial_enabled": int(ready[-1][1].group(1)) if ready else None,
-                        "event": event_dict(ready[-1] if ready else None)},
-        "state_checks": [{"raw": int(match.group(1), 16), "enabled": int(match.group(2)),
-                          "event": asdict(event)} for event, match in states],
-        "enable_calls": [{"before": int(match.group(1), 16), "after": int(match.group(2), 16),
-                          "enabled": int(match.group(3)), "event": asdict(event)} for event, match in enables],
-        "disable_calls": [{"before": int(match.group(1), 16), "after": int(match.group(2), 16),
-                           "enabled": int(match.group(3)), "event": asdict(event)} for event, match in disables],
+                    "size": size, "raw": int(mapped[-1][1].group(3), 16) if mapped else None,
+                    "ctrl5_offset": 0x80, "resource_covers_ctrl5": bool(size is not None and size >= 0x84),
+                    "stock_lagoon_0x60_layout": size == 0x60},
+        "probe_ready": {"observed": bool(ready),
+                        "initial_enabled": int(ready[-1][1].group(1)) if ready else None,
+                        "event": asdict(ready[-1][0]) if ready else None},
+        "enable_calls": [{"before": int(m.group(1), 16), "after": int(m.group(2), 16),
+                          "enabled": int(m.group(3)), "event": asdict(e)} for e, m in enables],
     }
-    heartbeat_rows = found(events, "heartbeat")
-    heartbeat = {
-        "count": len(heartbeat_rows),
-        "first_tick": int(heartbeat_rows[0][1].group(1)) if heartbeat_rows else None,
-        "last_tick": int(heartbeat_rows[-1][1].group(1)) if heartbeat_rows else None,
-        "latest_event": event_dict(heartbeat_rows[-1] if heartbeat_rows else None),
-    }
-    watchdog_rows = found(events, "watchdog")
-    watchdog = {
-        "observed": bool(watchdog_rows),
-        "before": int(watchdog_rows[-1][1].group(1)) if watchdog_rows else None,
-        "after": int(watchdog_rows[-1][1].group(2)) if watchdog_rows else None,
-        "disarmed": bool(watchdog_rows and watchdog_rows[-1][1].group(2) == "0"),
-        "event": event_dict(watchdog_rows[-1] if watchdog_rows else None),
-    }
-    return refgen, heartbeat, watchdog
 
 
-def classify(events: list[Event], refgen: dict[str, object], display: dict[str, object],
-             heartbeat: dict[str, object], screen: str) -> dict[str, str]:
+def simple_summaries(events: list[Event]) -> tuple[dict[str, object], dict[str, object]]:
+    heartbeats, watchdogs = matches(events, "heartbeat"), matches(events, "watchdog")
+    heartbeat = {"count": len(heartbeats),
+                 "first_tick": int(heartbeats[0][1].group(1)) if heartbeats else None,
+                 "last_tick": int(heartbeats[-1][1].group(1)) if heartbeats else None,
+                 "latest_event": asdict(heartbeats[-1][0]) if heartbeats else None}
+    watchdog = {"observed": bool(watchdogs),
+                "before": int(watchdogs[-1][1].group(1)) if watchdogs else None,
+                "after": int(watchdogs[-1][1].group(2)) if watchdogs else None,
+                "disarmed": bool(watchdogs and watchdogs[-1][1].group(2) == "0"),
+                "event": asdict(watchdogs[-1][0]) if watchdogs else None}
+    return heartbeat, watchdog
+
+
+def result(code: str, title: str, confidence: str, meaning: str, action: str) -> dict[str, str]:
+    return {"code": code, "title": title, "confidence": confidence,
+            "meaning": meaning, "next_action": action}
+
+
+def classify(events: list[Event], refgen: dict[str, object], display: dict[str, object], screen: str) -> dict[str, str]:
     if not events:
-        return verdict("no_recorder_events", "No usable A52USR2 events were recovered", "low",
-                       "The capture is missing, incomplete, or too damaged.",
-                       "Repeat collection and preserve the untouched 1 MiB RAMOOPS image.")
-    driver = refgen["driver_register"]
-    probe = refgen["probe_enter"]
-    failure = refgen["probe_failure"]
-    ready = refgen["probe_ready"]
-    enables = refgen["enable_calls"]
+        return result("no_recorder_events", "No usable A52USR2 events were recovered", "low",
+                      "The capture is missing, incomplete, or too damaged.",
+                      "Repeat collection and preserve the untouched 1 MiB RAMOOPS image.")
+    driver, probe = refgen["driver_register"], refgen["probe_enter"]
+    failure, ready, enables = refgen["probe_failure"], refgen["probe_ready"], refgen["enable_calls"]
     assert isinstance(driver, dict) and isinstance(probe, dict)
     assert isinstance(failure, dict) and isinstance(ready, dict) and isinstance(enables, list)
-    conf = str(refgen.get("confidence", "unknown"))
+    confidence = str(refgen.get("confidence", "unknown"))
     if not driver["observed"]:
-        return verdict("refgen_registration_missing", "REFGEN registration was not recorded", conf,
-                       "The initcall did not run, its record was lost, or another image was flashed.",
-                       "Verify the boot.img SHA-256 and inspect BOOT_EARLY and heartbeat records.")
+        return result("refgen_registration_missing", "REFGEN registration was not recorded", confidence,
+                      "The initcall did not run, its record was lost, or another image was flashed.",
+                      "Verify the boot.img hash and inspect BOOT_EARLY and heartbeat records.")
     if driver["rc"] not in (0, None):
-        return verdict("refgen_registration_failed", f"REFGEN registration failed with rc={driver['rc']}", conf,
-                       "The platform driver never became available.",
-                       "Resolve platform_driver_register before changing DSI code.")
+        return result("refgen_registration_failed", f"REFGEN registration failed with rc={driver['rc']}", confidence,
+                      "The platform driver never became available.",
+                      "Resolve platform_driver_register before changing DSI code.")
     if not probe["observed"]:
-        return verdict("refgen_probe_missing", "REFGEN registered but its DT probe never started", conf,
-                       "The stock provider node did not populate or match.",
-                       "Audit node status, compatible, parent population, and platform-device creation.")
+        return result("refgen_probe_missing", "REFGEN registered but its DT probe never started", confidence,
+                      "The stock provider node did not populate or match.",
+                      "Audit node status, compatible, parent population, and platform-device creation.")
     if failure["observed"]:
-        return verdict("refgen_probe_failed", f"REFGEN probe failed at {failure['stage']} with rc={failure['rc']}", conf,
-                       "The provider matched but could not finish registration.",
-                       f"Fix only the recorded probe stage {failure['stage']}.")
+        return result("refgen_probe_failed", f"REFGEN probe failed at {failure['stage']} with rc={failure['rc']}", confidence,
+                      "The provider matched but could not finish registration.",
+                      f"Fix only the recorded probe stage {failure['stage']}.")
     if not ready["observed"]:
-        return verdict("refgen_probe_incomplete", "REFGEN probe did not reach ready", conf,
-                       "The probe stalled or the final record was lost.",
-                       "Instrument the interval after the last REFGEN marker.")
-    successful_enable = any(isinstance(item, dict) and item.get("enabled") == 1 for item in enables)
-    if not successful_enable:
-        return verdict("refgen_not_enabled", "REFGEN registered but no successful enable was recorded", conf,
-                       "The DSI consumer may not have requested the supply or the write did not latch.",
-                       "Inspect refgen-supply acquisition and regulator_bulk_enable around DSI prepare.")
+        return result("refgen_probe_incomplete", "REFGEN probe did not reach ready", confidence,
+                      "The probe stalled or the final record was lost.",
+                      "Instrument the interval after the last REFGEN marker.")
+    if not any(isinstance(x, dict) and x.get("enabled") == 1 for x in enables):
+        return result("refgen_not_enabled", "REFGEN registered but no successful enable was recorded", confidence,
+                      "The DSI consumer may not have requested the supply or the write did not latch.",
+                      "Inspect refgen-supply acquisition and regulator enable around DSI prepare.")
     unmatched = display.get("unmatched_entries")
     assert isinstance(unmatched, list)
     if screen == "stable":
-        return verdict("refgen_hypothesis_supported", "REFGEN enabled and the display remained stable", conf,
-                       "The missing REFGEN provider was the leading black-screen cause.",
-                       "Repeat one controlled boot, then prepare a recorder-free candidate with the same REFGEN port.")
+        return result("refgen_hypothesis_supported", "REFGEN enabled and the display remained stable", confidence,
+                      "The missing REFGEN provider was the leading black-screen cause.",
+                      "Repeat one controlled boot, then prepare a recorder-free candidate with the same REFGEN port.")
     if screen == "black" and unmatched:
         function = str(unmatched[-1].get("function"))
-        return verdict("refgen_operational_display_scope_stalled",
-                       f"REFGEN enabled, then display stalled in {function}", conf,
-                       "REFGEN is operational; the remaining failure is inside the next recorded display boundary.",
-                       f"Add narrow markers inside {function}; do not change unrelated display code.")
+        return result("refgen_operational_display_scope_stalled", f"REFGEN enabled, then display stalled in {function}", confidence,
+                      "REFGEN is operational; the remaining failure is inside the next recorded display boundary.",
+                      f"Add narrow markers inside {function}; do not change unrelated display code.")
     if screen == "black":
-        return verdict("refgen_operational_black_screen_later",
-                       "REFGEN enabled but the black screen occurred after recorded display scopes", conf,
-                       "The remaining fault is later than the current probes or outside their coverage.",
-                       "Use the final critical timeline event to add one deeper probe layer.")
-    return verdict("refgen_operational_result_unknown", "REFGEN appears operational; physical display result is unknown", conf,
-                   "The capture alone cannot prove whether the screen remained usable.",
-                   "Reclassify the same capture with --screen-result stable or black.")
-
-
-def verdict(code: str, title: str, confidence_value: str, meaning: str, next_action: str) -> dict[str, str]:
-    return {"code": code, "title": title, "confidence": confidence_value,
-            "meaning": meaning, "next_action": next_action}
+        return result("refgen_operational_black_screen_later", "REFGEN enabled but the black screen occurred later", confidence,
+                      "The remaining fault is later than the current probes or outside their coverage.",
+                      "Use the final critical timeline event to add one deeper probe layer.")
+    return result("refgen_operational_result_unknown", "REFGEN appears operational; screen result is unknown", confidence,
+                  "The capture alone cannot prove whether the screen remained usable.",
+                  "Reclassify the same capture with --screen-result stable or black.")
 
 
 def run_decoder(script: Path, capture: Path, output: Path) -> dict[str, object]:
     if not script.is_file():
         return {"status": "missing", "script": str(script), "returncode": None}
-    result = subprocess.run([sys.executable, str(script), str(capture), "--output", str(output)],
-                            text=True, capture_output=True, check=False)
-    return {"status": "ok" if result.returncode == 0 else "no-events" if result.returncode == 2 else "failed",
-            "script": str(script), "returncode": result.returncode,
-            "stdout": result.stdout.strip(), "stderr": result.stderr.strip()}
+    done = subprocess.run([sys.executable, str(script), str(capture), "--output", str(output)],
+                          text=True, capture_output=True, check=False)
+    return {"status": "ok" if done.returncode == 0 else "no-events" if done.returncode == 2 else "failed",
+            "script": str(script), "returncode": done.returncode,
+            "stdout": done.stdout.strip(), "stderr": done.stderr.strip()}
 
 
 def write_outputs(output: Path, report: dict[str, object], events: list[Event]) -> None:
     output.mkdir(parents=True, exist_ok=True)
     (output / "diagnosis.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
-    result = report["verdict"]
-    assert isinstance(result, dict)
-    lines = ["# A52 REFGEN display diagnosis", "", f"**Verdict:** {result['title']}", "",
-             f"**Code:** `{result['code']}`  ", f"**Confidence:** `{result['confidence']}`", "",
-             "## Meaning", "", str(result["meaning"]), "", "## Next action", "",
-             str(result["next_action"]), "", "## Evidence", "",
-             f"- Selected events: {report['decoder']['selected_events']}",
-             f"- REFGEN: {report['refgen']}", f"- Display: {report['display']}",
-             f"- Heartbeat: {report['heartbeat']}", f"- Watchdog: {report['watchdog']}", ""]
-    (output / "diagnosis.md").write_text("\n".join(lines), encoding="utf-8")
+    verdict = report["verdict"]
+    assert isinstance(verdict, dict)
+    lines = ["# A52 REFGEN display diagnosis", "", f"**Verdict:** {verdict['title']}", "",
+             f"**Code:** `{verdict['code']}`  ", f"**Confidence:** `{verdict['confidence']}`", "",
+             "## Meaning", "", str(verdict["meaning"]), "", "## Next action", "",
+             str(verdict["next_action"]), "", "## Warnings", ""]
+    warnings = report.get("warnings")
+    lines.extend([f"- {item}" for item in warnings] if isinstance(warnings, list) and warnings else ["- None"])
+    lines.extend(["", "See `diagnosis.json` and `critical-timeline.csv` for complete evidence.", ""])
+    (output / "diagnosis.md").write_text("\n".join(lines))
     with (output / "critical-timeline.csv").open("w", newline="", encoding="utf-8") as handle:
         writer = csv.writer(handle)
         writer.writerow(["order", "seq", "monotonic_ns", "message", "confidence", "source", "offset"])
-        for item in events:
-            if item.message.startswith(CRITICAL):
-                writer.writerow([item.order, item.seq or "", item.monotonic_ns or "", item.message,
-                                 item.confidence, item.source, item.offset or ""])
+        for event in events:
+            if event.message.startswith(CRITICAL):
+                writer.writerow([event.order, event.seq or "", event.ns or "", event.message,
+                                 event.confidence, event.source, event.offset or ""])
 
 
-def diagnose(standard_csv: Path, mirrored_csv: Path, output: Path, screen: str,
+def diagnose(standard: Path, mirrored: Path, output: Path, screen: str,
              decoder_runs: dict[str, object] | None = None) -> dict[str, object]:
-    events, decoder = merge_events(standard_csv, mirrored_csv)
-    display = display_summary(events)
-    refgen, heartbeat, watchdog = summaries(events)
-    last_display = display.get("last_event")
-    latest_hb = heartbeat.get("latest_event")
-    if isinstance(last_display, dict) and isinstance(latest_hb, dict):
-        d_ns, h_ns = last_display.get("monotonic_ns"), latest_hb.get("monotonic_ns")
-        heartbeat["alive_500ms_after_last_display"] = bool(
-            isinstance(d_ns, int) and isinstance(h_ns, int) and h_ns - d_ns >= 500_000_000)
-    else:
-        heartbeat["alive_500ms_after_last_display"] = False
-    result = classify(events, refgen, display, heartbeat, screen)
+    events, decoder = merge(standard, mirrored)
+    refgen, display = refgen_summary(events), display_summary(events)
+    heartbeat, watchdog = simple_summaries(events)
+    last_display, latest_hb = display.get("last_event"), heartbeat.get("latest_event")
+    heartbeat["alive_500ms_after_last_display"] = bool(
+        isinstance(last_display, dict) and isinstance(latest_hb, dict)
+        and isinstance(last_display.get("ns"), int) and isinstance(latest_hb.get("ns"), int)
+        and latest_hb["ns"] - last_display["ns"] >= 500_000_000)
+    mapping, warnings = refgen.get("mapping"), []
+    if isinstance(mapping, dict) and mapping.get("observed") and not mapping.get("resource_covers_ctrl5"):
+        warnings.append("REFGEN CTRL5 offset 0x80 is outside the declared resource span; the A52 Lagoon stock layout declares 0x60 and the downstream driver uses the same offset.")
     report: dict[str, object] = {
-        "status": "diagnosed" if events else "no-events",
-        "screen_result": screen,
+        "status": "diagnosed" if events else "no-events", "screen_result": screen,
         "privacy": "metadata-only; no secure payloads, keys, tokens, or process memory",
-        "decoder": decoder,
-        "decoder_runs": decoder_runs or {},
-        "verdict": result,
-        "refgen": refgen,
-        "display": display,
-        "heartbeat": heartbeat,
-        "watchdog": watchdog,
+        "decoder": decoder, "decoder_runs": decoder_runs or {}, "warnings": warnings,
+        "verdict": classify(events, refgen, display, screen), "refgen": refgen,
+        "display": display, "heartbeat": heartbeat, "watchdog": watchdog,
     }
     write_outputs(output, report, events)
     return report
@@ -364,23 +310,19 @@ def self_test() -> None:
         root = Path(name)
         base = ["WDT disarm before=1 after=0", "REFGEN driver_register rc=0",
                 "REFGEN probe enter compat=qcom,refgen-kona-regulator",
-                "REFGEN mapped start=0x88e7000 size=132 raw=0x0",
-                "REFGEN probe ready initial_enabled=0",
-                "REFGEN kona_enable raw=0x0->0x1 enabled=1"]
-        fixture(root / "standard.csv", base + ["DISP enter fn=dsi_display_enable", "HB tick=1 online=8 run=2 j=100"])
-        report = diagnose(root / "standard.csv", root / "missing.csv", root / "black", "black")
-        if report["verdict"]["code"] != "refgen_operational_display_scope_stalled":
-            raise SystemExit("black-screen self-test failed")
+                "REFGEN mapped start=0x88e7000 size=96 raw=0x0",
+                "REFGEN probe ready initial_enabled=0", "REFGEN kona_enable raw=0x0->0x1 enabled=1"]
+        fixture(root / "black.csv", base + ["DISP enter fn=dsi_display_enable", "HB tick=1 online=8 run=2 j=100"])
+        report = diagnose(root / "black.csv", root / "none.csv", root / "black", "black")
+        assert report["verdict"]["code"] == "refgen_operational_display_scope_stalled"
+        assert report["refgen"]["mapping"]["stock_lagoon_0x60_layout"] is True
+        assert report["warnings"]
         fixture(root / "failed.csv", ["REFGEN driver_register rc=0",
                                       "REFGEN probe enter compat=qcom,refgen-kona-regulator",
                                       "REFGEN probe fail stage=ioremap rc=-16"])
-        report = diagnose(root / "failed.csv", root / "missing.csv", root / "failed", "unknown")
-        if report["verdict"]["code"] != "refgen_probe_failed":
-            raise SystemExit("probe-failure self-test failed")
+        assert diagnose(root / "failed.csv", root / "none.csv", root / "failed", "unknown")["verdict"]["code"] == "refgen_probe_failed"
         fixture(root / "stable.csv", base)
-        report = diagnose(root / "stable.csv", root / "missing.csv", root / "stable", "stable")
-        if report["verdict"]["code"] != "refgen_hypothesis_supported":
-            raise SystemExit("stable-screen self-test failed")
+        assert diagnose(root / "stable.csv", root / "none.csv", root / "stable", "stable")["verdict"]["code"] == "refgen_hypothesis_supported"
 
 
 def main() -> int:
@@ -398,28 +340,19 @@ def main() -> int:
     if args.self_test:
         print(json.dumps({"status": "self-test-passed"}, sort_keys=True))
         return 0
-
-    output = args.output.resolve()
-    standard_csv = args.standard_csv
-    mirrored_csv = args.mirrored_csv
-    runs: dict[str, object] = {}
+    output, standard, mirrored, runs = args.output.resolve(), args.standard_csv, args.mirrored_csv, {}
     if args.capture:
-        tools = Path(__file__).resolve().parent
-        standard_dir = output / "decoded-standard"
-        mirrored_dir = output / "decoded-mirrored"
-        standard_script = args.standard_decoder or tools / "decode-a52-unified-secure-recorder.py"
-        mirrored_script = args.mirrored_decoder or tools / "decode-a52-mirrored-ramoops-v2.py"
-        runs = {"standard": run_decoder(standard_script, args.capture.resolve(), standard_dir),
-                "mirrored": run_decoder(mirrored_script, args.capture.resolve(), mirrored_dir)}
-        standard_csv = standard_csv or standard_dir / "secure-events.csv"
-        mirrored_csv = mirrored_csv or mirrored_dir / "recovered-events.csv"
-    if standard_csv is None and mirrored_csv is None:
+        tools, capture = Path(__file__).resolve().parent, args.capture.resolve()
+        standard_dir, mirrored_dir = output / "decoded-standard", output / "decoded-mirrored"
+        runs = {"standard": run_decoder(args.standard_decoder or tools / "decode-a52-unified-secure-recorder.py", capture, standard_dir),
+                "mirrored": run_decoder(args.mirrored_decoder or tools / "decode-a52-mirrored-ramoops-v2.py", capture, mirrored_dir)}
+        standard, mirrored = standard or standard_dir / "secure-events.csv", mirrored or mirrored_dir / "recovered-events.csv"
+    if standard is None and mirrored is None:
         parser.error("provide a capture or at least one decoded CSV")
-    standard_csv = (standard_csv or Path("missing-standard.csv")).resolve()
-    mirrored_csv = (mirrored_csv or Path("missing-mirrored.csv")).resolve()
-    report = diagnose(standard_csv, mirrored_csv, output, args.screen_result, runs)
-    print(json.dumps({"status": report["status"], "verdict": report["verdict"]["code"],
-                      "output": str(output)}, sort_keys=True))
+    report = diagnose((standard or Path("missing-standard.csv")).resolve(),
+                      (mirrored or Path("missing-mirrored.csv")).resolve(),
+                      output, args.screen_result, runs)
+    print(json.dumps({"status": report["status"], "verdict": report["verdict"]["code"], "output": str(output)}, sort_keys=True))
     return 0 if report["status"] == "diagnosed" else 2
 
 

--- a/tools/a52-refgen/diagnose-a52-refgen-display.py
+++ b/tools/a52-refgen/diagnose-a52-refgen-display.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Diagnose Galaxy A52 REFGEN/display RAMOOPS recorder evidence.
+
+The tool consumes the CSV output from the standard A52USR2 decoder and the
+corruption-tolerant mirrored decoder. When a raw capture is supplied it can run
+both sibling decoders automatically. It never reads secure payload contents.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+CONFIDENCE = {"exact": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
+CRITICAL = ("REFGEN ", "DISP ", "HB ", "WDT ")
+
+PATTERNS = {
+    "register": re.compile(r"REFGEN driver_register rc=(-?\d+)$"),
+    "probe": re.compile(r"REFGEN probe enter compat=(\S+)$"),
+    "failure": re.compile(r"REFGEN probe fail stage=(\S+) rc=(-?\d+)$"),
+    "mapped": re.compile(r"REFGEN mapped start=0x([0-9a-fA-F]+) size=(\d+) raw=0x([0-9a-fA-F]+)$"),
+    "ready": re.compile(r"REFGEN probe ready initial_enabled=(-?\d+)$"),
+    "state": re.compile(r"REFGEN kona_state raw=0x([0-9a-fA-F]+) enabled=([01])$"),
+    "enable": re.compile(r"REFGEN kona_enable raw=0x([0-9a-fA-F]+)->0x([0-9a-fA-F]+) enabled=([01])$"),
+    "disable": re.compile(r"REFGEN kona_disable raw=0x([0-9a-fA-F]+)->0x([0-9a-fA-F]+) enabled=([01])$"),
+    "heartbeat": re.compile(r"HB tick=(\d+) online=(\d+) run=(\d+) j=(\d+)$"),
+    "watchdog": re.compile(r"WDT disarm before=([01]) after=([01])$"),
+    "enter": re.compile(r"DISP enter fn=(\S+)$"),
+    "exit": re.compile(r"DISP exit fn=(\S+) us=(\d+)$"),
+}
+
+
+@dataclass(frozen=True)
+class Event:
+    order: int
+    seq: int | None
+    monotonic_ns: int | None
+    message: str
+    confidence: str
+    source: str
+    offset: int | None = None
+
+    def key(self) -> tuple[int, int, int]:
+        if self.monotonic_ns is not None:
+            return (0, self.monotonic_ns, self.order)
+        if self.seq is not None:
+            return (1, self.seq, self.order)
+        return (2, self.order, self.order)
+
+
+def integer(value: str | None) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value, 0)
+    except ValueError:
+        return None
+
+
+def read_events(path: Path, source: str, default_confidence: str) -> list[Event]:
+    if not path.is_file():
+        return []
+    rows: list[Event] = []
+    with path.open(newline="", encoding="utf-8", errors="replace") as handle:
+        for order, row in enumerate(csv.DictReader(handle)):
+            message = (row.get("message") or "").strip()
+            if not message:
+                continue
+            confidence_value = (row.get("confidence") or default_confidence).lower()
+            rows.append(Event(
+                order=order,
+                seq=integer(row.get("seq")),
+                monotonic_ns=integer(row.get("monotonic_ns")),
+                message=message,
+                confidence=confidence_value if confidence_value in CONFIDENCE else "unknown",
+                source=source,
+                offset=integer(row.get("offset")),
+            ))
+    return rows
+
+
+def merge_events(standard_csv: Path, mirrored_csv: Path) -> tuple[list[Event], dict[str, int]]:
+    exact = read_events(standard_csv, "standard", "exact")
+    mirrored = read_events(mirrored_csv, "mirrored", "high")
+    selected = list(exact)
+    exact_pairs = {(item.seq, item.message) for item in exact}
+    exact_sequences = {item.seq for item in exact if item.seq is not None}
+    exact_messages = {item.message for item in exact}
+    for item in mirrored:
+        if item.confidence == "low":
+            continue
+        if (item.seq, item.message) in exact_pairs:
+            continue
+        if item.seq is not None and item.seq in exact_sequences:
+            continue
+        if item.seq is None and item.message in exact_messages:
+            continue
+        selected.append(item)
+    selected.sort(key=Event.key)
+    ordered = [Event(index, item.seq, item.monotonic_ns, item.message,
+                     item.confidence, item.source, item.offset)
+               for index, item in enumerate(selected)]
+    return ordered, {
+        "standard_events": len(exact),
+        "mirrored_events": len(mirrored),
+        "mirrored_high": sum(item.confidence == "high" for item in mirrored),
+        "mirrored_medium": sum(item.confidence == "medium" for item in mirrored),
+        "mirrored_low": sum(item.confidence == "low" for item in mirrored),
+        "selected_events": len(ordered),
+    }
+
+
+def found(events: Iterable[Event], name: str) -> list[tuple[Event, re.Match[str]]]:
+    pattern = PATTERNS[name]
+    answer = []
+    for event in events:
+        match = pattern.fullmatch(event.message)
+        if match:
+            answer.append((event, match))
+    return answer
+
+
+def event_dict(item: tuple[Event, re.Match[str]] | None) -> dict[str, object] | None:
+    return asdict(item[0]) if item else None
+
+
+def confidence(events: Iterable[Event]) -> str:
+    values = [item.confidence for item in events]
+    return min(values, key=lambda value: CONFIDENCE.get(value, 99)) if values else "none"
+
+
+def display_summary(events: list[Event]) -> dict[str, object]:
+    stack: list[tuple[str, Event]] = []
+    completed: list[dict[str, object]] = []
+    last: Event | None = None
+    for event in events:
+        enter = PATTERNS["enter"].fullmatch(event.message)
+        exit_match = PATTERNS["exit"].fullmatch(event.message)
+        if enter:
+            last = event
+            stack.append((enter.group(1), event))
+            continue
+        if not exit_match:
+            continue
+        last = event
+        function = exit_match.group(1)
+        index = next((i for i in range(len(stack) - 1, -1, -1)
+                      if stack[i][0] == function), None)
+        if index is None:
+            completed.append({"function": function, "orphan_exit": True,
+                              "duration_us": int(exit_match.group(2)),
+                              "exit_order": event.order})
+            continue
+        _, entered = stack.pop(index)
+        completed.append({"function": function, "orphan_exit": False,
+                          "duration_us": int(exit_match.group(2)),
+                          "enter_order": entered.order, "exit_order": event.order})
+    unmatched = [{"function": function, **asdict(event)} for function, event in stack]
+    return {
+        "event_count": sum(item.message.startswith("DISP ") for item in events),
+        "completed": completed,
+        "unmatched_entries": unmatched,
+        "last_event": asdict(last) if last else None,
+    }
+
+
+def summaries(events: list[Event]) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    refgen_events = [item for item in events if item.message.startswith("REFGEN ")]
+    register = found(events, "register")
+    probe = found(events, "probe")
+    failure = found(events, "failure")
+    mapped = found(events, "mapped")
+    ready = found(events, "ready")
+    states = found(events, "state")
+    enables = found(events, "enable")
+    disables = found(events, "disable")
+    refgen = {
+        "event_count": len(refgen_events),
+        "confidence": confidence(refgen_events),
+        "driver_register": {"observed": bool(register), "rc": int(register[-1][1].group(1)) if register else None,
+                            "event": event_dict(register[-1] if register else None)},
+        "probe_enter": {"observed": bool(probe), "compat": probe[-1][1].group(1) if probe else None,
+                        "event": event_dict(probe[-1] if probe else None)},
+        "probe_failure": {"observed": bool(failure), "stage": failure[-1][1].group(1) if failure else None,
+                          "rc": int(failure[-1][1].group(2)) if failure else None,
+                          "event": event_dict(failure[-1] if failure else None)},
+        "mapping": {"observed": bool(mapped),
+                    "start": int(mapped[-1][1].group(1), 16) if mapped else None,
+                    "size": int(mapped[-1][1].group(2)) if mapped else None,
+                    "raw": int(mapped[-1][1].group(3), 16) if mapped else None},
+        "probe_ready": {"observed": bool(ready), "initial_enabled": int(ready[-1][1].group(1)) if ready else None,
+                        "event": event_dict(ready[-1] if ready else None)},
+        "state_checks": [{"raw": int(match.group(1), 16), "enabled": int(match.group(2)),
+                          "event": asdict(event)} for event, match in states],
+        "enable_calls": [{"before": int(match.group(1), 16), "after": int(match.group(2), 16),
+                          "enabled": int(match.group(3)), "event": asdict(event)} for event, match in enables],
+        "disable_calls": [{"before": int(match.group(1), 16), "after": int(match.group(2), 16),
+                           "enabled": int(match.group(3)), "event": asdict(event)} for event, match in disables],
+    }
+    heartbeat_rows = found(events, "heartbeat")
+    heartbeat = {
+        "count": len(heartbeat_rows),
+        "first_tick": int(heartbeat_rows[0][1].group(1)) if heartbeat_rows else None,
+        "last_tick": int(heartbeat_rows[-1][1].group(1)) if heartbeat_rows else None,
+        "latest_event": event_dict(heartbeat_rows[-1] if heartbeat_rows else None),
+    }
+    watchdog_rows = found(events, "watchdog")
+    watchdog = {
+        "observed": bool(watchdog_rows),
+        "before": int(watchdog_rows[-1][1].group(1)) if watchdog_rows else None,
+        "after": int(watchdog_rows[-1][1].group(2)) if watchdog_rows else None,
+        "disarmed": bool(watchdog_rows and watchdog_rows[-1][1].group(2) == "0"),
+        "event": event_dict(watchdog_rows[-1] if watchdog_rows else None),
+    }
+    return refgen, heartbeat, watchdog
+
+
+def classify(events: list[Event], refgen: dict[str, object], display: dict[str, object],
+             heartbeat: dict[str, object], screen: str) -> dict[str, str]:
+    if not events:
+        return verdict("no_recorder_events", "No usable A52USR2 events were recovered", "low",
+                       "The capture is missing, incomplete, or too damaged.",
+                       "Repeat collection and preserve the untouched 1 MiB RAMOOPS image.")
+    driver = refgen["driver_register"]
+    probe = refgen["probe_enter"]
+    failure = refgen["probe_failure"]
+    ready = refgen["probe_ready"]
+    enables = refgen["enable_calls"]
+    assert isinstance(driver, dict) and isinstance(probe, dict)
+    assert isinstance(failure, dict) and isinstance(ready, dict) and isinstance(enables, list)
+    conf = str(refgen.get("confidence", "unknown"))
+    if not driver["observed"]:
+        return verdict("refgen_registration_missing", "REFGEN registration was not recorded", conf,
+                       "The initcall did not run, its record was lost, or another image was flashed.",
+                       "Verify the boot.img SHA-256 and inspect BOOT_EARLY and heartbeat records.")
+    if driver["rc"] not in (0, None):
+        return verdict("refgen_registration_failed", f"REFGEN registration failed with rc={driver['rc']}", conf,
+                       "The platform driver never became available.",
+                       "Resolve platform_driver_register before changing DSI code.")
+    if not probe["observed"]:
+        return verdict("refgen_probe_missing", "REFGEN registered but its DT probe never started", conf,
+                       "The stock provider node did not populate or match.",
+                       "Audit node status, compatible, parent population, and platform-device creation.")
+    if failure["observed"]:
+        return verdict("refgen_probe_failed", f"REFGEN probe failed at {failure['stage']} with rc={failure['rc']}", conf,
+                       "The provider matched but could not finish registration.",
+                       f"Fix only the recorded probe stage {failure['stage']}.")
+    if not ready["observed"]:
+        return verdict("refgen_probe_incomplete", "REFGEN probe did not reach ready", conf,
+                       "The probe stalled or the final record was lost.",
+                       "Instrument the interval after the last REFGEN marker.")
+    successful_enable = any(isinstance(item, dict) and item.get("enabled") == 1 for item in enables)
+    if not successful_enable:
+        return verdict("refgen_not_enabled", "REFGEN registered but no successful enable was recorded", conf,
+                       "The DSI consumer may not have requested the supply or the write did not latch.",
+                       "Inspect refgen-supply acquisition and regulator_bulk_enable around DSI prepare.")
+    unmatched = display.get("unmatched_entries")
+    assert isinstance(unmatched, list)
+    if screen == "stable":
+        return verdict("refgen_hypothesis_supported", "REFGEN enabled and the display remained stable", conf,
+                       "The missing REFGEN provider was the leading black-screen cause.",
+                       "Repeat one controlled boot, then prepare a recorder-free candidate with the same REFGEN port.")
+    if screen == "black" and unmatched:
+        function = str(unmatched[-1].get("function"))
+        return verdict("refgen_operational_display_scope_stalled",
+                       f"REFGEN enabled, then display stalled in {function}", conf,
+                       "REFGEN is operational; the remaining failure is inside the next recorded display boundary.",
+                       f"Add narrow markers inside {function}; do not change unrelated display code.")
+    if screen == "black":
+        return verdict("refgen_operational_black_screen_later",
+                       "REFGEN enabled but the black screen occurred after recorded display scopes", conf,
+                       "The remaining fault is later than the current probes or outside their coverage.",
+                       "Use the final critical timeline event to add one deeper probe layer.")
+    return verdict("refgen_operational_result_unknown", "REFGEN appears operational; physical display result is unknown", conf,
+                   "The capture alone cannot prove whether the screen remained usable.",
+                   "Reclassify the same capture with --screen-result stable or black.")
+
+
+def verdict(code: str, title: str, confidence_value: str, meaning: str, next_action: str) -> dict[str, str]:
+    return {"code": code, "title": title, "confidence": confidence_value,
+            "meaning": meaning, "next_action": next_action}
+
+
+def run_decoder(script: Path, capture: Path, output: Path) -> dict[str, object]:
+    if not script.is_file():
+        return {"status": "missing", "script": str(script), "returncode": None}
+    result = subprocess.run([sys.executable, str(script), str(capture), "--output", str(output)],
+                            text=True, capture_output=True, check=False)
+    return {"status": "ok" if result.returncode == 0 else "no-events" if result.returncode == 2 else "failed",
+            "script": str(script), "returncode": result.returncode,
+            "stdout": result.stdout.strip(), "stderr": result.stderr.strip()}
+
+
+def write_outputs(output: Path, report: dict[str, object], events: list[Event]) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "diagnosis.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    result = report["verdict"]
+    assert isinstance(result, dict)
+    lines = ["# A52 REFGEN display diagnosis", "", f"**Verdict:** {result['title']}", "",
+             f"**Code:** `{result['code']}`  ", f"**Confidence:** `{result['confidence']}`", "",
+             "## Meaning", "", str(result["meaning"]), "", "## Next action", "",
+             str(result["next_action"]), "", "## Evidence", "",
+             f"- Selected events: {report['decoder']['selected_events']}",
+             f"- REFGEN: {report['refgen']}", f"- Display: {report['display']}",
+             f"- Heartbeat: {report['heartbeat']}", f"- Watchdog: {report['watchdog']}", ""]
+    (output / "diagnosis.md").write_text("\n".join(lines), encoding="utf-8")
+    with (output / "critical-timeline.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["order", "seq", "monotonic_ns", "message", "confidence", "source", "offset"])
+        for item in events:
+            if item.message.startswith(CRITICAL):
+                writer.writerow([item.order, item.seq or "", item.monotonic_ns or "", item.message,
+                                 item.confidence, item.source, item.offset or ""])
+
+
+def diagnose(standard_csv: Path, mirrored_csv: Path, output: Path, screen: str,
+             decoder_runs: dict[str, object] | None = None) -> dict[str, object]:
+    events, decoder = merge_events(standard_csv, mirrored_csv)
+    display = display_summary(events)
+    refgen, heartbeat, watchdog = summaries(events)
+    last_display = display.get("last_event")
+    latest_hb = heartbeat.get("latest_event")
+    if isinstance(last_display, dict) and isinstance(latest_hb, dict):
+        d_ns, h_ns = last_display.get("monotonic_ns"), latest_hb.get("monotonic_ns")
+        heartbeat["alive_500ms_after_last_display"] = bool(
+            isinstance(d_ns, int) and isinstance(h_ns, int) and h_ns - d_ns >= 500_000_000)
+    else:
+        heartbeat["alive_500ms_after_last_display"] = False
+    result = classify(events, refgen, display, heartbeat, screen)
+    report: dict[str, object] = {
+        "status": "diagnosed" if events else "no-events",
+        "screen_result": screen,
+        "privacy": "metadata-only; no secure payloads, keys, tokens, or process memory",
+        "decoder": decoder,
+        "decoder_runs": decoder_runs or {},
+        "verdict": result,
+        "refgen": refgen,
+        "display": display,
+        "heartbeat": heartbeat,
+        "watchdog": watchdog,
+    }
+    write_outputs(output, report, events)
+    return report
+
+
+def fixture(path: Path, messages: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["seq", "monotonic_ns", "message"])
+        writer.writeheader()
+        for index, message in enumerate(messages, 1):
+            writer.writerow({"seq": index, "monotonic_ns": index * 1_000_000, "message": message})
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory() as name:
+        root = Path(name)
+        base = ["WDT disarm before=1 after=0", "REFGEN driver_register rc=0",
+                "REFGEN probe enter compat=qcom,refgen-kona-regulator",
+                "REFGEN mapped start=0x88e7000 size=132 raw=0x0",
+                "REFGEN probe ready initial_enabled=0",
+                "REFGEN kona_enable raw=0x0->0x1 enabled=1"]
+        fixture(root / "standard.csv", base + ["DISP enter fn=dsi_display_enable", "HB tick=1 online=8 run=2 j=100"])
+        report = diagnose(root / "standard.csv", root / "missing.csv", root / "black", "black")
+        if report["verdict"]["code"] != "refgen_operational_display_scope_stalled":
+            raise SystemExit("black-screen self-test failed")
+        fixture(root / "failed.csv", ["REFGEN driver_register rc=0",
+                                      "REFGEN probe enter compat=qcom,refgen-kona-regulator",
+                                      "REFGEN probe fail stage=ioremap rc=-16"])
+        report = diagnose(root / "failed.csv", root / "missing.csv", root / "failed", "unknown")
+        if report["verdict"]["code"] != "refgen_probe_failed":
+            raise SystemExit("probe-failure self-test failed")
+        fixture(root / "stable.csv", base)
+        report = diagnose(root / "stable.csv", root / "missing.csv", root / "stable", "stable")
+        if report["verdict"]["code"] != "refgen_hypothesis_supported":
+            raise SystemExit("stable-screen self-test failed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture", nargs="?", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("a52-refgen-display-diagnosis"))
+    parser.add_argument("--screen-result", choices=("unknown", "stable", "black"), default="unknown")
+    parser.add_argument("--standard-csv", type=Path)
+    parser.add_argument("--mirrored-csv", type=Path)
+    parser.add_argument("--standard-decoder", type=Path)
+    parser.add_argument("--mirrored-decoder", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    self_test()
+    if args.self_test:
+        print(json.dumps({"status": "self-test-passed"}, sort_keys=True))
+        return 0
+
+    output = args.output.resolve()
+    standard_csv = args.standard_csv
+    mirrored_csv = args.mirrored_csv
+    runs: dict[str, object] = {}
+    if args.capture:
+        tools = Path(__file__).resolve().parent
+        standard_dir = output / "decoded-standard"
+        mirrored_dir = output / "decoded-mirrored"
+        standard_script = args.standard_decoder or tools / "decode-a52-unified-secure-recorder.py"
+        mirrored_script = args.mirrored_decoder or tools / "decode-a52-mirrored-ramoops-v2.py"
+        runs = {"standard": run_decoder(standard_script, args.capture.resolve(), standard_dir),
+                "mirrored": run_decoder(mirrored_script, args.capture.resolve(), mirrored_dir)}
+        standard_csv = standard_csv or standard_dir / "secure-events.csv"
+        mirrored_csv = mirrored_csv or mirrored_dir / "recovered-events.csv"
+    if standard_csv is None and mirrored_csv is None:
+        parser.error("provide a capture or at least one decoded CSV")
+    standard_csv = (standard_csv or Path("missing-standard.csv")).resolve()
+    mirrored_csv = (mirrored_csv or Path("missing-mirrored.csv")).resolve()
+    report = diagnose(standard_csv, mirrored_csv, output, args.screen_result, runs)
+    print(json.dumps({"status": report["status"], "verdict": report["verdict"]["code"],
+                      "output": str(output)}, sort_keys=True))
+    return 0 if report["status"] == "diagnosed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope

Add metadata-only tooling for the next Galaxy A52 5G REFGEN hardware test. This branch does not modify kernel source, configuration, boot image, DTB, regulator behaviour, recorder instrumentation, or watchdog handling.

## Analyzer

- combines exact A52USR2 decoder output with high and medium confidence mirrored recovery
- gives exact records priority and excludes low-confidence recovery from verdicts
- audits REFGEN registration, DT probe, MMIO mapping, ready state and enable result
- pairs display entry and exit scopes and identifies the final unmatched function
- checks heartbeat and watchdog evidence
- emits `diagnosis.md`, `diagnosis.json`, and `critical-timeline.csv`
- produces one narrow next action instead of another broad speculative display patch

## Exact A52 source parity

The Kona driver uses register offset `0x80`, bit 0 for enable, and the same bit for `is_enabled`. The exact A52 Lagoon node declares `reg = <0x88e7000 0x60>`, while the working downstream driver still accesses offset `0x80`. This is an inherited DT/driver resource-span inconsistency, not a new register mismatch introduced by the ACK candidate. The analyzer reports it explicitly without changing the hardware behaviour before testing.

## Validation

Workflow 162 compiles the analyzer, runs built-in stable-screen, black-screen and REFGEN probe-failure tests, runs a decoded-CSV integration test using the exact `0x60` A52 layout, verifies the resource-span warning, and enforces the metadata-only privacy contract.

This remains a draft tooling PR. It is independent of hardware validation of the existing REFGEN `boot.img`.