### PR TITLE
Instrument the compiled A52 display path

### DIFF
--- a/.github/workflows/165-a52-active-display-scopes.yml
+++ b/.github/workflows/165-a52-active-display-scopes.yml
@@ -1,0 +1,356 @@
+name: 165 - A52 active display scopes
+
+run-name: Build REFGEN candidate with scopes in the compiled A52 display tree
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-active-display-scopes
+    paths:
+      - .github/workflows/165-a52-active-display-scopes.yml
+      - scripts/165_apply_a52_active_display_scopes.py
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-refgen-critical-retention
+    paths:
+      - .github/workflows/165-a52-active-display-scopes.yml
+      - scripts/165_apply_a52_active_display_scopes.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-active-display-scopes-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  RUN32_ARTIFACT_ID: '8635093061'
+  RETENTION_SOURCE_ARTIFACT_ID: '8652257328'
+  RETENTION_SOURCE_ARTIFACT_SHA256: 885b5f54945b9887d9778467b81b31c5e586b92685fc4369d23a6bbf0501b313
+  SECOND_CAPTURE_SHA256: afce7a237eb723f3b87c0326b6242e6a2816975057d193281e91bf958abd3614
+
+jobs:
+  build-package:
+    name: Compile and package active A52 display-scope candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out diagnostic project
+        uses: actions/checkout@v4
+
+      - name: Prepare runner and validate patcher
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/165_apply_a52_active_display_scopes.py \
+            scripts/38_repack_a52_p1_boot.py
+          python3 scripts/165_apply_a52_active_display_scopes.py --self-test
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Download retention source and Run 32 boot container
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p retention/extracted run32/extracted
+          curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${RETENTION_SOURCE_ARTIFACT_ID}/zip" \
+            --output retention/artifact.zip
+          printf '%s  %s\n' "${RETENTION_SOURCE_ARTIFACT_SHA256}" retention/artifact.zip \
+            | sha256sum -c -
+          curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${RUN32_ARTIFACT_ID}/zip" \
+            --output run32/artifact.zip
+          unzip -q retention/artifact.zip -d retention/extracted
+          unzip -q run32/artifact.zip -d run32/extracted
+          (cd retention/extracted && sha256sum -c SHA256SUMS)
+          (cd run32/extracted && sha256sum -c SHA256SUMS)
+
+          test -s retention/extracted/stage/refgen-critical-retention-source.patch
+          test -s retention/extracted/config/final.config
+          test -s retention/extracted/package/boot.img
+          test "$(tr -d '\r\n' < retention/extracted/compile/make-return-code.txt)" = 0
+          test -s run32/extracted/package/boot.img
+          grep -Fq 'A52_USR2_CRITICAL_PERSIST_V1' \
+            retention/extracted/stage/refgen-critical-retention-source.patch
+          grep -Fq 'REFGEN probe ready initial_enabled=%d' \
+            retention/extracted/stage/refgen-critical-retention-source.patch
+
+      - name: Restore audited retention source and apply active scopes
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d gki/common/.git
+          test "$(git -C gki/common rev-parse HEAD)" = "${GKI_COMMON_SHA}"
+          git -C gki/common reset --hard "${GKI_COMMON_SHA}"
+          git -C gki/common clean -fd
+
+          git -C gki/common apply --check \
+            "$PWD/retention/extracted/stage/refgen-critical-retention-source.patch"
+          git -C gki/common apply \
+            "$PWD/retention/extracted/stage/refgen-critical-retention-source.patch"
+
+          OUT="$PWD/artifacts/a52xq-refgen-active-display-scopes"
+          mkdir -p "$OUT/logs" "$OUT/stage" "$OUT/config" "$OUT/compile" \
+            "$OUT/package" "$OUT/tools"
+          python3 scripts/165_apply_a52_active_display_scopes.py \
+            --gki gki/common --output "$OUT/stage" \
+            2>&1 | tee "$OUT/logs/active-display-scopes-stage.log"
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path(
+              'artifacts/a52xq-refgen-active-display-scopes/stage/'
+              'phase28-a52-active-display-scopes-report.json'
+          ).read_text())
+          assert report['status'] == 'a52-active-display-scopes-v1-staged'
+          assert report['active_tree'] == 'drivers/a52_display'
+          assert report['target_file_count'] == 6
+          assert report['target_function_count'] == 20
+          assert report['inserted_function_count'] == 20
+          assert report['functional_change'] == 'instrumentation-only'
+          assert report['refgen_logic_unchanged'] is True
+          assert report['recorder_policy_unchanged'] is True
+          assert report['evidence_basis']['capture_sha256'] == (
+              'afce7a237eb723f3b87c0326b6242e6a2816975057d193281e91bf958abd3614'
+          )
+          PY
+
+          while IFS= read -r marker; do
+            test -n "$marker"
+            grep -R -Fq "$marker" gki/common/drivers/a52_display
+          done <<'EOF'
+          A52_ACKFR_SCOPE("DISP", "a52.dsi_bridge_pre_enable")
+          A52_ACKFR_SCOPE("DISP", "a52.dsi_display_prepare")
+          A52_ACKFR_SCOPE("DISP", "a52.dsi_panel_prepare")
+          A52_ACKFR_SCOPE("DISP", "a52.sde_crtc_commit_kickoff")
+          A52_ACKFR_SCOPE("DISP", "a52.sde_encoder_kickoff")
+          A52_ACKFR_SCOPE("DISP", "a52.ss_panel_on_pre")
+          A52_ACKFR_SCOPE("DISP", "a52.ss_panel_off_post")
+          EOF
+
+          git -C gki/common diff --check
+          git -C gki/common add -N .
+          git -C gki/common diff --binary --no-ext-diff \
+            > "$OUT/stage/refgen-active-display-scopes-source.patch"
+          test -s "$OUT/stage/refgen-active-display-scopes-source.patch"
+
+      - name: Compile active A52 display-scope kernel
+        run: |
+          set -Eeuo pipefail
+          OUT="$PWD/artifacts/a52xq-refgen-active-display-scopes"
+          BUILD="$PWD/workspace/gki-refgen-active-display-scopes-out"
+          mkdir -p "$BUILD"
+          cp retention/extracted/config/final.config "$BUILD/.config"
+
+          CLANG="$(readlink -f "$(command -v clang)")"
+          export PATH="$(dirname "$CLANG"):$PATH"
+          export CROSS_COMPILE=aarch64-linux-gnu-
+          export CLANG_TRIPLE=aarch64-linux-gnu-
+
+          make -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+            2>&1 | tee "$OUT/logs/olddefconfig.log"
+          cp "$BUILD/.config" "$OUT/config/final.config"
+          grep -Fxq 'CONFIG_REGULATOR_REFGEN=y' "$BUILD/.config"
+          grep -Fxq 'CONFIG_QCOM_WDT=y' "$BUILD/.config"
+
+          set +e
+          make -k -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+            KCFLAGS=-Wno-error=frame-larger-than Image \
+            > "$OUT/logs/compile.log" 2>&1
+          rc=$?
+          set -e
+          printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+          if [ "$rc" -ne 0 ]; then
+            echo '::group::Compiler errors'
+            grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+              "$OUT/logs/compile.log" | tail -n 300 || true
+            echo '::endgroup::'
+            tail -n 400 "$OUT/logs/compile.log" || true
+            exit "$rc"
+          fi
+
+          test -s "$BUILD/arch/arm64/boot/Image"
+          cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+          gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+          gzip -t "$OUT/package/Image.gz"
+
+          grep -Fq 'CC      drivers/a52_display/msm/dsi/dsi_display.o' "$OUT/logs/compile.log"
+          grep -Fq 'CC      drivers/a52_display/msm/dsi/dsi_panel.o' "$OUT/logs/compile.log"
+          grep -Fq 'CC      drivers/a52_display/msm/sde/sde_crtc.o' "$OUT/logs/compile.log"
+          grep -Fq 'CC      drivers/a52_display/msm/sde/sde_encoder.o' "$OUT/logs/compile.log"
+          grep -Fq 'CC      drivers/a52_display/msm/samsung/ss_dsi_panel_common.o' "$OUT/logs/compile.log"
+
+          while IFS= read -r marker; do
+            test -n "$marker"
+            grep -aFq "$marker" "$OUT/compile/Image"
+          done <<'EOF'
+          policy=critical-after-capacity
+          REFGEN probe ready initial_enabled=%d
+          REFGEN kona_disable raw=0x%x->0x%x enabled=%u
+          HB tick=%u online=%u run=%lu j=%lu
+          WDT disarm before=%u after=%u
+          a52.dsi_bridge_pre_enable
+          a52.dsi_display_prepare
+          a52.dsi_panel_prepare
+          a52.sde_crtc_commit_kickoff
+          a52.sde_encoder_kickoff
+          a52.ss_panel_on_pre
+          a52.ss_panel_off_post
+          EOF
+
+          if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+              "$OUT/logs/compile.log" > "$OUT/logs/compiler-errors.txt"; then
+            cat "$OUT/logs/compiler-errors.txt"
+            exit 1
+          fi
+          grep -Fq 'OBJCOPY arch/arm64/boot/Image' "$OUT/logs/compile.log"
+
+      - name: Repack and audit boot image
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-refgen-active-display-scopes
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source run32/extracted/package/boot.img \
+            --kernel "$OUT/package/Image.gz" \
+            --output "$OUT/package/boot.img" \
+            --report "$OUT/package/repack-report.json"
+          test -s "$OUT/package/boot.img"
+          cp retention/extracted/tools/decode-a52-unified-secure-recorder.py \
+            "$OUT/tools/decode-a52-unified-secure-recorder.py"
+
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import re
+          from pathlib import Path
+
+          root = Path('artifacts/a52xq-refgen-active-display-scopes')
+          scopes = json.loads((
+              root / 'stage/phase28-a52-active-display-scopes-report.json'
+          ).read_text())
+          repack = json.loads((root / 'package/repack-report.json').read_text())
+          compile_log = (root / 'logs/compile.log').read_text(errors='replace')
+          errors = re.findall(
+              r'^[^:\s][^:]*:\d+:\d+: (?:fatal error|error): ',
+              compile_log,
+              re.M,
+          )
+          image = root / 'compile/Image'
+          image_gz = root / 'package/Image.gz'
+          boot = root / 'package/boot.img'
+          final = {
+              'status': 'a52-refgen-active-display-scopes-boot-audited',
+              'flashable_candidate': True,
+              'hardware_validated': False,
+              'functional_change': 'instrumentation-only-active-a52-display',
+              'refgen_logic_unchanged': True,
+              'recorder_policy_unchanged': True,
+              'source_retention_artifact_id': 8652257328,
+              'source_retention_artifact_sha256':
+                  '885b5f54945b9887d9778467b81b31c5e586b92685fc4369d23a6bbf0501b313',
+              'second_capture_sha256':
+                  'afce7a237eb723f3b87c0326b6242e6a2816975057d193281e91bf958abd3614',
+              'active_scope_count': scopes['target_function_count'],
+              'active_scope_tree': scopes['active_tree'],
+              'payload_capture': False,
+              'compiler_error_count': len(errors),
+              'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+              'image_gz_sha256': hashlib.sha256(image_gz.read_bytes()).hexdigest(),
+              'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+              'boot_bytes': boot.stat().st_size,
+              'dtb_preserved': repack['invariants']['dtb_preserved'],
+              'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+              'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+          }
+          if errors:
+              raise SystemExit(f'compiler errors survived audit: {len(errors)}')
+          if final['boot_bytes'] != 100663296:
+              raise SystemExit(f"unexpected boot size: {final['boot_bytes']}")
+          if not all((
+              final['dtb_preserved'],
+              final['ramdisk_preserved'],
+              final['recovery_dtbo_preserved'],
+          )):
+              raise SystemExit('boot container invariant failed')
+          (root / 'final-audit.json').write_text(
+              json.dumps(final, indent=2, sort_keys=True) + '\n'
+          )
+          PY
+
+          cat > "$OUT/README-FIRST.txt" <<'EOF'
+          A52 REFGEN ACTIVE DISPLAY-SCOPE CANDIDATE
+
+          The previous hardware capture proved REFGEN registered, mapped and reached
+          ready with initial_enabled=1. The kernel remained alive past 52 seconds.
+          No DISP scopes appeared because the earlier patch instrumented the inactive
+          techpack/display duplicate while this kernel compiles drivers/a52_display.
+
+          This image changes instrumentation only. It adds metadata-only DISP entry
+          and exit scopes to the compiled A52 DSI, panel, CRTC, encoder and Samsung
+          panel power hooks. REFGEN logic, recorder retention, DTB, ramdisk, recovery
+          DTBO, heartbeat cadence and watchdog behavior are unchanged.
+
+          Flash only package/boot.img. If the screen remains black, wait at least
+          15 seconds, enter recovery directly and collect the raw 1 MiB RAMOOPS image.
+          EOF
+
+          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 \
+            | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          (cd "$OUT" && sha256sum -c SHA256SUMS)
+          cat "$OUT/final-audit.json"
+
+      - name: Upload active display-scope candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-refgen-active-display-scopes-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-refgen-active-display-scopes
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Require audited candidate
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          audit = json.loads(Path(
+              'artifacts/a52xq-refgen-active-display-scopes/final-audit.json'
+          ).read_text())
+          assert audit['status'] == 'a52-refgen-active-display-scopes-boot-audited'
+          assert audit['flashable_candidate'] is True
+          assert audit['hardware_validated'] is False
+          assert audit['functional_change'] == 'instrumentation-only-active-a52-display'
+          assert audit['refgen_logic_unchanged'] is True
+          assert audit['recorder_policy_unchanged'] is True
+          assert audit['active_scope_count'] == 20
+          assert audit['boot_bytes'] == 100663296
+          assert audit['compiler_error_count'] == 0
+          assert audit['dtb_preserved'] is True
+          assert audit['ramdisk_preserved'] is True
+          assert audit['recovery_dtbo_preserved'] is True
+          PY

