### PR TITLE
Trace the A52 display lifecycle before panel enable

### DIFF
--- a/.github/workflows/166-a52-display-lifecycle-scopes.yml
+++ b/.github/workflows/166-a52-display-lifecycle-scopes.yml
@@ -1,19 +1,15 @@
 name: 166 - A52 display lifecycle scopes
-
 run-name: Build REFGEN candidate with display probe, bind, KMS and clock scopes
 
 on:
   workflow_dispatch:
   push:
-    branches:
-      - agent/a52-display-lifecycle-scopes
+    branches: [agent/a52-display-lifecycle-scopes]
     paths:
       - .github/workflows/166-a52-display-lifecycle-scopes.yml
       - scripts/166_apply_a52_display_lifecycle_scopes.py
-      - scripts/38_repack_a52_p1_boot.py
   pull_request:
-    branches:
-      - agent/a52-active-display-scopes
+    branches: [agent/a52-active-display-scopes]
     paths:
       - .github/workflows/166-a52-display-lifecycle-scopes.yml
       - scripts/166_apply_a52_display_lifecycle_scopes.py
@@ -23,27 +19,24 @@ permissions:
   actions: read
 
 concurrency:
-  group: a52-display-lifecycle-scopes-${{ github.ref }}
+  group: a52-display-lifecycle-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
   RUN32_ARTIFACT_ID: '8635093061'
-  ACTIVE_SOURCE_ARTIFACT_ID: '8654956416'
-  ACTIVE_SOURCE_ARTIFACT_SHA256: a70b7cd08c3e578415cc5289a36a4efb1ad61cfe8734c2e198b9aa8ebb763c08
-  LATEST_CAPTURE_SHA256: e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad
+  ACTIVE_ARTIFACT_ID: '8654956416'
+  ACTIVE_ARTIFACT_SHA256: a70b7cd08c3e578415cc5289a36a4efb1ad61cfe8734c2e198b9aa8ebb763c08
+  CAPTURE_SHA256: e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad
 
 jobs:
   build-package:
-    name: Compile and package A52 display lifecycle candidate
     runs-on: ubuntu-22.04
     timeout-minutes: 360
-
     steps:
-      - name: Check out lifecycle branch
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Prepare runner and validate patcher
+      - name: Prepare and self-test
         run: |
           set -Eeuo pipefail
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
@@ -52,336 +45,154 @@ jobs:
             git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
             clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
             libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
-          python3 -m py_compile \
-            scripts/166_apply_a52_display_lifecycle_scopes.py \
-            scripts/38_repack_a52_p1_boot.py
+          python3 -m py_compile scripts/165_apply_a52_active_display_scopes.py \
+            scripts/166_apply_a52_display_lifecycle_scopes.py scripts/38_repack_a52_p1_boot.py
           python3 scripts/166_apply_a52_display_lifecycle_scopes.py --self-test
 
-      - name: Restore pinned GKI source
+      - name: Restore pinned GKI
         id: gki-cache
         uses: actions/cache/restore@v4
         with:
           path: gki
           key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
 
-      - name: Download active-scope source and Run 32 boot container
+      - name: Restore source and stage lifecycle scopes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
           mkdir -p active/extracted run32/extracted
           curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H 'Accept: application/vnd.github+json' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ACTIVE_SOURCE_ARTIFACT_ID}/zip" \
-            --output active/artifact.zip
-          printf '%s  %s\n' "${ACTIVE_SOURCE_ARTIFACT_SHA256}" active/artifact.zip \
-            | sha256sum -c -
+            -H "Authorization: Bearer ${GH_TOKEN}" -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ACTIVE_ARTIFACT_ID}/zip" \
+            -o active/artifact.zip
+          printf '%s  %s\n' "${ACTIVE_ARTIFACT_SHA256}" active/artifact.zip | sha256sum -c -
           curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" -H 'Accept: application/vnd.github+json' \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${RUN32_ARTIFACT_ID}/zip" \
-            --output run32/artifact.zip
+            -o run32/artifact.zip
           unzip -q active/artifact.zip -d active/extracted
           unzip -q run32/artifact.zip -d run32/extracted
           (cd active/extracted && sha256sum -c SHA256SUMS)
           (cd run32/extracted && sha256sum -c SHA256SUMS)
-
-          test -s active/extracted/stage/refgen-active-display-scopes-source.patch
+          SRC=active/extracted/stage/refgen-active-display-scopes-source.patch
+          test -s "$SRC"
+          grep -Fq 'a52.dsi_bridge_pre_enable' "$SRC"
+          grep -Fq 'A52_USR2_CRITICAL_PERSIST_V1' "$SRC"
+          grep -Fq 'REFGEN probe ready initial_enabled=%d' "$SRC"
           test -s active/extracted/config/final.config
-          test -s active/extracted/package/boot.img
           test -s active/extracted/tools/decode-a52-unified-secure-recorder.py
-          test "$(tr -d '\r\n' < active/extracted/compile/make-return-code.txt)" = 0
           test -s run32/extracted/package/boot.img
-          grep -Fq 'A52_ACTIVE_DISPLAY_SCOPES_V2' \
-            active/extracted/stage/refgen-active-display-scopes-source.patch
-          grep -Fq 'A52_USR2_CRITICAL_PERSIST_V1' \
-            active/extracted/stage/refgen-active-display-scopes-source.patch
-          grep -Fq 'REFGEN probe ready initial_enabled=%d' \
-            active/extracted/stage/refgen-active-display-scopes-source.patch
 
-      - name: Restore audited active source and apply lifecycle scopes
-        run: |
-          set -Eeuo pipefail
-          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
-          test -d gki/common/.git
-          test "$(git -C gki/common rev-parse HEAD)" = "${GKI_COMMON_SHA}"
           git -C gki/common reset --hard "${GKI_COMMON_SHA}"
           git -C gki/common clean -fd
