### PR TITLE
Trace the display lifecycle after QSEECOM succeeds

### DIFF
--- a/.github/workflows/174-a52-heap19-display-lifecycle.yml
+++ b/.github/workflows/174-a52-heap19-display-lifecycle.yml
@@ -1,0 +1,273 @@
+name: 174 - A52 heap-19 display lifecycle
+
+run-name: Build proven heap-19 QSEECOM path with early display lifecycle scopes
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-heap19-bufops-display-lifecycle
+    paths:
+      - .github/workflows/174-a52-heap19-display-lifecycle.yml
+      - scripts/174_apply_a52_combined_display_lifecycle.py
+      - scripts/165_apply_a52_active_display_scopes.py
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-qseecom-ta-heap19-kmap
+    paths:
+      - .github/workflows/174-a52-heap19-display-lifecycle.yml
+      - scripts/174_apply_a52_combined_display_lifecycle.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-heap19-display-lifecycle-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  PARITY_ARTIFACT_ID: '8665929748'
+  PARITY_ARTIFACT_SHA256: 432048228a8d2df7c83cf63f0d990f8c5a79504ff47321c355fcbac83c062f1a
+  CAPTURE_SHA256: f5897492c6fbb5f42324bc997e4fb9ed4bf05e64df035996b85141d5d90d2050
+  PROFILE: heap19-bufops-display-lifecycle-v1
+
+jobs:
+  build-package:
+    name: Compile and package combined lifecycle candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare runner and self-test patcher
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/165_apply_a52_active_display_scopes.py \
+            scripts/174_apply_a52_combined_display_lifecycle.py \
+            scripts/38_repack_a52_p1_boot.py
+          python3 scripts/174_apply_a52_combined_display_lifecycle.py --self-test
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Download and verify proven heap-19 parity artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          mkdir -p parity/extracted
+          curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${PARITY_ARTIFACT_ID}/zip" \
+            --output parity/artifact.zip
+          printf '%s  %s\n' "${PARITY_ARTIFACT_SHA256}" parity/artifact.zip | sha256sum -c -
+          unzip -q parity/artifact.zip -d parity/extracted
+          (cd parity/extracted && sha256sum -c SHA256SUMS)
+          test -s parity/extracted/stage/heap19-exact-dmabuf-parity-source.patch
+          test -s parity/extracted/config/final.config
+          test -s parity/extracted/package/boot.img
+          test -s parity/extracted/tools/decode-a52-unified-secure-recorder.py
+          test "$(tr -d '\r\n' < parity/extracted/compile/make-return-code.txt)" = 0
+          grep -Fq '"persistent_profile": "heap19-bufops-v1"' parity/extracted/final-audit.json
+          grep -Fq '"default_ack_mapping_preserved": true' parity/extracted/final-audit.json
+
+      - name: Reconstruct proven source and add lifecycle scopes
+        run: |
+          set -Eeuo pipefail
+          test -d gki/common/.git
+          test "$(git -C gki/common rev-parse HEAD)" = "${GKI_COMMON_SHA}"
+          git -C gki/common reset --hard "${GKI_COMMON_SHA}"
+          git -C gki/common clean -fd
+
+          SOURCE_PATCH="$PWD/parity/extracted/stage/heap19-exact-dmabuf-parity-source.patch"
+          git -C gki/common apply --check "$SOURCE_PATCH"
+          git -C gki/common apply "$SOURCE_PATCH"
+
+          OUT="$PWD/artifacts/a52xq-heap19-display-lifecycle"
+          mkdir -p "$OUT"/{logs,stage,config,compile,package,tools}
+          python3 scripts/174_apply_a52_combined_display_lifecycle.py \
+            --gki gki/common --output "$OUT/stage" \
+            2>&1 | tee "$OUT/logs/display-lifecycle-stage.log"
+
+          REPORT="$OUT/stage/phase32-a52-heap19-display-lifecycle-report.json"
+          grep -Fq '"status": "a52-heap19-bufops-display-lifecycle-v1-staged"' "$REPORT"
+          grep -Fq '"persistent_profile": "heap19-bufops-display-lifecycle-v1"' "$REPORT"
+          grep -Fq '"target_function_count": 24' "$REPORT"
+          grep -Fq '"inserted_function_count": 24' "$REPORT"
+          grep -Fq '"secure_memory_changes": false' "$REPORT"
+          grep -Fq '"qseecom_load_app_region_return": 0' "$REPORT"
+
+          HEAP=gki/common/drivers/staging/android/ion/heaps/a52_qseecom_ta_heap.c
+          REC=gki/common/drivers/a52_secure/a52_ack_secure_flight_recorder.c
+          grep -Fq '.buf_ops.get_flags = a52_qseecom_ta_get_flags' "$HEAP"
+          grep -Fq 'profile=heap19-bufops-display-lifecycle-v1' "$REC"
+          ! grep -Fq 'profile=heap19-bufops-v1' "$REC"
+          grep -RFl 'A52_ACKFR_SCOPE("DISP", "a52.life.msm_drm_register")' \
+            gki/common/drivers/a52_display/msm/msm_drv.c
+          grep -RFl 'A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_bind")' \
+            gki/common/drivers/a52_display/msm/dsi/dsi_display.c
+          grep -RFl 'A52_ACKFR_SCOPE("DISP", "a52.life.sde_kms_commit")' \
+            gki/common/drivers/a52_display/msm/sde/sde_kms.c
+          grep -RFl 'A52_ACKFR_SCOPE("DISP", "a52.life.ss_panel_init")' \
+            gki/common/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c
+
+          git -C gki/common diff --check
+          git -C gki/common add -N .
+          git -C gki/common diff --binary --no-ext-diff \
+            > "$OUT/stage/heap19-display-lifecycle-source.patch"
+          test -s "$OUT/stage/heap19-display-lifecycle-source.patch"
+
+      - name: Compile combined kernel
+        run: |
+          set -Eeuo pipefail
+          OUT="$PWD/artifacts/a52xq-heap19-display-lifecycle"
+          BUILD="$PWD/workspace/gki-heap19-display-lifecycle-out"
+          mkdir -p "$BUILD"
+          cp parity/extracted/config/final.config "$BUILD/.config"
+
+          CLANG="$(readlink -f "$(command -v clang)")"
+          export PATH="$(dirname "$CLANG"):$PATH"
+          export CROSS_COMPILE=aarch64-linux-gnu-
+          export CLANG_TRIPLE=aarch64-linux-gnu-
+
+          make -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+            > "$OUT/logs/olddefconfig.log" 2>&1
+          cp "$BUILD/.config" "$OUT/config/final.config"
+
+          set +e
+          make -k -C gki/common O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+            KCFLAGS=-Wno-error=frame-larger-than Image \
+            > "$OUT/logs/compile.log" 2>&1
+          rc=$?
+          set -e
+          printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+          if [ "$rc" -ne 0 ]; then
+            grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+              "$OUT/logs/compile.log" | tail -n 300 || true
+            tail -n 500 "$OUT/logs/compile.log" || true
+            exit "$rc"
+          fi
+
+          test -s "$BUILD/arch/arm64/boot/Image"
+          cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+          gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+          gzip -t "$OUT/package/Image.gz"
+
+          for marker in \
+            'profile=heap19-bufops-display-lifecycle-v1' \
+            'ION heap19 get_flags ret=%d flags=0x%lx' \
+            'a52.dsi_bridge_pre_enable' \
+            'a52.life.msm_drm_register' \
+            'a52.life.dsi_display_bind' \
+            'a52.life.sde_kms_commit' \
+            'a52.life.ss_panel_init'; do
+            grep -aFq "$marker" "$OUT/compile/Image"
+          done
+          if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+              "$OUT/logs/compile.log" > "$OUT/logs/compiler-errors.txt"; then
+            cat "$OUT/logs/compiler-errors.txt"
+            exit 1
+          fi
+          grep -Fq 'OBJCOPY arch/arm64/boot/Image' "$OUT/logs/compile.log"
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-heap19-display-lifecycle-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-heap19-display-lifecycle
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Repack and audit combined candidate
+        run: |
+          set -Eeuo pipefail
+          OUT=artifacts/a52xq-heap19-display-lifecycle
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source parity/extracted/package/boot.img \
+            --kernel "$OUT/package/Image.gz" \
+            --output "$OUT/package/boot.img" \
+            --report "$OUT/package/repack-report.json"
+          cp parity/extracted/tools/decode-a52-unified-secure-recorder.py "$OUT/tools/"
+
+          python3 - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          root = Path('artifacts/a52xq-heap19-display-lifecycle')
+          repack = json.loads((root / 'package/repack-report.json').read_text())
+          stage = json.loads((root / 'stage/phase32-a52-heap19-display-lifecycle-report.json').read_text())
+          boot = root / 'package/boot.img'
+          image = root / 'compile/Image'
+          audit = {
+              'status': 'a52-heap19-display-lifecycle-boot-audited',
+              'flashable_candidate': True,
+              'hardware_validated': False,
+              'persistent_profile': 'heap19-bufops-display-lifecycle-v1',
+              'capture_sha256': 'f5897492c6fbb5f42324bc997e4fb9ed4bf05e64df035996b85141d5d90d2050',
+              'source_parity_artifact_id': 8665929748,
+              'secure_memory_path_preserved': True,
+              'display_control_flow_changed': False,
+              'lifecycle_scope_count': stage['target_function_count'],
+              'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+              'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+              'boot_bytes': boot.stat().st_size,
+              'dtb_preserved': repack['invariants']['dtb_preserved'],
+              'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+              'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+          }
+          assert audit['boot_bytes'] == 100663296
+          assert audit['lifecycle_scope_count'] == 24
+          assert audit['dtb_preserved']
+          assert audit['ramdisk_preserved']
+          assert audit['recovery_dtbo_preserved']
+          (root / 'final-audit.json').write_text(
+              json.dumps(audit, indent=2, sort_keys=True) + '\n'
+          )
+          PY
+
+          cat > "$OUT/README-FIRST.txt" <<'EOF'
+          A52 HEAP-19 + EARLY DISPLAY LIFECYCLE DIAGNOSTIC
+
+          The previous hardware capture proved heap 19, DMA-BUF mapping, QTEE bridge
+          handling and QSEECOM application loading now return success. This image keeps
+          that path unchanged and adds 24 metadata-only scopes around the earlier DRM,
+          DSI, KMS, panel acquisition and commit lifecycle.
+
+          Flash only package/boot.img. If the screen is black, leave the phone running
+          for at least 15 seconds, enter OrangeFox directly, and export the untouched
+          raw 1 MiB RAMOOPS image before flashing another kernel.
+
+          Accept the capture only when it contains:
+          profile=heap19-bufops-display-lifecycle-v1
+          EOF
+
+          find "$OUT" -type f ! -name SHA256SUMS -print0 \
+            | sort -z | xargs -0 sha256sum \
+            | sed "s#  $OUT/#  ./#" > "$OUT/SHA256SUMS"
+          (cd "$OUT" && sha256sum -c SHA256SUMS)
+
+      - name: Upload audited combined candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-heap19-display-lifecycle-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-heap19-display-lifecycle
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/174_apply_a52_combined_display_lifecycle.py
+++ b/scripts/174_apply_a52_combined_display_lifecycle.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+REPORT_NAME = "phase32-a52-heap19-display-lifecycle-report.json"
+RECORDER_REL = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
+OLD_PROFILE = "heap19-bufops-v1"
+PROFILE = "heap19-bufops-display-lifecycle-v1"
+CAPTURE_SHA256 = "f5897492c6fbb5f42324bc997e4fb9ed4bf05e64df035996b85141d5d90d2050"
+
+TARGETS: dict[Path, tuple[str, ...]] = {
+    Path("drivers/a52_display/msm/msm_drv.c"): (
+        "msm_drm_register", "msm_pdev_probe", "msm_drm_bind",
+        "msm_drm_init", "_msm_drm_init_helper",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_display.c"): (
+        "dsi_display_register", "dsi_display_dev_probe", "dsi_display_init",
+        "dsi_display_bind", "dsi_display_res_init", "dsi_display_drm_bridge_init",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_drm.c"): ("dsi_bridge_attach",),
+    Path("drivers/a52_display/msm/dsi/dsi_panel.c"): (
+        "dsi_panel_get", "dsi_panel_drv_init",
+    ),
+    Path("drivers/a52_display/msm/dsi/dsi_phy.c"): ("dsi_phy_enable",),
+    Path("drivers/a52_display/msm/dsi/dsi_clk_manager.c"): (
+        "dsi_clk_update_link_clk_state",
+    ),
+    Path("drivers/a52_display/msm/sde/sde_kms.c"): (
+        "sde_kms_init", "sde_kms_hw_init", "_sde_kms_hw_init_blocks",
+        "sde_kms_prepare_commit", "sde_kms_commit", "sde_kms_complete_commit",
+    ),
+    Path("drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"): (
+        "ss_panel_init", "ss_early_display_init",
+    ),
+}
+
+
+def load_scope_helper():
+    path = Path(__file__).with_name("165_apply_a52_active_display_scopes.py")
+    spec = importlib.util.spec_from_file_location("a52_scope165", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load active-scope helper: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def scope_name(function: str) -> str:
+    return f"a52.life.{function}"
+
+
+def patch_profile(path: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="strict")
+    marker = f"profile={PROFILE}"
+    if marker in text:
+        return "already-present"
+
+    old_marker = f"profile={OLD_PROFILE}"
+    count = text.count(old_marker)
+    if count != 1:
+        raise SystemExit(
+            f"recorder profile anchor mismatch: expected one {old_marker!r}, found {count}"
+        )
+    path.write_text(text.replace(old_marker, marker, 1), encoding="utf-8")
+    return "replaced"
+
+
+def inject(helper, text: str, function: str) -> tuple[str, str]:
+    statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
+    if statement in text:
+        return text, "already-present"
+    openings = helper.definition_openings(text, function)
+    if len(openings) != 1:
+        raise SystemExit(
+            f"display lifecycle definition count mismatch: {function}: {len(openings)}"
+        )
+    opening = openings[0]
+    return text[: opening + 1] + "\n\t" + statement + text[opening + 1 :], "inserted"
+
+
+def run(gki: Path, output: Path) -> dict[str, object]:
+    helper = load_scope_helper()
+    recorder = gki / RECORDER_REL
+    if not recorder.is_file():
+        raise SystemExit(f"recorder source missing: {recorder}")
+    profile_state = patch_profile(recorder)
+
+    results: list[dict[str, object]] = []
+    inserted = 0
+    for rel, functions in TARGETS.items():
+        path = gki / rel
+        if not path.is_file():
+            raise SystemExit(f"compiled A52 display source missing: {path}")
+        text, include_changed = helper.add_include(helper.read(path))
+        states: list[dict[str, str]] = []
+        for function in functions:
+            text, state = inject(helper, text, function)
+            inserted += int(state == "inserted")
+            states.append({"function": function, "scope": scope_name(function), "state": state})
+        helper.write(path, text)
+        final = helper.read(path)
+        if helper.INCLUDE not in final:
+            raise SystemExit(f"recorder include missing: {path}")
+        for function in functions:
+            statement = f'A52_ACKFR_SCOPE("DISP", "{scope_name(function)}");'
+            if final.count(statement) != 1:
+                raise SystemExit(f"scope audit failed: {path}:{function}")
+        results.append({"path": str(rel), "include_changed": include_changed, "functions": states})
+
+    recorder_text = recorder.read_text(encoding="utf-8", errors="strict")
+    if recorder_text.count(f"profile={PROFILE}") != 1:
+        raise SystemExit("combined recorder profile audit failed")
+    if f"profile={OLD_PROFILE}" in recorder_text:
+        raise SystemExit("old recorder profile remains")
+
+    total = sum(len(functions) for functions in TARGETS.values())
+    report = {
+        "status": "a52-heap19-bufops-display-lifecycle-v1-staged",
+        "hardware_validated": False,
+        "functional_change": "instrumentation-only-on-proven-heap19-bufops-source",
+        "persistent_profile": PROFILE,
+        "previous_profile": OLD_PROFILE,
+        "profile_state": profile_state,
+        "active_tree": "drivers/a52_display",
+        "scope_domain": "DISP",
+        "scope_prefix": "a52.life.",
+        "target_file_count": len(TARGETS),
+        "target_function_count": total,
+        "inserted_function_count": inserted,
+        "payload_capture": False,
+        "secure_memory_changes": False,
+        "display_control_flow_changes": False,
+        "evidence_basis": {
+            "capture_sha256": CAPTURE_SHA256,
+            "raw_snapshot_bytes": 1048576,
+            "screen_result": "black",
+            "candidate_profile": OLD_PROFILE,
+            "heap19_get_flags_return": 0,
+            "qseecom_create_bridge_for_secbuf_return": 0,
+            "qseecom_dmabuf_map_return": 0,
+            "qseecom_vaddr_map_return": 0,
+            "qseecom_dmabuf_cache_operations_return": 0,
+            "qseecom_load_app_region_return": 0,
+            "finding": (
+                "The heap-19 and QSEECOM path now succeeds. Preserve it unchanged and "
+                "instrument the earlier DRM, DSI, KMS, panel-acquisition and commit lifecycle."
+            ),
+        },
+        "files": results,
+    }
+    output.mkdir(parents=True, exist_ok=True)
+    (output / REPORT_NAME).write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return report
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="a52-combined-lifecycle-") as tmp:
+        root = Path(tmp)
+        recorder = root / RECORDER_REL
+        recorder.parent.mkdir(parents=True, exist_ok=True)
+        recorder.write_text(
+            f'const char *s = "policy=critical-after-capacity profile={OLD_PROFILE} commit=%08x\\n";\n',
+            encoding="utf-8",
+        )
+        for rel, functions in TARGETS.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            body = ["#include <linux/kernel.h>\n\n"]
+            for index, function in enumerate(functions):
+                qualifier = "static " if index % 2 else ""
+                body.append(
+                    f"{qualifier}int {function}(void *arg);\n"
+                    f"{qualifier}int {function}(void *arg)\n"
+                    "{\n#if defined(TEST_A)\n\tif (arg) return 1;\n"
+                    "#else\n\tif (!arg) return 0;\n#endif\n\treturn arg != 0;\n}\n\n"
+                )
+            path.write_text("".join(body), encoding="utf-8")
+        first = run(root, root / "report")
+        expected = sum(len(v) for v in TARGETS.values())
+        if first["inserted_function_count"] != expected or first["profile_state"] != "replaced":
+            raise SystemExit("first-pass self-test failed")
+        second = run(root, root / "report2")
+        if second["inserted_function_count"] != 0 or second["profile_state"] != "already-present":
+            raise SystemExit("idempotence self-test failed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gki", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        print(json.dumps({"status": "self-test-passed"}, sort_keys=True))
+        return 0
+    if args.gki is None or args.output is None:
+        parser.error("--gki and --output are required unless --self-test is used")
+    print(json.dumps(run(args.gki.resolve(), args.output.resolve()), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Latest hardware result

The `heap19-bufops-v1` candidate still has a black physical screen, but the new raw 1 MiB RAMOOPS snapshot proves the former secure-memory blocker is solved:

- heap 19 registers and allocates
- `ION heap19 get_flags` returns `0`
- `qseecom_create_bridge_for_secbuf` returns `0`
- DMA-BUF map, virtual map and cache operations return `0`
- QTEE bridge allocation/free succeeds
- `qseecom_load_app_region` returns `0`
- no meaningful IOMMU/SMMU fault was recovered

Raw snapshot SHA-256: `f5897492c6fbb5f42324bc997e4fb9ed4bf05e64df035996b85141d5d90d2050`.

## Narrow next diagnostic

This PR reconstructs the exact successful PR #74 source artifact and keeps the heap-19/QSEECOM implementation unchanged. It adds the 24 earlier metadata-only display lifecycle scopes from PR #71 around:

- DRM registration, platform probe, bind and initialization
- DSI registration, probe, resource setup, bind and DRM bridge creation
- bridge attachment, panel acquisition and panel driver initialization
- DSI PHY and link-clock state
- SDE KMS allocation, hardware initialization and commit lifecycle
- Samsung panel and early-display initialization

The persistent recorder profile becomes:

`heap19-bufops-display-lifecycle-v1`

## Unchanged

No secure-memory behavior, DMA-BUF mapping behavior, QSEECOM control flow, panel command payload, display return value, regulator sequence, DTB, ramdisk or recovery DTBO is changed.

Workflow 174 rebuilds the complete kernel from the checksum-verified PR #74 artifact, verifies both the solved heap markers and all representative lifecycle markers, repacks the exact audited boot container and uploads a separate not-hardware-validated candidate.