--- a/scripts/165_apply_a52_active_display_scopes.py
+++ b/scripts/165_apply_a52_active_display_scopes.py
@@ -8,7 +8,7 @@ import tempfile
 from pathlib import Path
 
 REPORT_NAME = "phase28-a52-active-display-scopes-report.json"
-MARKER = "A52_ACTIVE_DISPLAY_SCOPES_V1"
+MARKER = "A52_ACTIVE_DISPLAY_SCOPES_V2"
 INCLUDE = "#include <linux/a52_ack_secure_flight_recorder.h>"
 CAPTURE_SHA256 = "afce7a237eb723f3b87c0326b6242e6a2816975057d193281e91bf958abd3614"
 
@@ -122,41 +122,38 @@ def mask_c(text: str) -> str:
     return "".join(out)
 
 
-def top_level_before(masked: str, position: int) -> bool:
-    depth = 0
-    for c in masked[:position]:
-        if c == "{":
-            depth += 1
-        elif c == "}":
-            depth -= 1
-    return depth == 0
+def definition_openings(text: str, name: str) -> list[int]:
+    """Return opening braces for definitions, ignoring calls and prototypes.
 
-
-def function_opening(text: str, name: str) -> int | None:
+    Do not use whole-file brace depth here. The downstream Samsung sources have
+    mutually exclusive preprocessor branches whose raw braces are intentionally
+    unbalanced until preprocessing.
+    """
     masked = mask_c(text)
