### PR TITLE
Add phase 182 supplier identity and DSI controller probe trace

### DIFF
--- a/.github/workflows/182-a52-dsi-ctrl-probe-trace.yml
+++ b/.github/workflows/182-a52-dsi-ctrl-probe-trace.yml
@@ -1,0 +1,98 @@
+name: 182 - A52 GKI 5.10 DSI controller probe trace
+
+run-name: Build GKI 5.10 supplier identity and DSI controller checkpoints
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-dsi-ctrl-probe-trace-v1
+    paths:
+      - .github/workflows/182-a52-dsi-ctrl-probe-trace.yml
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-display-really-probe-bypass-v1
+    paths:
+      - .github/workflows/182-a52-dsi-ctrl-probe-trace.yml
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-dsi-ctrl-probe-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-182 DSI controller trace image
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-182 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Build, trace, package and audit phase 182
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/182_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-dsi-ctrl-probe-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-dsi-ctrl-probe-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-182 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-dsi-ctrl-probe-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-dsi-ctrl-probe-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/182_apply.py
+++ b/scripts/182_apply.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_core(path: Path) -> None:
+    text = path.read_text()
+    text = one(text,
+        "void a52_device_links_force_probe(struct device *dev,\n"
+        "                                  unsigned int *kept,\n"
+        "                                  unsigned int *dropped);\n",
+        "extern void a52_ackfr_record(const char *fmt, ...);\n"
+        "void a52_device_links_force_probe(struct device *dev,\n"
+        "                                  unsigned int *kept,\n"
+        "                                  unsigned int *dropped);\n", "link declaration")
+    text = one(text,
+        "\tunsigned int local_dropped = 0;\n",
+        "\tunsigned int local_dropped = 0;\n\tunsigned int link_index = 0;\n",
+        "link index")
+    old = """\tdevice_links_write_lock();
+\tlist_for_each_entry_safe(link, ln, &dev->links.suppliers, c_node) {
+\t\tif (!(link->flags & DL_FLAG_MANAGED))
+\t\t\tcontinue;
+
+\t\tif (link->status != DL_STATE_AVAILABLE) {
+\t\t\tdevice_link_drop_managed(link);
+\t\t\tlocal_dropped++;
+\t\t\tcontinue;
+\t\t}
+
+\t\tWRITE_ONCE(link->status, DL_STATE_CONSUMER_PROBE);
+\t\tlocal_kept++;
+\t}
+"""
+    new = """\ta52_ackfr_record("DISP LINK begin c=%s", dev_name(dev));
+\tdevice_links_write_lock();
+\tlist_for_each_entry_safe(link, ln, &dev->links.suppliers, c_node) {
+\t\tconst char *sname, *sdrv, *sof, *action;
+
+\t\tif (!(link->flags & DL_FLAG_MANAGED))
+\t\t\tcontinue;
+\t\tsname = link->supplier ? dev_name(link->supplier) : "none";
+\t\tsdrv = link->supplier && link->supplier->driver &&
+\t\t\tlink->supplier->driver->name ? link->supplier->driver->name : "none";
+\t\tsof = link->supplier && link->supplier->of_node ?
+\t\t\tlink->supplier->of_node->full_name : "none";
+\t\taction = link->status == DL_STATE_AVAILABLE ? "keep" : "drop";
+\t\ta52_ackfr_record("DISP LINK n=%u s=%s st=%u fl=0x%x act=%s",
+\t\t\tlink_index, sname, (unsigned int)link->status, link->flags, action);
+\t\ta52_ackfr_record("DISP LINK n=%u of=%s drv=%s", link_index, sof, sdrv);
+\t\tlink_index++;
+
+\t\tif (link->status != DL_STATE_AVAILABLE) {
+\t\t\tdevice_link_drop_managed(link);
+\t\t\tlocal_dropped++;
+\t\t\tcontinue;
+\t\t}
+
+\t\tWRITE_ONCE(link->status, DL_STATE_CONSUMER_PROBE);
+\t\tlocal_kept++;
+\t}
+"""
+    text = one(text, old, new, "link loop")
+    text = one(text,
+        "\tdevice_links_write_unlock();\n\n\tif (kept)\n",
+        "\tdevice_links_write_unlock();\n"
+        "\ta52_ackfr_record(\"DISP LINK end c=%s kept=%u drop=%u\",\n"
+        "\t\tdev_name(dev), local_kept, local_dropped);\n\n\tif (kept)\n",
+        "link completion")
+    path.write_text(text)
+
+
+def patch_ctrl(path: Path) -> None:
+    text = path.read_text()
+    replacements = [
+        ("\tid = of_match_node(msm_dsi_of_match, pdev->dev.of_node);\n\tif (!id) {\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=match enter\");\n"
+         "\tid = of_match_node(msm_dsi_of_match, pdev->dev.of_node);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=match exit ok=%u\", id != NULL);\n\tif (!id) {\n", "match"),
+        ("\titem = devm_kzalloc(&pdev->dev, sizeof(*item), GFP_KERNEL);\n\tif (!item)\n\t\treturn -ENOMEM;\n\n"
+         "\tdsi_ctrl = devm_kzalloc(&pdev->dev, sizeof(*dsi_ctrl), GFP_KERNEL);\n\tif (!dsi_ctrl)\n\t\treturn -ENOMEM;\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=item_alloc enter\");\n"
+         "\titem = devm_kzalloc(&pdev->dev, sizeof(*item), GFP_KERNEL);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=item_alloc exit ok=%u\", item != NULL);\n\tif (!item)\n\t\treturn -ENOMEM;\n\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=ctrl_alloc enter\");\n"
+         "\tdsi_ctrl = devm_kzalloc(&pdev->dev, sizeof(*dsi_ctrl), GFP_KERNEL);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=ctrl_alloc exit ok=%u\", dsi_ctrl != NULL);\n\tif (!dsi_ctrl)\n\t\treturn -ENOMEM;\n", "allocations"),
+        ("\tspin_lock_init(&dsi_ctrl->irq_info.irq_lock);\n\n\trc = dsi_ctrl_dts_parse(dsi_ctrl, pdev->dev.of_node);\n",
+         "\tspin_lock_init(&dsi_ctrl->irq_info.irq_lock);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=state_init done ver=%u\", (unsigned int)dsi_ctrl->version);\n\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=dts enter\");\n\trc = dsi_ctrl_dts_parse(dsi_ctrl, pdev->dev.of_node);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=dts exit rc=%d\", rc);\n", "dts"),
+        ("\trc = dsi_ctrl_init_regmap(pdev, dsi_ctrl);\n\tif (rc) {\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=regmap enter\");\n\trc = dsi_ctrl_init_regmap(pdev, dsi_ctrl);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=regmap exit rc=%d\", rc);\n\tif (rc) {\n", "regmap"),
+        ("\trc = dsi_ctrl_clocks_init(pdev, dsi_ctrl);\n\tif (rc) {\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=clocks enter\");\n\trc = dsi_ctrl_clocks_init(pdev, dsi_ctrl);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=clocks exit rc=%d\", rc);\n\tif (rc) {\n", "clocks"),
+        ("\trc = dsi_ctrl_supplies_init(pdev, dsi_ctrl);\n\tif (rc) {\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=supplies enter\");\n\trc = dsi_ctrl_supplies_init(pdev, dsi_ctrl);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=supplies exit rc=%d\", rc);\n\tif (rc) {\n", "supplies"),
+        ("\trc = dsi_catalog_ctrl_setup(&dsi_ctrl->hw, dsi_ctrl->version,\n\t\tdsi_ctrl->cell_index, dsi_ctrl->phy_isolation_enabled,\n\t\tdsi_ctrl->null_insertion_enabled);\n\tif (rc) {\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=catalog enter i=%d\", dsi_ctrl->cell_index);\n"
+         "\trc = dsi_catalog_ctrl_setup(&dsi_ctrl->hw, dsi_ctrl->version,\n\t\tdsi_ctrl->cell_index, dsi_ctrl->phy_isolation_enabled,\n\t\tdsi_ctrl->null_insertion_enabled);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=catalog exit rc=%d\", rc);\n\tif (rc) {\n", "catalog"),
+        ("\trc = dsi_ctrl_axi_bus_client_init(pdev, dsi_ctrl);\n\tif (rc)\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=axi enter\");\n\trc = dsi_ctrl_axi_bus_client_init(pdev, dsi_ctrl);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=axi exit rc=%d\", rc);\n\tif (rc)\n", "axi"),
+        ("\tif (dsi_ctrl->hw.ops.map_mdp_regs)\n\t\tdsi_ctrl->hw.ops.map_mdp_regs(pdev, &dsi_ctrl->hw);\n\n\titem->ctrl = dsi_ctrl;\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=mdp enter has=%u\", dsi_ctrl->hw.ops.map_mdp_regs != NULL);\n"
+         "\tif (dsi_ctrl->hw.ops.map_mdp_regs)\n\t\tdsi_ctrl->hw.ops.map_mdp_regs(pdev, &dsi_ctrl->hw);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=mdp exit\");\n\n\titem->ctrl = dsi_ctrl;\n", "mdp"),
+        ("\tmutex_lock(&dsi_ctrl_list_lock);\n\tlist_add(&item->list, &dsi_ctrl_list);\n\tmutex_unlock(&dsi_ctrl_list_lock);\n\n\tmutex_init(&dsi_ctrl->ctrl_lock);\n",
+         "\ta52_ackfr_record(\"DISP CTRL step=list enter\");\n\tmutex_lock(&dsi_ctrl_list_lock);\n"
+         "\tlist_add(&item->list, &dsi_ctrl_list);\n\tmutex_unlock(&dsi_ctrl_list_lock);\n"
+         "\ta52_ackfr_record(\"DISP CTRL step=list exit\");\n\n\tmutex_init(&dsi_ctrl->ctrl_lock);\n", "list"),
+        ("\tdsi_ctrl->pdev = pdev;\n\tplatform_set_drvdata(pdev, dsi_ctrl);\n\tDSI_CTRL_INFO(dsi_ctrl, \"Probe successful\\n\");\n",
+         "\tdsi_ctrl->pdev = pdev;\n\ta52_ackfr_record(\"DISP CTRL step=drvdata enter\");\n"
+         "\tplatform_set_drvdata(pdev, dsi_ctrl);\n\ta52_ackfr_record(\"DISP CTRL step=drvdata exit\");\n"
+         "\tDSI_CTRL_INFO(dsi_ctrl, \"Probe successful\\n\");\n", "drvdata"),
+    ]
+    for old, new, label in replacements:
+        text = one(text, old, new, label)
+    path.write_text(text)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", type=Path, required=True)
+    root = ap.parse_args().root
+    patch_core(root / "drivers/base/core.c")
+    patch_ctrl(root / "drivers/a52_display/msm/dsi/dsi_ctrl.c")
+    print("phase182 supplier identity and DSI checkpoints applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/182_ci.sh
+++ b/scripts/182_ci.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-display-really-probe-bypass"
+OUT="$PWD/artifacts/a52xq-dsi-ctrl-probe-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT"/logs
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct and validate the complete phase-181 candidate first. Phase 182
+# changes only diagnostic logging around the existing display-only bypass.
+bash scripts/181_ci_v2.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{logs,stage,compile,package,tools}
+
+cp "$ROOT/drivers/base/core.c" "$OUT/stage/core-before-phase182.c"
+cp "$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c" "$OUT/stage/dsi-ctrl-before-phase182.c"
+python3 scripts/182_apply.py --root "$ROOT" | tee "$OUT/logs/phase182-apply.log"
+cp "$ROOT/drivers/base/core.c" "$OUT/stage/core-after-phase182.c"
+cp "$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c" "$OUT/stage/dsi-ctrl-after-phase182.c"
+cp scripts/182_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+for marker in \
+  'DISP LINK begin' \
+  'DISP LINK n=%u s=%s' \
+  'DISP LINK n=%u of=%s' \
+  'DISP LINK end' \
+  'DISP CTRL step=match enter' \
+  'DISP CTRL step=dts enter' \
+  'DISP CTRL step=regmap enter' \
+  'DISP CTRL step=clocks enter' \
+  'DISP CTRL step=supplies enter' \
+  'DISP CTRL step=catalog enter' \
+  'DISP CTRL step=axi enter' \
+  'DISP CTRL step=mdp enter' \
+  'DISP CTRL step=list enter' \
+  'DISP CTRL step=drvdata enter'; do
+  grep -Fq "$marker" "$ROOT/drivers/base/core.c" "$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+done
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase182-dsi-ctrl-probe-trace.patch"
+test -s "$OUT/stage/phase182-dsi-ctrl-probe-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase182-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase182-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase182-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase182-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'CC      drivers/base/core.o' "$OUT/logs/phase182-compile.log"
+grep -Fq 'CC      drivers/a52_display/msm/dsi/dsi_ctrl.o' "$OUT/logs/phase182-compile.log"
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 182 DSI controller probe trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+This candidate preserves the phase-181 display-only supplier-gate bypass. It
+adds diagnostic records for every managed supplier link before the bypass
+keeps or drops it, including supplier device, OF path, driver, status and
+flags. It also records entry and exit around each major operation inside
+dsi_ctrl_dev_probe(): match, allocations, DT parsing, regmap, clocks,
+voltage supplies, catalog, AXI, MDP mapping, list insertion and drvdata.
+
+No supplier decision, panel command, display timing, display mode, regulator
+value or ESD policy is changed by phase 182.
+
+After testing, collect the untouched raw 1 MiB RAMOOPS ZIP.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-dsi-ctrl-probe-trace')
+base = json.loads(Path('artifacts/a52xq-display-really-probe-bypass/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-dsi-ctrl-probe-trace-audited',
+    'phase': 182,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase181': False,
+    'phase181_supplier_bypass_preserved': True,
+    'supplier_link_identity_capture': [
+        'supplier-device', 'supplier-of-path', 'supplier-driver',
+        'link-status', 'link-flags', 'keep-or-drop'
+    ],
+    'dsi_ctrl_probe_stages': [
+        'match', 'item-allocation', 'controller-allocation', 'state-init',
+        'dts-parse', 'regmap', 'clocks', 'supplies', 'catalog', 'axi',
+        'mdp-map', 'list-add', 'drvdata'
+    ],
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'esd_policy_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+assert audit['dtb_preserved'] is True
+assert audit['ramdisk_preserved'] is True
+assert audit['recovery_dtbo_preserved'] is True
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Evidence from phase 181

The recovered device trace proves that phase 181 passes the generic supplier gate and reaches the real Qualcomm DSI controller probe:

- `device_links_check_suppliers()` returns `-EPROBE_DEFER`
- the display-only bypass keeps 2 managed links and drops 2
- pinctrl, DMA configuration and driver sysfs setup return `0`
- `drm_dsi_ctrl` enters `dsi_ctrl_dev_probe()`
- the final recovered event is the controller probe-node marker

The phone remains on the Samsung bootloader logo, with no driver-probe exit or later boot event.

## Phase 182

This phase preserves the phase-181 bypass unchanged and adds diagnostics only:

- records every managed supplier link before it is kept or dropped
- records supplier device name, OF path, bound driver, link state and flags
- records entry and exit around DSI match, allocations, DT parsing, regmap, clocks, supplies, catalog, AXI, MDP mapping, list insertion and drvdata
- retains the two-copy Reed-Solomon persistent recorder and matching decoders

## Controlled scope

Phase 182 does not change supplier decisions, panel commands, display timings, display modes, regulator values, DTB, ramdisk, recovery DTBO or ESD policy.

## Hardware validation

Flash only the generated `package/boot.img`. After reproduction, collect the untouched raw 1 MiB RAMOOPS ZIP.