### PR TITLE
Test GKI 5.10 display probe with fw_devlink disabled

### DIFF
--- a/.github/workflows/178-a52-gki510-fwdevlink-off.yml
+++ b/.github/workflows/178-a52-gki510-fwdevlink-off.yml
@@ -1,0 +1,75 @@
+name: 178 - A52 GKI 5.10 fw_devlink isolation
+
+run-name: Build GKI 5.10 fw_devlink=off display isolation candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-gki510-fwdevlink-off-v1
+    paths:
+      - .github/workflows/178-a52-gki510-fwdevlink-off.yml
+      - scripts/178_ci.sh
+      - tools/patch-a52-gki510-boot.py
+      - .github/workflows/177-a52-display-init-recorder-plain.yml
+      - patches/177-a52-display-init-recorder-plain.patch
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload.b64
+      - scripts/177_patch_payload_chunks/**
+      - tools/decode-a52-display-init-trace.py
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-gki510-fwdevlink-off-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build fw_devlink isolation boot image
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out isolation branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Build, patch and audit isolation candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/178_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-gki510-fwdevlink-off-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-gki510-fwdevlink-off
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload isolation candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-gki510-fwdevlink-off-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-gki510-fwdevlink-off
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/178-a52-gki510-fwdevlink-off.yml
+++ b/.github/workflows/178-a52-gki510-fwdevlink-off.yml
@@ -19,6 +19,21 @@ on:
       - scripts/177_patch_payload_chunks/**
       - tools/decode-a52-display-init-trace.py
       - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-display-init-recorder-v1
+    paths:
+      - .github/workflows/178-a52-gki510-fwdevlink-off.yml
+      - scripts/178_ci.sh
+      - tools/patch-a52-gki510-boot.py
+      - .github/workflows/177-a52-display-init-recorder-plain.yml
+      - patches/177-a52-display-init-recorder-plain.patch
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload.b64
+      - scripts/177_patch_payload_chunks/**
+      - tools/decode-a52-display-init-trace.py
+      - scripts/38_repack_a52_p1_boot.py
 
 permissions:
   contents: read

--- a/docs/178-build-notes.md
+++ b/docs/178-build-notes.md
@@ -1,0 +1,3 @@
+# Build notes
+
+The phase 178 artifact is a single-variable comparison against the previous GKI display recorder candidate. The display port and recorder source are unchanged. Only the kernel command line and Samsung footer packaging are modified.

--- a/docs/178-data-collection.md
+++ b/docs/178-data-collection.md
@@ -1,0 +1,3 @@
+# Data collection
+
+If the display remains black, preserve the failed boot long enough to collect the raw 1 MiB RAMOOPS archive. Restore the working boot image only after the archive is copied off the device.

--- a/docs/178-expected-results.md
+++ b/docs/178-expected-results.md
@@ -1,0 +1,5 @@
+# Expected results
+
+- Display works: device-link dependency gating is confirmed as a blocker.
+- Display advances further but remains black: the first blocker is bypassed and the recorder should show the next failing stage.
+- No change: investigate a different cause using the new RAMOOPS capture.

--- a/docs/178-flash-warning.md
+++ b/docs/178-flash-warning.md
@@ -1,0 +1,3 @@
+# Flash warning
+
+Flash only the generated `package/boot.img` from the successful phase 178 artifact. Keep the working boot image available for immediate restoration and collect RAMOOPS before restoring if the display remains black.

--- a/docs/178-fwdevlink-isolation.md
+++ b/docs/178-fwdevlink-isolation.md
@@ -1,0 +1,5 @@
+# A52 GKI 5.10 fw_devlink isolation
+
+This branch keeps the existing GKI 5.10 kernel and display recorder unchanged while testing whether Linux 5.10 firmware device-link dependency gating prevents the A52 SDE and DSI display devices from probing.
+
+The generated boot image appends `fw_devlink=off` and restores the Samsung `SEANDROIDENFORCE` footer. Kernel, ramdisk, DTB, recovery DTBO and boot ID are audited as unchanged.

--- a/docs/178-handoff.md
+++ b/docs/178-handoff.md
@@ -1,0 +1,3 @@
+# Handoff
+
+After CI succeeds, use the generated `package/boot.img` for the hardware test and report whether the screen stays active, turns black later, or behaves exactly like the previous candidate.

--- a/docs/178-rationale.md
+++ b/docs/178-rationale.md
@@ -1,0 +1,3 @@
+# Rationale
+
+The previous persistent trace showed the DSI PHY binding while the SDE, DSI display, and DSI controller devices remained unbound. This phase tests whether Linux 5.10 firmware device-link supplier gating is preventing those consumers from entering their probe callbacks.

--- a/docs/178-scope.md
+++ b/docs/178-scope.md
@@ -1,0 +1,3 @@
+# Scope
+
+This test remains on GKI Linux 5.10. It does not rebuild or restore the Samsung 4.19 kernel. The working 4.19 data is used only as the hardware reference for display startup ordering.

--- a/docs/178-single-variable.md
+++ b/docs/178-single-variable.md
@@ -1,0 +1,3 @@
+# Single-variable test
+
+The generated phase 178 boot image differs from the previous candidate only by the `fw_devlink=off` command-line token and restoration of the Samsung footer. The GKI kernel and display recorder remain unchanged.

--- a/docs/178-test-procedure.md
+++ b/docs/178-test-procedure.md
@@ -1,0 +1,7 @@
+# Hardware test procedure
+
+1. Download the successful phase 178 Actions artifact.
+2. Flash only `package/boot.img` to BOOT.
+3. Observe whether the bootloader image remains visible through Android startup.
+4. If the screen becomes black, collect the same raw 1 MiB RAMOOPS archive before restoring the working boot image.
+5. Do not flash `package/boot-pre-fwdevlink-off.img`.

--- a/scripts/178_ci.sh
+++ b/scripts/178_ci.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-display-init-recorder-plain"
+OUT="$PWD/artifacts/a52xq-gki510-fwdevlink-off"
+TOOL="$PWD/tools/patch-a52-gki510-boot.py"
+
+bash scripts/177_ci_exact.sh
+
+test -s "$BASE_OUT/package/boot.img"
+test -s "$TOOL"
+python3 -m py_compile "$TOOL"
+
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+
+mv "$OUT/package/boot.img" "$OUT/package/boot-pre-fwdevlink-off.img"
+python3 "$TOOL" \
+  --input "$OUT/package/boot-pre-fwdevlink-off.img" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/fwdevlink-off-repack-report.json" \
+  --append-cmdline 'fw_devlink=off'
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+root = Path('artifacts/a52xq-gki510-fwdevlink-off')
+boot = root / 'package/boot.img'
+report = json.loads((root / 'package/fwdevlink-off-repack-report.json').read_text())
+audit_path = root / 'final-audit.json'
+audit = json.loads(audit_path.read_text())
+audit.update({
+    'status': 'a52-gki510-fwdevlink-off-display-recorder-boot-audited',
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'test_hypothesis': 'fw_devlink prevents SDE, DSI display, and DSI controller probe callbacks from entering',
+    'fw_devlink_mode': 'off',
+    'samsung_footer_restored': True,
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'post_repack_invariants': report['invariants'],
+})
+audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 black-screen isolation candidate: fw_devlink=off
+
+Mission: boot the Galaxy A52 on the Android 12 GKI 5.10 kernel.
+Current blocker: the bootloader image disappears after roughly 20 seconds and
+Android remains on a black screen.
+
+The previous persistent trace showed:
+  - the GKI 5.10 display drivers register successfully;
+  - the DSI PHY binds;
+  - qcom,sde-kms, qcom,dsi-display, and qcom,dsi-ctrl-hw-v2.4 remain unbound;
+  - their probe callbacks are not observed;
+  - panel prepare, DSI command transfer, and backlight are therefore not reached.
+
+This candidate is intentionally narrow. Compared with the previous display
+recorder image, it changes only the boot packaging metadata:
+  1. appends fw_devlink=off to the kernel command line;
+  2. restores the Samsung SEANDROIDENFORCE + four 0xff footer at the first
+     page boundary after the DTB.
+
+Kernel, ramdisk, DTB, external DTBO, recorder instrumentation, and display
+port source are preserved from the previous candidate.
+
+Flash package/boot.img to BOOT only. Do not flash
+package/boot-pre-fwdevlink-off.img.
+
+Success criterion:
+  - the display remains active through Android startup and the lock screen or
+    home screen becomes visible.
+
+If it is still black, collect the same raw 1 MiB RAMOOPS archive before
+restoring the working boot image.
+EOF
+
+rm -f "$OUT/SHA256SUMS"
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/tools/patch-a52-gki510-boot.py
+++ b/tools/patch-a52-gki510-boot.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+from pathlib import Path
+
+MAGIC = b"ANDROID!"
+HEADER_V2_MIN = 1660
+SAMSUNG_FOOTER = b"SEANDROIDENFORCE" + b"\xff" * 4
+
+
+def align(value: int, page_size: int) -> int:
+    return (value + page_size - 1) // page_size * page_size
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def c_string(data: bytes) -> str:
+    return data.split(b"\0", 1)[0].decode("ascii", errors="strict")
+
+
+def parse_boot(data: bytes) -> dict[str, object]:
+    if len(data) < HEADER_V2_MIN or data[:8] != MAGIC:
+        raise SystemExit("invalid Android boot image")
+
+    (
+        kernel_size,
+        kernel_addr,
+        ramdisk_size,
+        ramdisk_addr,
+        second_size,
+        second_addr,
+        tags_addr,
+        page_size,
+        header_version,
+        os_version,
+    ) = struct.unpack_from("<10I", data, 8)
+
+    if header_version != 2:
+        raise SystemExit(f"expected boot header v2, got {header_version}")
+    if page_size <= 0 or page_size & (page_size - 1):
+        raise SystemExit(f"invalid page size {page_size}")
+
+    recovery_dtbo_size = struct.unpack_from("<I", data, 1632)[0]
+    recovery_dtbo_offset = struct.unpack_from("<Q", data, 1636)[0]
+    header_size = struct.unpack_from("<I", data, 1644)[0]
+    dtb_size = struct.unpack_from("<I", data, 1648)[0]
+    dtb_addr = struct.unpack_from("<Q", data, 1652)[0]
+
+    kernel_offset = page_size
+    ramdisk_offset = kernel_offset + align(kernel_size, page_size)
+    second_offset = ramdisk_offset + align(ramdisk_size, page_size)
+    recovery_offset = (
+        recovery_dtbo_offset
+        if recovery_dtbo_size and recovery_dtbo_offset
+        else second_offset + align(second_size, page_size)
+    )
+    dtb_offset = (
+        align(recovery_offset + recovery_dtbo_size, page_size)
+        if recovery_dtbo_size
+        else second_offset + align(second_size, page_size)
+    )
+    component_end = dtb_offset + dtb_size
+    footer_offset = align(component_end, page_size)
+
+    if component_end > len(data):
+        raise SystemExit("boot image component extends past file end")
+    if footer_offset + len(SAMSUNG_FOOTER) > len(data):
+        raise SystemExit("Samsung footer does not fit in boot partition image")
+
+    cmdline = (c_string(data[64:576]) + c_string(data[608:1632])).strip()
+    return {
+        "kernel_size": kernel_size,
+        "kernel_addr": kernel_addr,
+        "ramdisk_size": ramdisk_size,
+        "ramdisk_addr": ramdisk_addr,
+        "second_size": second_size,
+        "second_addr": second_addr,
+        "tags_addr": tags_addr,
+        "page_size": page_size,
+        "header_version": header_version,
+        "os_version": os_version,
+        "board": c_string(data[48:64]),
+        "cmdline": cmdline,
+        "recovery_dtbo_size": recovery_dtbo_size,
+        "recovery_dtbo_offset": recovery_dtbo_offset,
+        "header_size": header_size,
+        "dtb_size": dtb_size,
+        "dtb_addr": dtb_addr,
+        "kernel_offset": kernel_offset,
+        "ramdisk_offset": ramdisk_offset,
+        "second_offset": second_offset,
+        "recovery_offset": recovery_offset,
+        "dtb_offset": dtb_offset,
+        "component_end": component_end,
+        "footer_offset": footer_offset,
+        "kernel": data[kernel_offset : kernel_offset + kernel_size],
+        "ramdisk": data[ramdisk_offset : ramdisk_offset + ramdisk_size],
+        "second": data[second_offset : second_offset + second_size],
+        "recovery_dtbo": (
+            data[recovery_offset : recovery_offset + recovery_dtbo_size]
+            if recovery_dtbo_size
+            else b""
+        ),
+        "dtb": data[dtb_offset : dtb_offset + dtb_size] if dtb_size else b"",
+        "id": data[576:608],
+    }
+
+
+def set_cmdline(header: bytearray, cmdline: str) -> None:
+    encoded = cmdline.encode("ascii")
+    if len(encoded) >= 1536:
+        raise SystemExit(f"boot cmdline is too long: {len(encoded)} bytes")
+    encoded += b"\0"
+    header[64:576] = b"\0" * 512
+    header[608:1632] = b"\0" * 1024
+    header[64 : 64 + min(len(encoded), 512)] = encoded[:512]
+    if len(encoded) > 512:
+        extra = encoded[512:]
+        header[608 : 608 + len(extra)] = extra
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Patch an audited A52 GKI 5.10 boot image for the fw_devlink isolation test"
+    )
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--append-cmdline", default="fw_devlink=off")
+    args = parser.parse_args()
+
+    original_data = args.input.read_bytes()
+    original = parse_boot(original_data)
+
+    tokens = original["cmdline"].split()
+    append_tokens = args.append_cmdline.split()
+    for token in append_tokens:
+        key = token.split("=", 1)[0]
+        tokens = [item for item in tokens if item.split("=", 1)[0] != key]
+        tokens.append(token)
+    new_cmdline = " ".join(tokens)
+
+    output = bytearray(original_data)
+    set_cmdline(output, new_cmdline)
+
+    footer_offset = int(original["footer_offset"])
+    output[footer_offset : footer_offset + len(SAMSUNG_FOOTER)] = SAMSUNG_FOOTER
+
+    rebuilt_data = bytes(output)
+    rebuilt = parse_boot(rebuilt_data)
+
+    invariants = {
+        "partition_size_preserved": len(rebuilt_data) == len(original_data),
+        "header_version_preserved": rebuilt["header_version"] == original["header_version"],
+        "page_size_preserved": rebuilt["page_size"] == original["page_size"],
+        "board_preserved": rebuilt["board"] == original["board"],
+        "kernel_preserved": sha256(rebuilt["kernel"]) == sha256(original["kernel"]),
+        "ramdisk_preserved": sha256(rebuilt["ramdisk"]) == sha256(original["ramdisk"]),
+        "second_preserved": sha256(rebuilt["second"]) == sha256(original["second"]),
+        "recovery_dtbo_preserved": sha256(rebuilt["recovery_dtbo"]) == sha256(original["recovery_dtbo"]),
+        "dtb_preserved": sha256(rebuilt["dtb"]) == sha256(original["dtb"]),
+        "boot_id_preserved": rebuilt["id"] == original["id"],
+        "fw_devlink_off_present": "fw_devlink=off" in rebuilt["cmdline"].split(),
+        "samsung_footer_present": rebuilt_data[
+            footer_offset : footer_offset + len(SAMSUNG_FOOTER)
+        ] == SAMSUNG_FOOTER,
+    }
+    failed = [name for name, passed in invariants.items() if not passed]
+    if failed:
+        raise SystemExit("post-repack audit failed: " + ", ".join(failed))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(rebuilt_data)
+
+    report = {
+        "status": "a52-gki510-fw-devlink-off-boot-audited",
+        "hardware_validated": False,
+        "flashable_candidate": True,
+        "purpose": "test whether Linux 5.10 fw_devlink supplier gating blocks the A52 display stack",
+        "input_sha256": sha256(original_data),
+        "output_sha256": sha256(rebuilt_data),
+        "output_bytes": len(rebuilt_data),
+        "original_cmdline": original["cmdline"],
+        "patched_cmdline": rebuilt["cmdline"],
+        "samsung_footer_hex": SAMSUNG_FOOTER.hex(),
+        "samsung_footer_offset": footer_offset,
+        "component_end": original["component_end"],
+        "invariants": invariants,
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Build a narrowly scoped Galaxy A52 GKI 5.10 black-screen isolation candidate.

## Changes

- preserve the existing phase-177 GKI 5.10 kernel and display recorder
- append `fw_devlink=off` to the boot command line
- restore the Samsung `SEANDROIDENFORCE` footer
- audit that the kernel, ramdisk, DTB, recovery DTBO, boot ID and partition size remain unchanged

## Hypothesis

Linux 5.10 firmware device-link supplier gating is preventing the SDE, DSI display and DSI controller probe paths from entering. The previous trace showed the DSI PHY binding while those higher display devices remained unbound.

## Hardware validation

Do not merge based on CI alone. Flash only the generated `package/boot.img`, observe the display around the previous 20-second black-screen point, and collect the raw RAMOOPS image if the display remains black.