-
-          git -C gki/common apply --check \
-            "$PWD/active/extracted/stage/refgen-active-display-scopes-source.patch"
-          git -C gki/common apply \
-            "$PWD/active/extracted/stage/refgen-active-display-scopes-source.patch"
+          git -C gki/common apply --check "$PWD/$SRC"
+          git -C gki/common apply "$PWD/$SRC"
 
           OUT="$PWD/artifacts/a52xq-refgen-display-lifecycle-scopes"
-          mkdir -p "$OUT/logs" "$OUT/stage" "$OUT/config" "$OUT/compile" \
-            "$OUT/package" "$OUT/tools"
+          mkdir -p "$OUT"/{logs,stage,config,compile,package,tools}
           python3 scripts/166_apply_a52_display_lifecycle_scopes.py \
-            --gki gki/common --output "$OUT/stage" \
-            2>&1 | tee "$OUT/logs/display-lifecycle-stage.log"
-
+            --gki gki/common --output "$OUT/stage" | tee "$OUT/logs/stage.log"
           python3 - <<'PY'
           import json
           from pathlib import Path
-
-          report = json.loads(Path(
-              'artifacts/a52xq-refgen-display-lifecycle-scopes/stage/'
-              'phase29-a52-display-lifecycle-scopes-report.json'
-          ).read_text())
-          assert report['status'] == 'a52-display-lifecycle-scopes-v1-staged'
-          assert report['active_tree'] == 'drivers/a52_display'
-          assert report['persistent_profile'] == 'display-lifecycle-v1'
-          assert report['target_file_count'] == 8
-          assert report['target_function_count'] == 24
-          assert report['inserted_function_count'] == 24
-          assert report['functional_change'] == 'instrumentation-only'
-          assert report['refgen_logic_unchanged'] is True
-          assert report['display_control_flow_unchanged'] is True
-          assert report['recorder_retention_policy_unchanged'] is True
-          assert report['evidence_basis']['capture_sha256'] == (
-              'e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad'
-          )
+          p = Path('artifacts/a52xq-refgen-display-lifecycle-scopes/stage/phase29-a52-display-lifecycle-scopes-report.json')
+          r = json.loads(p.read_text())
+          assert r['status'] == 'a52-display-lifecycle-scopes-v1-staged'
+          assert r['persistent_profile'] == 'display-lifecycle-v1'
+          assert r['target_file_count'] == 8
+          assert r['target_function_count'] == r['inserted_function_count'] == 24
+          assert r['refgen_logic_unchanged'] and r['display_control_flow_unchanged']
+          assert r['recorder_retention_policy_unchanged']
+          assert r['evidence_basis']['capture_sha256'] == 'e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad'
           PY
-
-          while IFS= read -r marker; do
-            test -n "$marker"
-            grep -R -Fq "$marker" gki/common/drivers/a52_display \
-              gki/common/drivers/a52_secure/a52_ack_secure_flight_recorder.c
-          done <<'EOF'
-          profile=display-lifecycle-v1
-          A52_ACKFR_SCOPE("DISP", "a52.life.msm_drm_register")
-          A52_ACKFR_SCOPE("DISP", "a52.life.msm_pdev_probe")
-          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_dev_probe")
-          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_bind")
-          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_bridge_attach")
-          A52_ACKFR_SCOPE("DISP", "a52.life.sde_kms_hw_init")
-          A52_ACKFR_SCOPE("DISP", "a52.life.sde_kms_commit")
-          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_clk_update_link_clk_state")
-          A52_ACKFR_SCOPE("DISP", "a52.life.ss_panel_init")
-          EOF
-
           git -C gki/common diff --check
           git -C gki/common add -N .
-          git -C gki/common diff --binary --no-ext-diff \
-            > "$OUT/stage/refgen-display-lifecycle-scopes-source.patch"
-          test -s "$OUT/stage/refgen-display-lifecycle-scopes-source.patch"
+          git -C gki/common diff --binary --no-ext-diff > "$OUT/stage/refgen-display-lifecycle-scopes-source.patch"
 
-      - name: Compile display lifecycle kernel
+      - name: Compile, repack and audit
         run: |
           set -Eeuo pipefail
           OUT="$PWD/artifacts/a52xq-refgen-display-lifecycle-scopes"
-          BUILD="$PWD/workspace/gki-refgen-display-lifecycle-scopes-out"
+          BUILD="$PWD/workspace/gki-display-lifecycle-out"
           mkdir -p "$BUILD"
           cp active/extracted/config/final.config "$BUILD/.config"
-
-          CLANG="$(readlink -f "$(command -v clang)")"
-          export PATH="$(dirname "$CLANG"):$PATH"
-          export CROSS_COMPILE=aarch64-linux-gnu-
-          export CLANG_TRIPLE=aarch64-linux-gnu-
-
+          export CROSS_COMPILE=aarch64-linux-gnu- CLANG_TRIPLE=aarch64-linux-gnu-
           make -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
-            2>&1 | tee "$OUT/logs/olddefconfig.log"
+            > "$OUT/logs/olddefconfig.log" 2>&1
           cp "$BUILD/.config" "$OUT/config/final.config"
-          grep -Fxq 'CONFIG_REGULATOR_REFGEN=y' "$BUILD/.config"
-          grep -Fxq 'CONFIG_QCOM_WDT=y' "$BUILD/.config"
-
-          set +e
           make -k -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
-            KCFLAGS=-Wno-error=frame-larger-than Image \
-            > "$OUT/logs/compile.log" 2>&1
-          rc=$?
-          set -e
-          printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
-          if [ "$rc" -ne 0 ]; then
-            grep -nE '(^|: )(fatal error|error): |undefined reference to' \
-              "$OUT/logs/compile.log" | tail -n 300 || true
-            tail -n 400 "$OUT/logs/compile.log" || true
-            exit "$rc"
-          fi
-
+            KCFLAGS=-Wno-error=frame-larger-than Image > "$OUT/logs/compile.log" 2>&1
           test -s "$BUILD/arch/arm64/boot/Image"
           cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+          printf '0\n' > "$OUT/compile/make-return-code.txt"
           gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