+    openings: list[int] = []
     for match in re.finditer(r"\b" + re.escape(name) + r"\s*\(", masked):
-        if not top_level_before(masked, match.start()):
-            continue
         paren = match.end() - 1
         depth = 0
         close_paren = -1
         for i in range(paren, len(masked)):
-            if masked[i] == "(":
+            c = masked[i]
+            if c == "(":
                 depth += 1
-            elif masked[i] == ")":
+            elif c == ")":
                 depth -= 1
                 if depth == 0:
                     close_paren = i
                     break
         if close_paren < 0:
             continue
-        tail = masked[close_paren + 1: close_paren + 2048]
+
+        tail = masked[close_paren + 1 : close_paren + 4097]
         brace_rel = tail.find("{")
         semi_rel = tail.find(";")
         if brace_rel < 0 or (semi_rel >= 0 and semi_rel < brace_rel):
             continue
-        return close_paren + 1 + brace_rel
-    return None
+        openings.append(close_paren + 1 + brace_rel)
+    return openings
 
 
 def scope_name(function: str) -> str:
@@ -167,11 +164,13 @@ def inject_scope(text: str, function: str) -> tuple[str, str]:
     statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
     if statement in text:
         return text, "already-present"
-    opening = function_opening(text, function)
-    if opening is None:
-        raise SystemExit(f"active display function missing: {function}")
-    text = text[:opening + 1] + "\n\t" + statement + text[opening + 1:]
-    return text, "inserted"
+    openings = definition_openings(text, function)
+    if len(openings) != 1:
+        raise SystemExit(
+            f"active display definition count mismatch: {function}: {len(openings)}"
+        )
+    opening = openings[0]
+    return text[: opening + 1] + "\n\t" + statement + text[opening + 1 :], "inserted"
 
 
 def audit_file(path: Path, functions: tuple[str, ...]) -> None:
