### PR TITLE
Add phase 181 display really_probe gate trace and bypass

### DIFF
--- a/.github/workflows/181-a52-display-really-probe-bypass.yml
+++ b/.github/workflows/181-a52-display-really-probe-bypass.yml
@@ -1,0 +1,92 @@
+name: 181 - A52 GKI 5.10 display really_probe gate bypass
+
+run-name: Build GKI 5.10 display really_probe trace and supplier-gate bypass
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-display-really-probe-bypass-v1
+    paths:
+      - .github/workflows/181-a52-display-really-probe-bypass.yml
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-display-bindcore-trace-retry-v1
+    paths:
+      - .github/workflows/181-a52-display-really-probe-bypass.yml
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-display-really-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-181 display really_probe image
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-181 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Build, trace, bypass, package and audit phase 181
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/181_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-display-really-probe-bypass-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-display-really-probe-bypass
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-181 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-display-really-probe-bypass-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-display-really-probe-bypass
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/181-a52-display-really-probe-bypass.yml
+++ b/.github/workflows/181-a52-display-really-probe-bypass.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/181-a52-display-really-probe-bypass.yml
       - scripts/181_apply.py
       - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
       - scripts/180_ci.sh
       - scripts/180_apply.py
       - scripts/180_payloads/**
@@ -27,6 +28,7 @@ on:
       - .github/workflows/181-a52-display-really-probe-bypass.yml
       - scripts/181_apply.py
       - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
       - scripts/180_ci.sh
       - scripts/180_apply.py
       - scripts/180_payloads/**
@@ -71,7 +73,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
-        run: bash scripts/181_ci.sh
+        run: bash scripts/181_ci_v2.sh
 
       - name: Upload failed diagnostics
         if: ${{ failure() }}

--- a/scripts/181_apply.py
+++ b/scripts/181_apply.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    dd = args.root / "drivers/base/dd.c"
+    text = dd.read_text(encoding="utf-8")
+
+    text = replace_once(
+        text,
+        "extern void a52_persistent_diag_mark(const char *fmt, ...);\n",
+        "extern void a52_persistent_diag_mark(const char *fmt, ...);\n"
+        "extern void a52_ackfr_record(const char *fmt, ...);\n",
+        "recorder declaration",
+    )
+
+    text = replace_once(
+        text,
+        "\nvoid driver_deferred_probe_add(struct device *dev)\n",
+        "\nstatic bool a52_display_probe_device(const struct device *dev)\n"
+        "{\n"
+        "\tif (!dev || !dev->of_node)\n"
+        "\t\treturn false;\n\n"
+        "\treturn of_device_is_compatible(dev->of_node, \"qcom,sde-kms\") ||\n"
+        "\t       of_device_is_compatible(dev->of_node, \"qcom,dsi-display\") ||\n"
+        "\t       of_device_is_compatible(dev->of_node, \"qcom,dsi-ctrl-hw-v2.4\");\n"
+        "}\n\n"
+        "void driver_deferred_probe_add(struct device *dev)\n",
+        "display target helper",
+    )
+
+    text = replace_once(
+        text,
+        "static int really_probe(struct device *dev, struct device_driver *drv)\n"
+        "{\n"
+        "\tint ret = -EPROBE_DEFER;\n",
+        "static int really_probe(struct device *dev, struct device_driver *drv)\n"
+        "{\n"
+        "\tint ret = -EPROBE_DEFER;\n\n"
+        "\tif (a52_display_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"DISP RP enter dev=%s drv=%s\",\n"
+        "\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\");\n",
+        "really_probe entry",
+    )
+
+    text = replace_once(
+        text,
+        "\tif (ret == -EPROBE_DEFER)\n"
+        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n",
+        "\tif (a52_display_probe_device(dev)) {\n"
+        "\t\tconst char *reason = dev->p && dev->p->deferred_probe_reason ?\n"
+        "\t\t\tdev->p->deferred_probe_reason : \"-\";\n\n"
+        "\t\ta52_ackfr_record(\"DISP RP suppliers dev=%s rc=%d reason=%s\",\n"
+        "\t\t\tdev_name(dev), ret, reason);\n"
+        "\t}\n"
+        "\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev)) {\n"
+        "\t\tunsigned int kept = 0;\n"
+        "\t\tunsigned int dropped = 0;\n\n"
+        "\t\ta52_device_links_force_probe(dev, &kept, &dropped);\n"
+        "\t\ta52_ackfr_record(\"DISP RP bypass dev=%s kept=%u drop=%u\",\n"
+        "\t\t\tdev_name(dev), kept, dropped);\n"
+        "\t\tret = 0;\n"
+        "\t}\n"
+        "\tif (ret == -EPROBE_DEFER)\n"
+        "\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n",
+        "supplier gate",
+    )
+
+    text = replace_once(
+        text,
+        "\tret = pinctrl_bind_pins(dev);\n",
+        "\tret = pinctrl_bind_pins(dev);\n"
+        "\tif (a52_display_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"DISP RP pinctrl dev=%s rc=%d\", dev_name(dev), ret);\n",
+        "pinctrl stage",
+    )
+
+    text = replace_once(
+        text,
+        "\t\tret = dev->bus->dma_configure(dev);\n",
+        "\t\tret = dev->bus->dma_configure(dev);\n"
+        "\t\tif (a52_display_probe_device(dev))\n"
+        "\t\t\ta52_ackfr_record(\"DISP RP dma dev=%s rc=%d\", dev_name(dev), ret);\n",
+        "dma stage",
+    )
+
+    text = replace_once(
+        text,
+        "\tret = driver_sysfs_add(dev);\n",
+        "\tret = driver_sysfs_add(dev);\n"
+        "\tif (a52_display_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"DISP RP sysfs dev=%s rc=%d\", dev_name(dev), ret);\n",
+        "sysfs stage",
+    )
+
+    text = replace_once(
+        text,
+        "\t\tret = dev->pm_domain->activate(dev);\n",
+        "\t\tret = dev->pm_domain->activate(dev);\n"
+        "\t\tif (a52_display_probe_device(dev))\n"
+        "\t\t\ta52_ackfr_record(\"DISP RP pm dev=%s rc=%d\", dev_name(dev), ret);\n",
+        "pm stage",
+    )
+
+    text = replace_once(
+        text,
+        "\t\tret = dev->bus->probe(dev);\n",
+        "\t\tif (a52_display_probe_device(dev))\n"
+        "\t\t\ta52_ackfr_record(\"DISP RP busprobe enter dev=%s drv=%s\",\n"
+        "\t\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\");\n"
+        "\t\tret = dev->bus->probe(dev);\n"
+        "\t\tif (a52_display_probe_device(dev))\n"
+        "\t\t\ta52_ackfr_record(\"DISP RP busprobe exit dev=%s rc=%d\",\n"
+        "\t\t\t\tdev_name(dev), ret);\n",
+        "bus probe stage",
+    )
+
+    text = replace_once(
+        text,
+        "\t\tret = drv->probe(dev);\n",
+        "\t\tif (a52_display_probe_device(dev))\n"
+        "\t\t\ta52_ackfr_record(\"DISP RP drvprobe enter dev=%s drv=%s\",\n"
+        "\t\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\");\n"
+        "\t\tret = drv->probe(dev);\n"
+        "\t\tif (a52_display_probe_device(dev))\n"
+        "\t\t\ta52_ackfr_record(\"DISP RP drvprobe exit dev=%s rc=%d\",\n"
+        "\t\t\t\tdev_name(dev), ret);\n",
+        "driver probe stage",
+    )
+
+    text = replace_once(
+        text,
+        "done:\n\tatomic_dec(&probe_count);\n",
+        "done:\n"
+        "\tif (a52_display_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"DISP RP done dev=%s rc=%d bound=%s\",\n"
+        "\t\t\tdev_name(dev), ret, dev->driver && dev->driver->name ?\n"
+        "\t\t\tdev->driver->name : \"-\");\n"
+        "\tatomic_dec(&probe_count);\n",
+        "really_probe completion",
+    )
+
+    dd.write_text(text, encoding="utf-8")
+    print(dd)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/181_apply.py
+++ b/scripts/181_apply.py
@@ -47,10 +47,16 @@ def main() -> int:
         text,
         "static int really_probe(struct device *dev, struct device_driver *drv)\n"
         "{\n"
-        "\tint ret = -EPROBE_DEFER;\n",
+        "\tint ret = -EPROBE_DEFER;\n"
+        "\tint local_trigger_count = atomic_read(&deferred_trigger_count);\n"
+        "\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n"
+        "\t\t\t   !drv->suppress_bind_attrs;\n",
         "static int really_probe(struct device *dev, struct device_driver *drv)\n"
         "{\n"
-        "\tint ret = -EPROBE_DEFER;\n\n"
+        "\tint ret = -EPROBE_DEFER;\n"
+        "\tint local_trigger_count = atomic_read(&deferred_trigger_count);\n"
+        "\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n"
+        "\t\t\t   !drv->suppress_bind_attrs;\n\n"
         "\tif (a52_display_probe_device(dev))\n"
         "\t\ta52_ackfr_record(\"DISP RP enter dev=%s drv=%s\",\n"
         "\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\");\n",
@@ -100,10 +106,12 @@ def main() -> int:
 
     text = replace_once(
         text,
-        "\tret = driver_sysfs_add(dev);\n",
+        "\tret = driver_sysfs_add(dev);\n"
+        "\tif (a52_run40_preprobe_target(dev)) {\n",
         "\tret = driver_sysfs_add(dev);\n"
         "\tif (a52_display_probe_device(dev))\n"
-        "\t\ta52_ackfr_record(\"DISP RP sysfs dev=%s rc=%d\", dev_name(dev), ret);\n",
+        "\t\ta52_ackfr_record(\"DISP RP sysfs dev=%s rc=%d\", dev_name(dev), ret);\n"
+        "\tif (a52_run40_preprobe_target(dev)) {\n",
         "sysfs stage",
     )
 

--- a/scripts/181_ci.sh
+++ b/scripts/181_ci.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-display-bindcore-retry"
+OUT="$PWD/artifacts/a52xq-display-really-probe-bypass"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT"/logs
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct and validate the complete phase-180 baseline first. This preserves
+# the RS(32) recorder and the two independent persistent copies unchanged.
+bash scripts/180_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{logs,stage,compile,package,tools}
+
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-before-phase181.c"
+python3 scripts/181_apply.py --root "$ROOT" | tee "$OUT/logs/phase181-apply.log"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-after-phase181.c"
+cp scripts/181_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+grep -Fq 'a52_display_probe_device' "$ROOT/drivers/base/dd.c"
+grep -Fq 'DISP RP suppliers' "$ROOT/drivers/base/dd.c"
+grep -Fq 'DISP RP bypass' "$ROOT/drivers/base/dd.c"
+grep -Fq 'a52_device_links_force_probe(dev, &kept, &dropped);' "$ROOT/drivers/base/dd.c"
+grep -Fq 'DISP RP pinctrl' "$ROOT/drivers/base/dd.c"
+grep -Fq 'DISP RP dma' "$ROOT/drivers/base/dd.c"
+grep -Fq 'DISP RP busprobe enter' "$ROOT/drivers/base/dd.c"
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase181-display-really-probe-source.patch"
+test -s "$OUT/stage/phase181-display-really-probe-source.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase181-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase181-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase181-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase181-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'CC      drivers/base/dd.o' "$OUT/logs/phase181-compile.log"
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 181 display really_probe gate test
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+This candidate keeps Reed-Solomon protection and two independent recorder
+copies. It records each generic pre-probe stage for the SDE, DSI display and
+DSI controller devices. When the generic supplier check returns EPROBE_DEFER,
+it performs the display-only supplier-link preparation from inside
+really_probe(), where the helper was designed to run, then continues to
+pinctrl, DMA and the real driver probe.
+
+Panel commands, panel timing, display modes and ESD policy are unchanged.
+After testing, collect the untouched raw 1 MiB RAMOOPS ZIP.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-display-really-probe-bypass')
+base = json.loads(Path('artifacts/a52xq-display-bindcore-retry/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-display-really-probe-bypass-audited',
+    'phase': 181,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'error_correction': 'reed-solomon-32-parity-symbols',
+    'independent_copies': 2,
+    'crc32': False,
+    'driver_match_proven': True,
+    'normal_attach_result': -517,
+    'really_probe_supplier_gate_bypass': 'display-only-on-EPROBE_DEFER',
+    'preprobe_stage_capture': [
+        'supplier-check', 'pinctrl', 'dma-configure', 'driver-sysfs',
+        'pm-domain', 'bus-probe', 'driver-probe', 'completion'
+    ],
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'esd_policy_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+assert audit['dtb_preserved'] is True
+assert audit['ramdisk_preserved'] is True
+assert audit['recovery_dtbo_preserved'] is True
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/181_ci_v2.sh
+++ b/scripts/181_ci_v2.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+path = Path('scripts/181_apply.py')
+text = path.read_text(encoding='utf-8')
+old = '''        "\\tret = driver_sysfs_add(dev);\\n",
+        "\\tret = driver_sysfs_add(dev);\\n"
+        "\\tif (a52_display_probe_device(dev))\\n"
+        "\\t\\ta52_ackfr_record(\\"DISP RP sysfs dev=%s rc=%d\\", dev_name(dev), ret);\\n",
+'''
+new = '''        "\\tret = driver_sysfs_add(dev);\\n"
+        "\\tif (a52_run40_preprobe_target(dev)) {\\n",
+        "\\tret = driver_sysfs_add(dev);\\n"
+        "\\tif (a52_display_probe_device(dev))\\n"
+        "\\t\\ta52_ackfr_record(\\"DISP RP sysfs dev=%s rc=%d\\", dev_name(dev), ret);\\n"
+        "\\tif (a52_run40_preprobe_target(dev)) {\\n",
+'''
+if text.count(old) != 1:
+    raise SystemExit(f'phase181 apply-source sysfs anchor count={text.count(old)}')
+path.write_text(text.replace(old, new, 1), encoding='utf-8')
+PY
+
+exec bash scripts/181_ci.sh

--- a/scripts/181_ci_v2.sh
+++ b/scripts/181_ci_v2.sh
@@ -6,21 +6,15 @@ from pathlib import Path
 
 path = Path('scripts/181_apply.py')
 text = path.read_text(encoding='utf-8')
-old = '''        "\\tret = driver_sysfs_add(dev);\\n",
-        "\\tret = driver_sysfs_add(dev);\\n"
-        "\\tif (a52_display_probe_device(dev))\\n"
-        "\\t\\ta52_ackfr_record(\\"DISP RP sysfs dev=%s rc=%d\\", dev_name(dev), ret);\\n",
-'''
-new = '''        "\\tret = driver_sysfs_add(dev);\\n"
+expected = '''        "\\tret = driver_sysfs_add(dev);\\n"
         "\\tif (a52_run40_preprobe_target(dev)) {\\n",
         "\\tret = driver_sysfs_add(dev);\\n"
         "\\tif (a52_display_probe_device(dev))\\n"
         "\\t\\ta52_ackfr_record(\\"DISP RP sysfs dev=%s rc=%d\\", dev_name(dev), ret);\\n"
         "\\tif (a52_run40_preprobe_target(dev)) {\\n",
 '''
-if text.count(old) != 1:
-    raise SystemExit(f'phase181 apply-source sysfs anchor count={text.count(old)}')
-path.write_text(text.replace(old, new, 1), encoding='utf-8')
+if text.count(expected) != 1:
+    raise SystemExit(f'phase181 anchored sysfs block count={text.count(expected)}')
 PY
 
 exec bash scripts/181_ci.sh


### PR DESCRIPTION
## Evidence from phase 180

The Reed–Solomon recovered trace proves that the SDE, DSI display and DSI controller drivers all exist and match their device-tree nodes, but `device_attach()` returns `-EPROBE_DEFER` before the DSI controller probe entry is reached.

Normal retry results:

- controller: `-517`
- DSI display: `-517`
- SDE/DRM: `-517`

The phase-180 force helper was called before `device_attach()`. That helper transitions surviving links to `CONSUMER_PROBE`, so the following generic supplier check can reject them again. The helper must run inside `really_probe()` after the supplier check, which is how the existing targeted storage workaround uses it.

## Phase 181

- preserves Reed–Solomon protection and two independent persistent copies
- targets only `qcom,sde-kms`, `qcom,dsi-display` and `qcom,dsi-ctrl-hw-v2.4`
- records supplier check, pinctrl, DMA configuration, sysfs, PM-domain activation, bus/driver probe and completion
- when the supplier check returns `EPROBE_DEFER`, runs the existing link preparation inside `really_probe()` and continues
- leaves panel commands, modes, timings and ESD policy unchanged

## Hardware validation

Flash only the generated `package/boot.img`. After the result, collect the untouched raw 1 MiB RAMOOPS ZIP.