-          gzip -t "$OUT/package/Image.gz"
 
-          while IFS= read -r object; do
-            grep -Fq "CC      ${object}" "$OUT/logs/compile.log"
-          done <<'EOF'
-          drivers/a52_display/msm/msm_drv.o
-          drivers/a52_display/msm/dsi/dsi_display.o
-          drivers/a52_display/msm/dsi/dsi_drm.o
-          drivers/a52_display/msm/dsi/dsi_panel.o
-          drivers/a52_display/msm/dsi/dsi_phy.o
-          drivers/a52_display/msm/dsi/dsi_clk_manager.o
-          drivers/a52_display/msm/sde/sde_kms.o
-          drivers/a52_display/msm/samsung/ss_dsi_panel_common.o
-          EOF
-
-          while IFS= read -r marker; do
-            test -n "$marker"
+          for marker in \
+            'policy=critical-after-capacity profile=display-lifecycle-v1' \
+            'a52.life.msm_drm_register' 'a52.life.msm_pdev_probe' \
+            'a52.life.dsi_display_dev_probe' 'a52.life.dsi_display_bind' \
+            'a52.life.sde_kms_hw_init' 'a52.life.sde_kms_commit' \
+            'a52.life.dsi_clk_update_link_clk_state' 'a52.life.ss_panel_init'; do
             grep -aFq "$marker" "$OUT/compile/Image"
-          done <<'EOF'
-          policy=critical-after-capacity profile=display-lifecycle-v1
-          REFGEN probe ready initial_enabled=%d
-          HB tick=%u online=%u run=%lu j=%lu
-          WDT disarm before=%u after=%u
-          a52.life.msm_drm_register
-          a52.life.msm_pdev_probe
-          a52.life.dsi_display_dev_probe
-          a52.life.dsi_display_bind
-          a52.life.sde_kms_hw_init
-          a52.life.sde_kms_commit
-          a52.life.dsi_clk_update_link_clk_state
-          a52.life.ss_panel_init
-          EOF
-
+          done
           if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
               "$OUT/logs/compile.log" > "$OUT/logs/compiler-errors.txt"; then
             cat "$OUT/logs/compiler-errors.txt"
             exit 1
           fi
-          grep -Fq 'OBJCOPY arch/arm64/boot/Image' "$OUT/logs/compile.log"
 
-      - name: Upload failed diagnostics
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: a52xq-display-lifecycle-${{ github.run_number }}-FAILED-DIAGNOSTICS
-          path: artifacts/a52xq-refgen-display-lifecycle-scopes
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Repack and audit boot image
-        run: |
-          set -Eeuo pipefail
-          OUT=artifacts/a52xq-refgen-display-lifecycle-scopes
           python3 scripts/38_repack_a52_p1_boot.py \
-            --source run32/extracted/package/boot.img \
-            --kernel "$OUT/package/Image.gz" \
-            --output "$OUT/package/boot.img" \
-            --report "$OUT/package/repack-report.json"
-          test -s "$OUT/package/boot.img"
-          cp active/extracted/tools/decode-a52-unified-secure-recorder.py \
-            "$OUT/tools/decode-a52-unified-secure-recorder.py"
-
+            --source run32/extracted/package/boot.img --kernel "$OUT/package/Image.gz" \
+            --output "$OUT/package/boot.img" --report "$OUT/package/repack-report.json"
+          cp active/extracted/tools/decode-a52-unified-secure-recorder.py "$OUT/tools/"
           python3 - <<'PY'
-          import hashlib
-          import json
-          import re
+          import hashlib, json
           from pathlib import Path
-
           root = Path('artifacts/a52xq-refgen-display-lifecycle-scopes')
-          scopes = json.loads((
-              root / 'stage/phase29-a52-display-lifecycle-scopes-report.json'
-          ).read_text())
           repack = json.loads((root / 'package/repack-report.json').read_text())
-          compile_log = (root / 'logs/compile.log').read_text(errors='replace')
-          errors = re.findall(
-              r'^[^:\s][^:]*:\d+:\d+: (?:fatal error|error): ',
-              compile_log,
-              re.M,
-          )
-          image = root / 'compile/Image'
-          image_gz = root / 'package/Image.gz'
           boot = root / 'package/boot.img'