@@ -180,10 +179,9 @@ def audit_file(path: Path, functions: tuple[str, ...]) -> None:
         raise SystemExit(f"recorder include missing: {path}")
     for function in functions:
         statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
-        if text.count(statement) != 1:
-            raise SystemExit(
-                f"scope audit failed for {path}:{function}: count={text.count(statement)}"
-            )
+        count = text.count(statement)
+        if count != 1:
+            raise SystemExit(f"scope audit failed for {path}:{function}: count={count}")
 
 
 def run(gki: Path, output: Path) -> dict[str, object]:
@@ -193,12 +191,11 @@ def run(gki: Path, output: Path) -> dict[str, object]:
         path = gki / rel
         if not path.is_file():
             raise SystemExit(f"compiled A52 display source missing: {path}")
-        text = read(path)
-        text, include_changed = add_include(text)
+        text, include_changed = add_include(read(path))
         states: list[dict[str, str]] = []
         for function in functions:
             text, state = inject_scope(text, function)
-            inserted += state == "inserted"
+            inserted += int(state == "inserted")
             states.append(
                 {
                     "function": function,
@@ -227,6 +224,7 @@ def run(gki: Path, output: Path) -> dict[str, object]:
         "inactive_tree_previously_instrumented": "techpack/display",
         "scope_domain": "DISP",
         "scope_prefix": "a52.",
+        "parser": "definition-based-preprocessor-safe",
         "target_file_count": len(TARGETS),
         "target_function_count": total,
         "inserted_function_count": inserted,
@@ -264,8 +262,14 @@ def self_test() -> None:
             for index, function in enumerate(functions):
                 qualifier = "static " if index % 2 else ""
                 body.append(
+                    f"{qualifier}int {function}(void *arg);\n"
                     f"{qualifier}int {function}(void *arg)\n"
                     "{\n"
+                    "#if defined(TEST_A)\n"
+                    "\tif (arg) { return 1; }\n"
+                    "#else\n"
+                    "\tif (!arg) { return 0; }\n"
+                    "#endif\n"
                     "\treturn arg != 0;\n"
                     "}\n\n"
                 )

--- a/scripts/165_apply_a52_active_display_scopes.py
+++ b/scripts/165_apply_a52_active_display_scopes.py
@@ -59,11 +59,26 @@ def write(path: Path, text: str) -> None:
 def add_include(text: str) -> tuple[str, bool]:
     if INCLUDE in text:
         return text, False
-    matches = list(re.finditer(r"^#include[^\n]*\n", text, flags=re.M))
-    if not matches:
-        raise SystemExit("no include anchor found")
-    pos = matches[-1].end()
-    return text[:pos] + INCLUDE + "\n" + text[pos:], True
+
+    # Insert into the initial unconditional include block. Several Samsung files
+    # contain additional #include directives thousands of lines later, inside
+    # functions or CONFIG_DISPLAY_SAMSUNG blocks. Using the global last include
+    # would place the recorder declaration after the instrumented function.
+    offset = 0
+    seen_include = False
+    insert_at = -1
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if line.startswith("#include"):
+            seen_include = True
+            insert_at = offset + len(line)
+        elif seen_include and stripped and not stripped.startswith(("/*", "*", "//")):
+            break
+        offset += len(line)
+
+    if insert_at < 0:
+        raise SystemExit("initial include anchor not found")
+    return text[:insert_at] + INCLUDE + "\n" + text[insert_at:], True
 
 
 def mask_c(text: str) -> str:

--- a/scripts/165_apply_a52_active_display_scopes.py
+++ b/scripts/165_apply_a52_active_display_scopes.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+from pathlib import Path
+
+REPORT_NAME = "phase28-a52-active-display-scopes-report.json"
+MARKER = "A52_ACTIVE_DISPLAY_SCOPES_V1"
+INCLUDE = "#include <linux/a52_ack_secure_flight_recorder.h>"
+CAPTURE_SHA256 = "afce7a237eb723f3b87c0326b6242e6a2816975057d193281e91bf958abd3614"
+
+TARGETS: dict[Path, tuple[str, ...]] = {
+    Path("drivers/a52_display/msm/dsi/dsi_drm.c"): (
+        "dsi_bridge_pre_enable",
+        "dsi_bridge_enable",
+        "dsi_bridge_disable",
+        "dsi_bridge_post_disable",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_display.c"): (
+        "dsi_display_prepare",
+        "dsi_display_enable",
+        "dsi_display_disable",
+        "dsi_display_unprepare",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_panel.c"): (
+        "dsi_panel_prepare",
+        "dsi_panel_enable",
+        "dsi_panel_disable",
+        "dsi_panel_unprepare",
+    ),
+    Path("drivers/a52_display/msm/sde/sde_crtc.c"): (
+        "sde_crtc_commit_kickoff",
+    ),
+    Path("drivers/a52_display/msm/sde/sde_encoder.c"): (
+        "sde_encoder_kickoff",
+    ),
+    Path("drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"): (
+        "ss_panel_attach_set",
+        "ss_panel_data_read_gpara",
+        "ss_panel_on_pre",
+        "ss_panel_on_post",
+        "ss_panel_off_pre",
+        "ss_panel_off_post",
+    ),
+}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="strict")
+
+
+def write(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def add_include(text: str) -> tuple[str, bool]:
+    if INCLUDE in text:
+        return text, False
+    matches = list(re.finditer(r"^#include[^\n]*\n", text, flags=re.M))
+    if not matches:
+        raise SystemExit("no include anchor found")
+    pos = matches[-1].end()
+    return text[:pos] + INCLUDE + "\n" + text[pos:], True
+
+
+def mask_c(text: str) -> str:
+    out = list(text)
+    state = "normal"
+    escaped = False
+    i = 0
+    while i < len(text):
+        c = text[i]
+        n = text[i + 1] if i + 1 < len(text) else ""
+        if state == "normal":
+            if c == "/" and n == "/":
+                out[i] = out[i + 1] = " "
+                state = "line-comment"
+                i += 2
+                continue
+            if c == "/" and n == "*":
+                out[i] = out[i + 1] = " "
+                state = "block-comment"
+                i += 2
+                continue
+            if c == '"':
+                out[i] = " "
+                state = "string"
+                escaped = False
+            elif c == "'":
+                out[i] = " "
+                state = "char"
+                escaped = False
+        elif state == "line-comment":
+            if c == "\n":
+                state = "normal"
+            else:
+                out[i] = " "
+        elif state == "block-comment":
+            if c == "*" and n == "/":
+                out[i] = out[i + 1] = " "
+                state = "normal"
+                i += 2
+                continue
+            if c != "\n":
+                out[i] = " "
+        else:
+            quote = '"' if state == "string" else "'"
+            if c == "\n":
+                escaped = False
+            else:
+                out[i] = " "
+                if escaped:
+                    escaped = False
+                elif c == "\\":
+                    escaped = True
+                elif c == quote:
+                    state = "normal"
+        i += 1
+    return "".join(out)
+
+
+def top_level_before(masked: str, position: int) -> bool:
+    depth = 0
+    for c in masked[:position]:
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+    return depth == 0
+
+
+def function_opening(text: str, name: str) -> int | None:
+    masked = mask_c(text)
+    for match in re.finditer(r"\b" + re.escape(name) + r"\s*\(", masked):
+        if not top_level_before(masked, match.start()):
+            continue
+        paren = match.end() - 1
+        depth = 0
+        close_paren = -1
+        for i in range(paren, len(masked)):
+            if masked[i] == "(":
+                depth += 1
+            elif masked[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    close_paren = i
+                    break
+        if close_paren < 0:
+            continue
+        tail = masked[close_paren + 1: close_paren + 2048]
+        brace_rel = tail.find("{")
+        semi_rel = tail.find(";")
+        if brace_rel < 0 or (semi_rel >= 0 and semi_rel < brace_rel):
+            continue
+        return close_paren + 1 + brace_rel
+    return None
+
+
+def scope_name(function: str) -> str:
+    return f"a52.{function}"
+
+
+def inject_scope(text: str, function: str) -> tuple[str, str]:
+    statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
+    if statement in text:
+        return text, "already-present"
+    opening = function_opening(text, function)
+    if opening is None:
+        raise SystemExit(f"active display function missing: {function}")
+    text = text[:opening + 1] + "\n\t" + statement + text[opening + 1:]
+    return text, "inserted"
+
+
+def audit_file(path: Path, functions: tuple[str, ...]) -> None:
+    text = read(path)
+    if INCLUDE not in text:
+        raise SystemExit(f"recorder include missing: {path}")
+    for function in functions:
+        statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
+        if text.count(statement) != 1:
+            raise SystemExit(
+                f"scope audit failed for {path}:{function}: count={text.count(statement)}"
+            )
+
+
+def run(gki: Path, output: Path) -> dict[str, object]:
+    results: list[dict[str, object]] = []
+    inserted = 0
+    for rel, functions in TARGETS.items():
+        path = gki / rel
+        if not path.is_file():
+            raise SystemExit(f"compiled A52 display source missing: {path}")
+        text = read(path)
+        text, include_changed = add_include(text)
+        states: list[dict[str, str]] = []
+        for function in functions:
+            text, state = inject_scope(text, function)
+            inserted += state == "inserted"
+            states.append(
+                {
+                    "function": function,
+                    "scope": scope_name(function),
+                    "state": state,
+                }
+            )
+        write(path, text)
+        audit_file(path, functions)
+        results.append(
+            {
+                "path": str(rel),
+                "include_changed": include_changed,
+                "functions": states,
+            }
+        )
+
+    total = sum(len(functions) for functions in TARGETS.values())
+    report = {
+        "status": "a52-active-display-scopes-v1-staged",
+        "hardware_validated": False,
+        "functional_change": "instrumentation-only",
+        "refgen_logic_unchanged": True,
+        "recorder_policy_unchanged": True,
+        "active_tree": "drivers/a52_display",
+        "inactive_tree_previously_instrumented": "techpack/display",
+        "scope_domain": "DISP",
+        "scope_prefix": "a52.",
+        "target_file_count": len(TARGETS),
+        "target_function_count": total,
+        "inserted_function_count": inserted,
+        "payload_capture": False,
+        "evidence_basis": {
+            "capture_sha256": CAPTURE_SHA256,
+            "screen_result": "black",
+            "refgen_driver_register_rc": 0,
+            "refgen_probe_ready_initial_enabled": 1,
+            "heartbeat_last_tick": 103,
+            "heartbeat_last_monotonic_ns": 52724026229,
+            "recovered_display_scope_events": 0,
+            "finding": (
+                "the compiled objects came from drivers/a52_display while the prior "
+                "scope patch targeted the inactive techpack/display duplicate"
+            ),
+        },
+        "files": results,
+    }
+    output.mkdir(parents=True, exist_ok=True)
+    (output / REPORT_NAME).write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="a52-active-display-scopes-") as tmp:
+        root = Path(tmp)
+        for rel, functions in TARGETS.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            body = ["#include <linux/kernel.h>\n\n"]
+            for index, function in enumerate(functions):
+                qualifier = "static " if index % 2 else ""
+                body.append(
+                    f"{qualifier}int {function}(void *arg)\n"
+                    "{\n"
+                    "\treturn arg != 0;\n"
+                    "}\n\n"
+                )
+            path.write_text("".join(body), encoding="utf-8")
+        report = run(root, root / "report")
+        expected = sum(len(v) for v in TARGETS.values())
+        if report["target_function_count"] != expected:
+            raise SystemExit("target-count self-test failed")
+        if report["inserted_function_count"] != expected:
+            raise SystemExit("insertion self-test failed")
+        second = run(root, root / "report2")
+        if second["inserted_function_count"] != 0:
+            raise SystemExit("idempotence self-test failed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Instrument the compiled Galaxy A52 display tree with persistent "
+            "metadata-only DISP scopes."
+        )
+    )
+    parser.add_argument("--gki", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        print(json.dumps({"status": "self-test-passed"}, sort_keys=True))
+        return 0
+    if args.gki is None or args.output is None:
+        parser.error("--gki and --output are required unless --self-test is used")
+
+    report = run(args.gki.resolve(), args.output.resolve())
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Hardware evidence

The second Galaxy A52 5G capture from the critical-retention kernel preserved the REFGEN sequence and heartbeat window.

- raw 1 MiB RAMOOPS SHA-256: `afce7a237eb723f3b87c0326b6242e6a2816975057d193281e91bf958abd3614`
- REFGEN driver registration returned `0`
- the provider mapped the stock resource and reached `probe ready initial_enabled=1`
- the watchdog was disarmed
- heartbeat records continued through tick 103 at approximately 52.7 seconds
- the physical screen remained black
- zero `DISP` scope records were recovered

## Root cause of the missing display evidence

The previous source patch inserted Qualcomm/Samsung display scopes under `techpack/display`, but the audited compile log shows this kernel builds and executes the duplicate tree under `drivers/a52_display`. The runtime console contains downstream SDE, DSI and Samsung panel activity, confirming that display execution bypassed the instrumented files.

## Narrow change

This PR adds metadata-only entry and exit scopes to 20 functions in the compiled `drivers/a52_display` tree:

- bridge pre-enable, enable, disable and post-disable
- display prepare, enable, disable and unprepare
- panel prepare, enable, disable and unprepare
- SDE CRTC commit kickoff
- SDE encoder kickoff
- Samsung panel attach, data-read, on-pre, on-post, off-pre and off-post hooks

Every scope uses a unique `DISP a52.<function>` name.

## Unchanged behavior

This PR does not change REFGEN logic, register offsets, regulator state handling, DTB, ramdisk, recovery DTBO, recorder retention, heartbeat cadence, watchdog behavior, display control flow or panel payloads.

## Workflow 165

Workflow 165 reconstructs the exact successful retention source from artifact `8652257328`, verifies its artifact digest and full manifest, applies only the active-tree scopes, requires the real `drivers/a52_display` objects in the compile log, checks the unique scope strings in the final `Image`, repacks against the checksum-verified Run 32 boot container, and audits the final boot image.

The resulting image remains not hardware validated until the next phone capture identifies the last completed or stalled active display hook.