-          final = {
+          audit = {
               'status': 'a52-refgen-display-lifecycle-scopes-boot-audited',
               'flashable_candidate': True,
               'hardware_validated': False,
-              'functional_change': 'instrumentation-only-display-lifecycle',
-              'refgen_logic_unchanged': True,
-              'display_control_flow_unchanged': True,
-              'recorder_retention_policy_unchanged': True,
-              'persistent_profile': scopes['persistent_profile'],
+              'persistent_profile': 'display-lifecycle-v1',
+              'lifecycle_scope_count': 24,
               'source_active_artifact_id': 8654956416,
-              'source_active_artifact_sha256':
-                  'a70b7cd08c3e578415cc5289a36a4efb1ad61cfe8734c2e198b9aa8ebb763c08',
-              'latest_capture_sha256':
-                  'e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad',
-              'lifecycle_scope_count': scopes['target_function_count'],
-              'lifecycle_scope_tree': scopes['active_tree'],
-              'payload_capture': False,
-              'compiler_error_count': len(errors),
-              'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
-              'image_gz_sha256': hashlib.sha256(image_gz.read_bytes()).hexdigest(),
+              'latest_capture_sha256': 'e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad',
               'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
               'boot_bytes': boot.stat().st_size,
               'dtb_preserved': repack['invariants']['dtb_preserved'],
               'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
               'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
           }
-          if errors:
-              raise SystemExit(f'compiler errors survived audit: {len(errors)}')
-          if final['boot_bytes'] != 100663296:
-              raise SystemExit(f"unexpected boot size: {final['boot_bytes']}")
-          if not all((
-              final['dtb_preserved'],
-              final['ramdisk_preserved'],
-              final['recovery_dtbo_preserved'],
-          )):
-              raise SystemExit('boot container invariant failed')
-          (root / 'final-audit.json').write_text(
-              json.dumps(final, indent=2, sort_keys=True) + '\n'
-          )
+          assert audit['boot_bytes'] == 100663296
+          assert audit['dtb_preserved'] and audit['ramdisk_preserved'] and audit['recovery_dtbo_preserved']
+          (root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
           PY
-
           cat > "$OUT/README-FIRST.txt" <<'EOF'
-          A52 REFGEN DISPLAY LIFECYCLE-SCOPE CANDIDATE
-
-          The latest black-screen capture preserved REFGEN registration and ready state,
-          plus 184 heartbeat records through approximately 95.6 seconds. None of the 20
-          prepare, enable, panel or kickoff scopes was recovered.
-
-          This image adds a persistent profile=display-lifecycle-v1 identity and
-          metadata-only entry and exit scopes around the compiled display registration,
-          platform probe, component bind, DSI resource setup, bridge attach, KMS init,
-          commit lifecycle and the observed DSI link-clock update path.
-
-          REFGEN behavior, display control flow, panel command payloads, DTB, ramdisk,
-          recovery DTBO, recorder retention, heartbeat cadence and watchdog handling are
-          unchanged.
-
-          Flash only package/boot.img. If the screen remains black, wait at least 15
-          seconds, enter recovery directly and collect the untouched raw 1 MiB RAMOOPS
-          image. The recovered BOOT line must contain profile=display-lifecycle-v1.
+          A52 DISPLAY LIFECYCLE DIAGNOSTIC
+          Flash only package/boot.img. On a black screen, wait at least 15 seconds,
+          enter recovery directly, and collect the untouched raw 1 MiB RAMOOPS image.
+          Accept the capture only if BOOT contains profile=display-lifecycle-v1.
           EOF
-
-          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 \
-            | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
           (cd "$OUT" && sha256sum -c SHA256SUMS)
-          cat "$OUT/final-audit.json"
 
-      - name: Upload display lifecycle candidate
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-display-lifecycle-${{ github.run_number }}-FAILED
+          path: artifacts/a52xq-refgen-display-lifecycle-scopes
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload candidate
         uses: actions/upload-artifact@v4
         with:
           name: a52xq-refgen-display-lifecycle-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
           path: artifacts/a52xq-refgen-display-lifecycle-scopes
           if-no-files-found: error
           retention-days: 30
-
-      - name: Require audited candidate
-        run: |
-          set -Eeuo pipefail
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          audit = json.loads(Path(
-              'artifacts/a52xq-refgen-display-lifecycle-scopes/final-audit.json'
-          ).read_text())
-          assert audit['status'] == 'a52-refgen-display-lifecycle-scopes-boot-audited'
-          assert audit['flashable_candidate'] is True
-          assert audit['hardware_validated'] is False
-          assert audit['functional_change'] == 'instrumentation-only-display-lifecycle'
-          assert audit['refgen_logic_unchanged'] is True
-          assert audit['display_control_flow_unchanged'] is True
-          assert audit['recorder_retention_policy_unchanged'] is True
-          assert audit['persistent_profile'] == 'display-lifecycle-v1'
-          assert audit['lifecycle_scope_count'] == 24
-          assert audit['boot_bytes'] == 100663296
-          assert audit['compiler_error_count'] == 0
-          assert audit['dtb_preserved'] is True
-          assert audit['ramdisk_preserved'] is True
-          assert audit['recovery_dtbo_preserved'] is True
-          PY

--- a/.github/workflows/166-a52-display-lifecycle-scopes.yml
+++ b/.github/workflows/166-a52-display-lifecycle-scopes.yml
@@ -1,0 +1,387 @@
+name: 166 - A52 display lifecycle scopes
+
+run-name: Build REFGEN candidate with display probe, bind, KMS and clock scopes
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-display-lifecycle-scopes
+    paths:
+      - .github/workflows/166-a52-display-lifecycle-scopes.yml
+      - scripts/166_apply_a52_display_lifecycle_scopes.py
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-active-display-scopes
+    paths:
+      - .github/workflows/166-a52-display-lifecycle-scopes.yml
+      - scripts/166_apply_a52_display_lifecycle_scopes.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-display-lifecycle-scopes-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  RUN32_ARTIFACT_ID: '8635093061'
+  ACTIVE_SOURCE_ARTIFACT_ID: '8654956416'
+  ACTIVE_SOURCE_ARTIFACT_SHA256: a70b7cd08c3e578415cc5289a36a4efb1ad61cfe8734c2e198b9aa8ebb763c08
+  LATEST_CAPTURE_SHA256: e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad
+
+jobs:
+  build-package:
+    name: Compile and package A52 display lifecycle candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out lifecycle branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner and validate patcher
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/166_apply_a52_display_lifecycle_scopes.py \
+            scripts/38_repack_a52_p1_boot.py
+          python3 scripts/166_apply_a52_display_lifecycle_scopes.py --self-test
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Download active-scope source and Run 32 boot container
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p active/extracted run32/extracted
+          curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ACTIVE_SOURCE_ARTIFACT_ID}/zip" \
+            --output active/artifact.zip
+          printf '%s  %s\n' "${ACTIVE_SOURCE_ARTIFACT_SHA256}" active/artifact.zip \
+            | sha256sum -c -
+          curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${RUN32_ARTIFACT_ID}/zip" \
+            --output run32/artifact.zip
+          unzip -q active/artifact.zip -d active/extracted
+          unzip -q run32/artifact.zip -d run32/extracted
+          (cd active/extracted && sha256sum -c SHA256SUMS)
+          (cd run32/extracted && sha256sum -c SHA256SUMS)
+
+          test -s active/extracted/stage/refgen-active-display-scopes-source.patch
+          test -s active/extracted/config/final.config
+          test -s active/extracted/package/boot.img
+          test -s active/extracted/tools/decode-a52-unified-secure-recorder.py
+          test "$(tr -d '\r\n' < active/extracted/compile/make-return-code.txt)" = 0
+          test -s run32/extracted/package/boot.img
+          grep -Fq 'A52_ACTIVE_DISPLAY_SCOPES_V2' \
+            active/extracted/stage/refgen-active-display-scopes-source.patch
+          grep -Fq 'A52_USR2_CRITICAL_PERSIST_V1' \
+            active/extracted/stage/refgen-active-display-scopes-source.patch
+          grep -Fq 'REFGEN probe ready initial_enabled=%d' \
+            active/extracted/stage/refgen-active-display-scopes-source.patch
+
+      - name: Restore audited active source and apply lifecycle scopes
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d gki/common/.git
+          test "$(git -C gki/common rev-parse HEAD)" = "${GKI_COMMON_SHA}"
+          git -C gki/common reset --hard "${GKI_COMMON_SHA}"
+          git -C gki/common clean -fd
+
+          git -C gki/common apply --check \
+            "$PWD/active/extracted/stage/refgen-active-display-scopes-source.patch"
+          git -C gki/common apply \
+            "$PWD/active/extracted/stage/refgen-active-display-scopes-source.patch"
+
+          OUT="$PWD/artifacts/a52xq-refgen-display-lifecycle-scopes"
+          mkdir -p "$OUT/logs" "$OUT/stage" "$OUT/config" "$OUT/compile" \
+            "$OUT/package" "$OUT/tools"
+          python3 scripts/166_apply_a52_display_lifecycle_scopes.py \
+            --gki gki/common --output "$OUT/stage" \
+            2>&1 | tee "$OUT/logs/display-lifecycle-stage.log"
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path(
+              'artifacts/a52xq-refgen-display-lifecycle-scopes/stage/'
+              'phase29-a52-display-lifecycle-scopes-report.json'
+          ).read_text())
+          assert report['status'] == 'a52-display-lifecycle-scopes-v1-staged'
+          assert report['active_tree'] == 'drivers/a52_display'
+          assert report['persistent_profile'] == 'display-lifecycle-v1'
+          assert report['target_file_count'] == 8
+          assert report['target_function_count'] == 24
+          assert report['inserted_function_count'] == 24
+          assert report['functional_change'] == 'instrumentation-only'
+          assert report['refgen_logic_unchanged'] is True
+          assert report['display_control_flow_unchanged'] is True
+          assert report['recorder_retention_policy_unchanged'] is True
+          assert report['evidence_basis']['capture_sha256'] == (
+              'e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad'
+          )
+          PY
+
+          while IFS= read -r marker; do
+            test -n "$marker"
+            grep -R -Fq "$marker" gki/common/drivers/a52_display \
+              gki/common/drivers/a52_secure/a52_ack_secure_flight_recorder.c
+          done <<'EOF'
+          profile=display-lifecycle-v1
+          A52_ACKFR_SCOPE("DISP", "a52.life.msm_drm_register")
+          A52_ACKFR_SCOPE("DISP", "a52.life.msm_pdev_probe")
+          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_dev_probe")
+          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_bind")
+          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_bridge_attach")
+          A52_ACKFR_SCOPE("DISP", "a52.life.sde_kms_hw_init")
+          A52_ACKFR_SCOPE("DISP", "a52.life.sde_kms_commit")
+          A52_ACKFR_SCOPE("DISP", "a52.life.dsi_clk_update_link_clk_state")
+          A52_ACKFR_SCOPE("DISP", "a52.life.ss_panel_init")
+          EOF
+
+          git -C gki/common diff --check
+          git -C gki/common add -N .
+          git -C gki/common diff --binary --no-ext-diff \
+            > "$OUT/stage/refgen-display-lifecycle-scopes-source.patch"
+          test -s "$OUT/stage/refgen-display-lifecycle-scopes-source.patch"
+
+      - name: Compile display lifecycle kernel
+        run: |
+          set -Eeuo pipefail
+          OUT="$PWD/artifacts/a52xq-refgen-display-lifecycle-scopes"
+          BUILD="$PWD/workspace/gki-refgen-display-lifecycle-scopes-out"
+          mkdir -p "$BUILD"
+          cp active/extracted/config/final.config "$BUILD/.config"
+
+          CLANG="$(readlink -f "$(command -v clang)")"
+          export PATH="$(dirname "$CLANG"):$PATH"
+          export CROSS_COMPILE=aarch64-linux-gnu-
+          export CLANG_TRIPLE=aarch64-linux-gnu-
+
+          make -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+            2>&1 | tee "$OUT/logs/olddefconfig.log"
+          cp "$BUILD/.config" "$OUT/config/final.config"
+          grep -Fxq 'CONFIG_REGULATOR_REFGEN=y' "$BUILD/.config"
+          grep -Fxq 'CONFIG_QCOM_WDT=y' "$BUILD/.config"
+
+          set +e
+          make -k -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+            KCFLAGS=-Wno-error=frame-larger-than Image \
+            > "$OUT/logs/compile.log" 2>&1
+          rc=$?
+          set -e
+          printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+          if [ "$rc" -ne 0 ]; then
+            grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+              "$OUT/logs/compile.log" | tail -n 300 || true
+            tail -n 400 "$OUT/logs/compile.log" || true
+            exit "$rc"
+          fi
+
+          test -s "$BUILD/arch/arm64/boot/Image"
+          cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+          gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+          gzip -t "$OUT/package/Image.gz"
+
+          while IFS= read -r object; do
+            grep -Fq "CC      ${object}" "$OUT/logs/compile.log"
+          done <<'EOF'
+          drivers/a52_display/msm/msm_drv.o
+          drivers/a52_display/msm/dsi/dsi_display.o
+          drivers/a52_display/msm/dsi/dsi_drm.o
+          drivers/a52_display/msm/dsi/dsi_panel.o
+          drivers/a52_display/msm/dsi/dsi_phy.o
+          drivers/a52_display/msm/dsi/dsi_clk_manager.o
+          drivers/a52_display/msm/sde/sde_kms.o
+          drivers/a52_display/msm/samsung/ss_dsi_panel_common.o
+          EOF
+
+          while IFS= read -r marker; do
+            test -n "$marker"
+            grep -aFq "$marker" "$OUT/compile/Image"
+          done <<'EOF'
+          policy=critical-after-capacity profile=display-lifecycle-v1
+          REFGEN probe ready initial_enabled=%d
+          HB tick=%u online=%u run=%lu j=%lu
+          WDT disarm before=%u after=%u
+          a52.life.msm_drm_register
+          a52.life.msm_pdev_probe
+          a52.life.dsi_display_dev_probe
+          a52.life.dsi_display_bind
+          a52.life.sde_kms_hw_init
+          a52.life.sde_kms_commit
+          a52.life.dsi_clk_update_link_clk_state
+          a52.life.ss_panel_init
+          EOF
+
+          if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+              "$OUT/logs/compile.log" > "$OUT/logs/compiler-errors.txt"; then
+            cat "$OUT/logs/compiler-errors.txt"
+            exit 1
+          fi
+          grep -Fq 'OBJCOPY arch/arm64/boot/Image' "$OUT/logs/compile.log"
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-display-lifecycle-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-refgen-display-lifecycle-scopes
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Repack and audit boot image
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-refgen-display-lifecycle-scopes
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source run32/extracted/package/boot.img \
+            --kernel "$OUT/package/Image.gz" \
+            --output "$OUT/package/boot.img" \
+            --report "$OUT/package/repack-report.json"
+          test -s "$OUT/package/boot.img"
+          cp active/extracted/tools/decode-a52-unified-secure-recorder.py \
+            "$OUT/tools/decode-a52-unified-secure-recorder.py"
+
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import re
+          from pathlib import Path
+
+          root = Path('artifacts/a52xq-refgen-display-lifecycle-scopes')
+          scopes = json.loads((
+              root / 'stage/phase29-a52-display-lifecycle-scopes-report.json'
+          ).read_text())
+          repack = json.loads((root / 'package/repack-report.json').read_text())
+          compile_log = (root / 'logs/compile.log').read_text(errors='replace')
+          errors = re.findall(
+              r'^[^:\s][^:]*:\d+:\d+: (?:fatal error|error): ',
+              compile_log,
+              re.M,
+          )
+          image = root / 'compile/Image'
+          image_gz = root / 'package/Image.gz'
+          boot = root / 'package/boot.img'
+          final = {
+              'status': 'a52-refgen-display-lifecycle-scopes-boot-audited',
+              'flashable_candidate': True,
+              'hardware_validated': False,
+              'functional_change': 'instrumentation-only-display-lifecycle',
+              'refgen_logic_unchanged': True,
+              'display_control_flow_unchanged': True,
+              'recorder_retention_policy_unchanged': True,
+              'persistent_profile': scopes['persistent_profile'],
+              'source_active_artifact_id': 8654956416,
+              'source_active_artifact_sha256':
+                  'a70b7cd08c3e578415cc5289a36a4efb1ad61cfe8734c2e198b9aa8ebb763c08',
+              'latest_capture_sha256':
+                  'e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad',
+              'lifecycle_scope_count': scopes['target_function_count'],
+              'lifecycle_scope_tree': scopes['active_tree'],
+              'payload_capture': False,
+              'compiler_error_count': len(errors),
+              'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+              'image_gz_sha256': hashlib.sha256(image_gz.read_bytes()).hexdigest(),
+              'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+              'boot_bytes': boot.stat().st_size,
+              'dtb_preserved': repack['invariants']['dtb_preserved'],
+              'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+              'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+          }
+          if errors:
+              raise SystemExit(f'compiler errors survived audit: {len(errors)}')
+          if final['boot_bytes'] != 100663296:
+              raise SystemExit(f"unexpected boot size: {final['boot_bytes']}")
+          if not all((
+              final['dtb_preserved'],
+              final['ramdisk_preserved'],
+              final['recovery_dtbo_preserved'],
+          )):
+              raise SystemExit('boot container invariant failed')
+          (root / 'final-audit.json').write_text(
+              json.dumps(final, indent=2, sort_keys=True) + '\n'
+          )
+          PY
+
+          cat > "$OUT/README-FIRST.txt" <<'EOF'
+          A52 REFGEN DISPLAY LIFECYCLE-SCOPE CANDIDATE
+
+          The latest black-screen capture preserved REFGEN registration and ready state,
+          plus 184 heartbeat records through approximately 95.6 seconds. None of the 20
+          prepare, enable, panel or kickoff scopes was recovered.
+
+          This image adds a persistent profile=display-lifecycle-v1 identity and
+          metadata-only entry and exit scopes around the compiled display registration,
+          platform probe, component bind, DSI resource setup, bridge attach, KMS init,
+          commit lifecycle and the observed DSI link-clock update path.
+
+          REFGEN behavior, display control flow, panel command payloads, DTB, ramdisk,
+          recovery DTBO, recorder retention, heartbeat cadence and watchdog handling are
+          unchanged.
+
+          Flash only package/boot.img. If the screen remains black, wait at least 15
+          seconds, enter recovery directly and collect the untouched raw 1 MiB RAMOOPS
+          image. The recovered BOOT line must contain profile=display-lifecycle-v1.
+          EOF
+
+          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 \
+            | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          (cd "$OUT" && sha256sum -c SHA256SUMS)
+          cat "$OUT/final-audit.json"
+
+      - name: Upload display lifecycle candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-refgen-display-lifecycle-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-refgen-display-lifecycle-scopes
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Require audited candidate
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          audit = json.loads(Path(
+              'artifacts/a52xq-refgen-display-lifecycle-scopes/final-audit.json'
+          ).read_text())
+          assert audit['status'] == 'a52-refgen-display-lifecycle-scopes-boot-audited'
+          assert audit['flashable_candidate'] is True
+          assert audit['hardware_validated'] is False
+          assert audit['functional_change'] == 'instrumentation-only-display-lifecycle'
+          assert audit['refgen_logic_unchanged'] is True
+          assert audit['display_control_flow_unchanged'] is True
+          assert audit['recorder_retention_policy_unchanged'] is True
+          assert audit['persistent_profile'] == 'display-lifecycle-v1'
+          assert audit['lifecycle_scope_count'] == 24
+          assert audit['boot_bytes'] == 100663296
+          assert audit['compiler_error_count'] == 0
+          assert audit['dtb_preserved'] is True
+          assert audit['ramdisk_preserved'] is True
+          assert audit['recovery_dtbo_preserved'] is True
+          PY

--- a/scripts/166_apply_a52_display_lifecycle_scopes.py
+++ b/scripts/166_apply_a52_display_lifecycle_scopes.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+REPORT_NAME = "phase29-a52-display-lifecycle-scopes-report.json"
+RECORDER_REL = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
+PROFILE = "display-lifecycle-v1"
+CAPTURE_SHA256 = "e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad"
+
+TARGETS: dict[Path, tuple[str, ...]] = {
+    Path("drivers/a52_display/msm/msm_drv.c"): (
+        "msm_drm_register", "msm_pdev_probe", "msm_drm_bind",
+        "msm_drm_init", "_msm_drm_init_helper",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_display.c"): (
+        "dsi_display_register", "dsi_display_dev_probe", "dsi_display_init",
+        "dsi_display_bind", "dsi_display_res_init", "dsi_display_drm_bridge_init",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_drm.c"): ("dsi_bridge_attach",),
+    Path("drivers/a52_display/msm/dsi/dsi_panel.c"): (
+        "dsi_panel_get", "dsi_panel_drv_init",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_phy.c"): ("dsi_phy_enable",),
+    Path("drivers/a52_display/msm/dsi/dsi_clk_manager.c"): (
+        "dsi_clk_update_link_clk_state",
+    ),
+    Path("drivers/a52_display/msm/sde/sde_kms.c"): (
+        "sde_kms_init", "sde_kms_hw_init", "_sde_kms_hw_init_blocks",
+        "sde_kms_prepare_commit", "sde_kms_commit", "sde_kms_complete_commit",
+    ),
+    Path("drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"): (
+        "ss_panel_init", "ss_early_display_init",
+    ),
+}
+
+
+def load_scope_helper():
+    path = Path(__file__).with_name("165_apply_a52_active_display_scopes.py")
+    spec = importlib.util.spec_from_file_location("a52_scope165", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load active-scope helper: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def scope_name(function: str) -> str:
+    return f"a52.life.{function}"
+
+
+def patch_profile(path: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="strict")
+    marker = f"profile={PROFILE}"
+    if marker in text:
+        return "already-present"
+    old = "policy=critical-after-capacity commit=%08x\\n"
+    new = f"policy=critical-after-capacity {marker} commit=%08x\\n"
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"recorder profile anchor mismatch: expected 1, found {count}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+    return "inserted"
+
+
+def inject(helper, text: str, function: str) -> tuple[str, str]:
+    statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
+    if statement in text:
+        return text, "already-present"
+    openings = helper.definition_openings(text, function)
+    if len(openings) != 1:
+        raise SystemExit(
+            f"display lifecycle definition count mismatch: {function}: {len(openings)}"
+        )
+    opening = openings[0]
+    return text[:opening + 1] + "\n\t" + statement + text[opening + 1:], "inserted"
+
+
+def run(gki: Path, output: Path) -> dict[str, object]:
+    helper = load_scope_helper()
+    recorder = gki / RECORDER_REL
+    if not recorder.is_file():
+        raise SystemExit(f"recorder source missing: {recorder}")
+    profile_state = patch_profile(recorder)
+
+    results: list[dict[str, object]] = []
+    inserted = 0
+    for rel, functions in TARGETS.items():
+        path = gki / rel
+        if not path.is_file():
+            raise SystemExit(f"compiled A52 display source missing: {path}")
+        text, include_changed = helper.add_include(helper.read(path))
+        states: list[dict[str, str]] = []
+        for function in functions:
+            text, state = inject(helper, text, function)
+            inserted += int(state == "inserted")
+            states.append({"function": function, "scope": scope_name(function), "state": state})
+        helper.write(path, text)
+        final = helper.read(path)
+        if helper.INCLUDE not in final:
+            raise SystemExit(f"recorder include missing: {path}")
+        for function in functions:
+            statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
+            if final.count(statement) != 1:
+                raise SystemExit(f"scope audit failed: {path}:{function}")
+        results.append({"path": str(rel), "include_changed": include_changed, "functions": states})
+
+    total = sum(len(functions) for functions in TARGETS.values())
+    report = {
+        "status": "a52-display-lifecycle-scopes-v1-staged",
+        "hardware_validated": False,
+        "functional_change": "instrumentation-only",
+        "refgen_logic_unchanged": True,
+        "display_control_flow_unchanged": True,
+        "recorder_retention_policy_unchanged": True,
+        "persistent_profile": PROFILE,
+        "profile_state": profile_state,
+        "active_tree": "drivers/a52_display",
+        "scope_domain": "DISP",
+        "scope_prefix": "a52.life.",
+        "target_file_count": len(TARGETS),
+        "target_function_count": total,
+        "inserted_function_count": inserted,
+        "payload_capture": False,
+        "evidence_basis": {
+            "capture_sha256": CAPTURE_SHA256,
+            "raw_snapshot_bytes": 1048576,
+            "screen_result": "black",
+            "refgen_driver_register_rc": 0,
+            "refgen_probe_ready_initial_enabled": 1,
+            "heartbeat_last_tick": 184,
+            "heartbeat_last_monotonic_ns": 95590044038,
+            "recovered_active_display_scope_events": 0,
+            "candidate_identity_recovered": False,
+            "runtime_display_anchors": [
+                "msm_drm interrupt activity",
+                "dsi_ctrl interrupt activity",
+                "dsi_clk_update_link_clk_state console activity",
+            ],
+            "finding": (
+                "REFGEN is operational and the kernel remains alive, but none of the "
+                "prepare/enable/kickoff scopes is present. Instrument the earlier "
+                "registration, probe, bind, KMS, and observed link-clock path and add "
+                "a persistent build profile before changing display behavior."
+            ),
+        },
+        "files": results,
+    }
+    output.mkdir(parents=True, exist_ok=True)
+    (output / REPORT_NAME).write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return report
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="a52-display-lifecycle-") as tmp:
+        root = Path(tmp)
+        recorder = root / RECORDER_REL
+        recorder.parent.mkdir(parents=True, exist_ok=True)
+        recorder.write_text(
+            'const char *s = "policy=critical-after-capacity commit=%08x\\n";\n',
+            encoding="utf-8",
+        )
+        for rel, functions in TARGETS.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            body = ["#include <linux/kernel.h>\n\n"]
+            for index, function in enumerate(functions):
+                qualifier = "static " if index % 2 else ""
+                body.append(
+                    f"{qualifier}int {function}(void *arg);\n"
+                    f"{qualifier}int {function}(void *arg)\n"
+                    "{\n#if defined(TEST_A)\n\tif (arg) return 1;\n"
+                    "#else\n\tif (!arg) return 0;\n#endif\n\treturn arg != 0;\n}\n\n"
+                )
+            path.write_text("".join(body), encoding="utf-8")
+        first = run(root, root / "report")
+        expected = sum(len(v) for v in TARGETS.values())
+        if first["inserted_function_count"] != expected or first["profile_state"] != "inserted":
+            raise SystemExit("first-pass self-test failed")
+        second = run(root, root / "report2")
+        if second["inserted_function_count"] != 0 or second["profile_state"] != "already-present":
+            raise SystemExit("idempotence self-test failed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gki", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        print(json.dumps({"status": "self-test-passed"}, sort_keys=True))
+        return 0
+    if args.gki is None or args.output is None:
+        parser.error("--gki and --output are required unless --self-test is used")
+    print(json.dumps(run(args.gki.resolve(), args.output.resolve()), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Hardware evidence

The latest Galaxy A52 5G black-screen capture contains a complete 1 MiB RAMOOPS snapshot with SHA-256:

`e3daa915eddb43433735127c987f2c3febb9549b1fb8b42b7d67d1315acf84ad`

The mirrored recorder evidence shows:

- REFGEN driver registration returned `0`
- the REFGEN provider mapped and reached `probe ready initial_enabled=1`
- the watchdog was disarmed
- 184 heartbeat records continued through approximately 95.6 seconds
- the physical screen remained black
- none of the 20 `a52.*` prepare, enable, panel or kickoff scopes was recovered
- the normal console still contains `msm_drm`, `dsi_ctrl` and DSI link-clock activity

This moves the next diagnostic boundary earlier than panel prepare and kickoff. It does not justify another REFGEN or panel-command change.

## Missing identity in the previous capture

The previous recorder control record did not identify the exact diagnostic profile. The new source may have been flashed, but the capture alone cannot cryptographically distinguish the active-display-scope image from the preceding retention image.

This PR adds `profile=display-lifecycle-v1` to the persistent A52USR2 control record. The next capture must contain that marker before its scope evidence is accepted.

## Narrow instrumentation layer

The patch adds 24 metadata-only entry and exit scopes in the compiled `drivers/a52_display` tree around:

- DRM registration, platform probe, component bind and DRM initialization
- DSI registration, platform probe, component setup, resource setup and bind
- DSI bridge attachment and DRM bridge creation
- panel object acquisition and panel driver initialization
- DSI PHY enable
- the observed DSI link-clock update function
- SDE KMS allocation, hardware initialization, block initialization and commit lifecycle
- Samsung panel initialization and early-display initialization

The existing prepare, enable, panel and kickoff scopes remain in place.

## Unchanged behavior

This PR does not change:

- REFGEN implementation or register access
- display control flow or return values
- panel command payloads
- regulator sequencing
- device tree, ramdisk or recovery DTBO
- recorder retention policy
- heartbeat cadence or watchdog behavior

## Workflow 166 result

Workflow run `30276795602` completed successfully.

- artifact ID: `8658010549`
- artifact: `a52xq-refgen-display-lifecycle-5-NOT-HARDWARE-VALIDATED`
- artifact ZIP SHA-256: `6b432e6379ca24aefab58d7aab35b349496b3903d999f5ef7e1c47bc5a532c6e`
- audited `boot.img` SHA-256: `b88d2e16463b60a1f043d2d7a15be532efb280ae70235ad260062da18b3621f1`
- audited `boot.img` size: `100663296` bytes
- lifecycle scopes: `24`
- persistent profile: `display-lifecycle-v1`
- compiler result: success
- DTB preserved: yes
- ramdisk preserved: yes
- recovery DTBO preserved: yes

Workflow 166 reconstructed the exact successful active-display-scope source from artifact `8654956416`, verified artifact SHA-256 `a70b7cd08c3e578415cc5289a36a4efb1ad61cfe8734c2e198b9aa8ebb763c08`, applied only the lifecycle/profile patch, compiled the affected display tree, verified the profile and representative scope strings in the final `Image`, repacked against the checksum-verified Run 32 boot container and audited all boot-container invariants.

The output remains not hardware validated until the next phone capture identifies the last completed or unmatched lifecycle scope.