### PR TITLE
Enable Lagoon dispcc and preserve DSI supplier deferral

### DIFF
--- a/.github/workflows/183-a52-dispcc-probe-trace.yml
+++ b/.github/workflows/183-a52-dispcc-probe-trace.yml
@@ -1,0 +1,102 @@
+name: 183 - A52 GKI 5.10 Lagoon dispcc probe trace
+
+run-name: Build GKI 5.10 Lagoon display clock controller candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-dispcc-probe-trace-v1
+    paths:
+      - .github/workflows/183-a52-dispcc-probe-trace.yml
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-dsi-ctrl-probe-trace-v1
+    paths:
+      - .github/workflows/183-a52-dispcc-probe-trace.yml
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-dispcc-probe-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-183 Lagoon dispcc candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-183 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Build, trace, package and audit phase 183
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/183_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-dispcc-probe-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-dispcc-probe-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-183 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-dispcc-probe-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-dispcc-probe-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/183-a52-dispcc-probe-trace.yml
+++ b/.github/workflows/183-a52-dispcc-probe-trace.yml
@@ -1,6 +1,6 @@
 name: 183 - A52 GKI 5.10 Lagoon dispcc probe trace
 
-run-name: Build GKI 5.10 Lagoon display clock controller candidate
+run-name: Build GKI 5.10 Lagoon dispcc candidate with unchanged PSTORE
 
 on:
   workflow_dispatch:

--- a/scripts/183_apply.py
+++ b/scripts/183_apply.py
@@ -62,16 +62,6 @@ def patch_dispcc(path: Path) -> None:
 
     text = one(
         text,
-        "\tvdd_cx.regulator[0] = devm_regulator_get(&pdev->dev, \"vdd_cx\");\n",
-        "\ta52_ackfr_record(\"DISPCC step=vdd_cx enter\");\n"
-        "\tvdd_cx.regulator[0] = devm_regulator_get(&pdev->dev, \"vdd_cx\");\n"
-        "\ta52_ackfr_record(\"DISPCC step=vdd_cx exit rc=%ld\",\n"
-        "\t\tIS_ERR(vdd_cx.regulator[0]) ? PTR_ERR(vdd_cx.regulator[0]) : 0L);\n",
-        "dispcc regulator",
-    )
-
-    text = one(
-        text,
         "\tregmap = qcom_cc_map(pdev, &disp_cc_lagoon_desc);\n",
         "\ta52_ackfr_record(\"DISPCC step=map enter\");\n"
         "\tregmap = qcom_cc_map(pdev, &disp_cc_lagoon_desc);\n"

--- a/scripts/183_apply.py
+++ b/scripts/183_apply.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_driver_core(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    old = "\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev)) {\n"
+    new = (
+        "\tif (ret == -EPROBE_DEFER && dev->of_node &&\n"
+        "\t    of_device_is_compatible(dev->of_node, \"qcom,dsi-ctrl-hw-v2.4\"))\n"
+        "\t\ta52_ackfr_record(\"DISP RP defer-preserved dev=%s rc=%d\",\n"
+        "\t\t\tdev_name(dev), ret);\n"
+        "\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev) &&\n"
+        "\t    !(dev->of_node && of_device_is_compatible(dev->of_node,\n"
+        "\t\t\t\t\t\t \"qcom,dsi-ctrl-hw-v2.4\"))) {\n"
+    )
+    text = one(text, old, new, "preserve DSI controller deferral")
+    path.write_text(text, encoding="utf-8")
+
+
+def add_recorder_decl(text: str) -> str:
+    declaration = "extern void a52_ackfr_record(const char *fmt, ...);\n"
+    if declaration in text:
+        return text
+    includes = list(re.finditer(r"^#include[^\n]*\n", text, flags=re.MULTILINE))
+    if not includes:
+        raise SystemExit("dispcc includes: no include block found")
+    pos = includes[-1].end()
+    return text[:pos] + "\n" + declaration + text[pos:]
+
+
+def patch_dispcc(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = add_recorder_decl(text)
+
+    text = one(
+        text,
+        "static int disp_cc_lagoon_probe(struct platform_device *pdev)\n"
+        "{\n"
+        "\tstruct regmap *regmap;\n"
+        "\tint ret;\n",
+        "static int disp_cc_lagoon_probe(struct platform_device *pdev)\n"
+        "{\n"
+        "\tstruct regmap *regmap;\n"
+        "\tint ret;\n\n"
+        "\ta52_ackfr_record(\"DISPCC probe enter dev=%s node=%s\",\n"
+        "\t\tdev_name(&pdev->dev), pdev->dev.of_node ?\n"
+        "\t\tpdev->dev.of_node->full_name : \"none\");\n",
+        "dispcc probe entry",
+    )
+
+    text = one(
+        text,
+        "\tvdd_cx.regulator[0] = devm_regulator_get(&pdev->dev, \"vdd_cx\");\n",
+        "\ta52_ackfr_record(\"DISPCC step=vdd_cx enter\");\n"
+        "\tvdd_cx.regulator[0] = devm_regulator_get(&pdev->dev, \"vdd_cx\");\n"
+        "\ta52_ackfr_record(\"DISPCC step=vdd_cx exit rc=%ld\",\n"
+        "\t\tIS_ERR(vdd_cx.regulator[0]) ? PTR_ERR(vdd_cx.regulator[0]) : 0L);\n",
+        "dispcc regulator",
+    )
+
+    text = one(
+        text,
+        "\tregmap = qcom_cc_map(pdev, &disp_cc_lagoon_desc);\n",
+        "\ta52_ackfr_record(\"DISPCC step=map enter\");\n"
+        "\tregmap = qcom_cc_map(pdev, &disp_cc_lagoon_desc);\n"
+        "\ta52_ackfr_record(\"DISPCC step=map exit rc=%ld\",\n"
+        "\t\tIS_ERR(regmap) ? PTR_ERR(regmap) : 0L);\n",
+        "dispcc map",
+    )
+
+    text = one(
+        text,
+        "\tclk_fabia_pll_configure(&disp_cc_pll0, regmap, &disp_cc_pll0_config);\n",
+        "\ta52_ackfr_record(\"DISPCC step=pll enter\");\n"
+        "\tclk_fabia_pll_configure(&disp_cc_pll0, regmap, &disp_cc_pll0_config);\n"
+        "\ta52_ackfr_record(\"DISPCC step=pll exit\");\n",
+        "dispcc pll",
+    )
+
+    text = one(
+        text,
+        "\tret = qcom_cc_really_probe(pdev, &disp_cc_lagoon_desc, regmap);\n",
+        "\ta52_ackfr_record(\"DISPCC step=register enter\");\n"
+        "\tret = qcom_cc_really_probe(pdev, &disp_cc_lagoon_desc, regmap);\n"
+        "\ta52_ackfr_record(\"DISPCC step=register exit rc=%d\", ret);\n",
+        "dispcc clock registration",
+    )
+
+    text = one(
+        text,
+        "\tdev_info(&pdev->dev, \"Registered DISP CC clocks\\n\");\n\n"
+        "\treturn ret;\n",
+        "\tdev_info(&pdev->dev, \"Registered DISP CC clocks\\n\");\n"
+        "\ta52_ackfr_record(\"DISPCC probe done rc=%d\", ret);\n\n"
+        "\treturn ret;\n",
+        "dispcc probe completion",
+    )
+
+    text = one(
+        text,
+        "static int __init disp_cc_lagoon_init(void)\n"
+        "{\n"
+        "\treturn platform_driver_register(&disp_cc_lagoon_driver);\n"
+        "}\n",
+        "static int __init disp_cc_lagoon_init(void)\n"
+        "{\n"
+        "\tint rc;\n\n"
+        "\ta52_ackfr_record(\"DISPCC init enter\");\n"
+        "\trc = platform_driver_register(&disp_cc_lagoon_driver);\n"
+        "\ta52_ackfr_record(\"DISPCC init exit rc=%d\", rc);\n"
+        "\treturn rc;\n"
+        "}\n",
+        "dispcc init",
+    )
+
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    patch_driver_core(args.root / "drivers/base/dd.c")
+    patch_dispcc(args.root / "drivers/clk/qcom/dispcc-lagoon.c")
+    print("phase183 dispcc enable/probe instrumentation applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/183_ci.sh
+++ b/scripts/183_ci.sh
@@ -30,14 +30,9 @@ git -C "$ROOT" diff --check
 # dispcc, but the final configuration did not build the Lagoon dispcc driver.
 "$ROOT/scripts/config" --file "$BUILD/.config" --enable DISP_CC_LAGOON
 
-# Enable block-backed pstore capability only. No blkdev, partition or size is
-# configured, so this cannot write to storage in this candidate.
-if grep -q '^config PSTORE_ZONE' "$ROOT/fs/pstore/Kconfig"; then
-  "$ROOT/scripts/config" --file "$BUILD/.config" --enable PSTORE_ZONE
-fi
-if grep -q '^config PSTORE_BLK' "$ROOT/fs/pstore/Kconfig"; then
-  "$ROOT/scripts/config" --file "$BUILD/.config" --enable PSTORE_BLK
-fi
+# Keep the existing RAMOOPS/pstore recorder configuration unchanged. The
+# pinned kernel does not expose PSTORE_BLK in this configuration, and phase 183
+# does not need a block-backed recorder.
 
 CLANG="$(readlink -f "$(command -v clang)")"
 export PATH="$(dirname "$CLANG"):$PATH"
@@ -49,9 +44,11 @@ make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
 cp "$BUILD/.config" "$OUT/config/final.config"
 
 grep -Fqx 'CONFIG_DISP_CC_LAGOON=y' "$BUILD/.config"
-if grep -q '^config PSTORE_BLK' "$ROOT/fs/pstore/Kconfig"; then
-  grep -Fqx 'CONFIG_PSTORE_BLK=y' "$BUILD/.config"
-fi
+grep -E '^(# )?CONFIG_PSTORE' "$OUT/config/before-phase183.config" \
+  > "$OUT/logs/pstore-before-phase183.txt" || true
+grep -E '^(# )?CONFIG_PSTORE' "$OUT/config/final.config" \
+  > "$OUT/logs/pstore-after-phase183.txt" || true
+cmp "$OUT/logs/pstore-before-phase183.txt" "$OUT/logs/pstore-after-phase183.txt"
 
 for marker in \
   'DISP RP defer-preserved' \
@@ -118,11 +115,11 @@ Phase 183:
   - records disp_cc-lagoon driver init and every major probe stage
   - preserves normal -EPROBE_DEFER handling for qcom,dsi-ctrl-hw-v2.4
   - does not drop the DSI controller's unresolved supplier links
-  - enables pstore/blk capability when present, but configures no block target
+  - leaves the existing RAMOOPS/pstore configuration unchanged
 
-No storage partition is written by this image. RAMOOPS remains the active
-persistent recorder. After testing, collect the untouched raw 1 MiB RAMOOPS
-ZIP before flashing another kernel.
+No storage backend is added or changed by this image. RAMOOPS remains the
+active persistent recorder. After testing, collect the untouched raw 1 MiB
+RAMOOPS ZIP before flashing another kernel.
 EOF
 
 python3 - <<'PY'
@@ -133,8 +130,11 @@ root = Path('artifacts/a52xq-dispcc-probe-trace')
 base = json.loads(Path('artifacts/a52xq-dsi-ctrl-probe-trace/final-audit.json').read_text())
 repack = json.loads((root / 'package/repack-report.json').read_text())
 config = (root / 'config/final.config').read_text()
+before_config = (root / 'config/before-phase183.config').read_text()
 image = root / 'compile/Image'
 boot = root / 'package/boot.img'
+pstore_before = [line for line in before_config.splitlines() if line.startswith('CONFIG_PSTORE') or line.startswith('# CONFIG_PSTORE')]
+pstore_after = [line for line in config.splitlines() if line.startswith('CONFIG_PSTORE') or line.startswith('# CONFIG_PSTORE')]
 audit = dict(base)
 audit.update({
     'status': 'a52-dispcc-probe-trace-audited',
@@ -150,7 +150,7 @@ audit.update({
         'driver-register', 'probe-entry', 'regmap',
         'pll-configure', 'clock-register', 'probe-complete'
     ],
-    'pstore_blk_capability_enabled': 'CONFIG_PSTORE_BLK=y' in config,
+    'pstore_configuration_changed': pstore_before != pstore_after,
     'pstore_block_target_configured': False,
     'storage_write_added': False,
     'panel_commands_changed': False,
@@ -165,6 +165,7 @@ audit.update({
     'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
 })
 assert audit['disp_cc_lagoon_enabled'] is True
+assert audit['pstore_configuration_changed'] is False
 assert audit['dtb_preserved'] is True
 assert audit['ramdisk_preserved'] is True
 assert audit['recovery_dtbo_preserved'] is True

--- a/scripts/183_ci.sh
+++ b/scripts/183_ci.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-dsi-ctrl-probe-trace"
+OUT="$PWD/artifacts/a52xq-dispcc-probe-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct and validate phase 182 first. Phase 183 then enables the Lagoon
+# display clock controller, instruments its registration/probe path, and stops
+# forcing the DSI controller through unresolved supplier links.
+bash scripts/182_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-before-phase183.c"
+cp "$ROOT/drivers/clk/qcom/dispcc-lagoon.c" "$OUT/stage/dispcc-lagoon-before-phase183.c"
+cp "$BUILD/.config" "$OUT/config/before-phase183.config"
+python3 scripts/183_apply.py --root "$ROOT" | tee "$OUT/logs/phase183-apply.log"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-after-phase183.c"
+cp "$ROOT/drivers/clk/qcom/dispcc-lagoon.c" "$OUT/stage/dispcc-lagoon-after-phase183.c"
+cp scripts/183_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+# The phase-182 capture proved that the DSI controller consumes clocks from
+# dispcc, but the final configuration did not build the Lagoon dispcc driver.
+"$ROOT/scripts/config" --file "$BUILD/.config" --enable SDM_DISPCC_LAGOON
+
+# Enable block-backed pstore capability only. No blkdev, partition or size is
+# configured, so this cannot write to storage in this candidate.
+if grep -q '^config PSTORE_ZONE' "$ROOT/fs/pstore/Kconfig"; then
+  "$ROOT/scripts/config" --file "$BUILD/.config" --enable PSTORE_ZONE
+fi
+if grep -q '^config PSTORE_BLK' "$ROOT/fs/pstore/Kconfig"; then
+  "$ROOT/scripts/config" --file "$BUILD/.config" --enable PSTORE_BLK
+fi
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+  > "$OUT/logs/phase183-olddefconfig.log" 2>&1
+cp "$BUILD/.config" "$OUT/config/final.config"
+
+grep -Fqx 'CONFIG_SDM_DISPCC_LAGOON=y' "$BUILD/.config"
+if grep -q '^config PSTORE_BLK' "$ROOT/fs/pstore/Kconfig"; then
+  grep -Fqx 'CONFIG_PSTORE_BLK=y' "$BUILD/.config"
+fi
+
+for marker in \
+  'DISP RP defer-preserved' \
+  'DISPCC init enter' \
+  'DISPCC probe enter' \
+  'DISPCC step=vdd_cx enter' \
+  'DISPCC step=map enter' \
+  'DISPCC step=pll enter' \
+  'DISPCC step=register enter' \
+  'DISPCC probe done'; do
+  grep -Fq "$marker" "$ROOT/drivers/base/dd.c" "$ROOT/drivers/clk/qcom/dispcc-lagoon.c"
+done
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase183-dispcc-probe-trace.patch"
+test -s "$OUT/stage/phase183-dispcc-probe-trace.patch"
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase183-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase183-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase183-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase183-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'CC      drivers/base/dd.o' "$OUT/logs/phase183-compile.log"
+grep -Fq 'CC      drivers/clk/qcom/dispcc-lagoon.o' "$OUT/logs/phase183-compile.log"
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 183 Lagoon display-clock-controller trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 182 proved that drm_dsi_ctrl stops in dsi_ctrl_clocks_init() after its
+unavailable qcom,dispcc supplier was dropped. The previous final config built
+CONFIG_SDM_GCC_LAGOON but omitted CONFIG_SDM_DISPCC_LAGOON.
+
+Phase 183:
+  - enables CONFIG_SDM_DISPCC_LAGOON=y
+  - records disp_cc-lagoon driver init and every major probe stage
+  - preserves normal -EPROBE_DEFER handling for qcom,dsi-ctrl-hw-v2.4
+  - does not drop the DSI controller's unresolved supplier links
+  - enables pstore/blk capability when present, but configures no block target
+
+No storage partition is written by this image. RAMOOPS remains the active
+persistent recorder. After testing, collect the untouched raw 1 MiB RAMOOPS
+ZIP before flashing another kernel.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-dispcc-probe-trace')
+base = json.loads(Path('artifacts/a52xq-dsi-ctrl-probe-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+config = (root / 'config/final.config').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-dispcc-probe-trace-audited',
+    'phase': 183,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase182': True,
+    'root_cause_hypothesis': 'Lagoon display clock controller omitted from final config',
+    'sdm_dispcc_lagoon_enabled': 'CONFIG_SDM_DISPCC_LAGOON=y' in config,
+    'dsi_controller_supplier_bypass_disabled': True,
+    'dsi_controller_normal_defer_preserved': True,
+    'dispcc_probe_stages': [
+        'driver-register', 'probe-entry', 'vdd-cx', 'regmap',
+        'pll-configure', 'clock-register', 'probe-complete'
+    ],
+    'pstore_blk_capability_enabled': 'CONFIG_PSTORE_BLK=y' in config,
+    'pstore_block_target_configured': False,
+    'storage_write_added': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'esd_policy_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+assert audit['sdm_dispcc_lagoon_enabled'] is True
+assert audit['dtb_preserved'] is True
+assert audit['ramdisk_preserved'] is True
+assert audit['recovery_dtbo_preserved'] is True
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/183_ci.sh
+++ b/scripts/183_ci.sh
@@ -57,7 +57,6 @@ for marker in \
   'DISP RP defer-preserved' \
   'DISPCC init enter' \
   'DISPCC probe enter' \
-  'DISPCC step=vdd_cx enter' \
   'DISPCC step=map enter' \
   'DISPCC step=pll enter' \
   'DISPCC step=register enter' \
@@ -148,7 +147,7 @@ audit.update({
     'dsi_controller_supplier_bypass_disabled': True,
     'dsi_controller_normal_defer_preserved': True,
     'dispcc_probe_stages': [
-        'driver-register', 'probe-entry', 'vdd-cx', 'regmap',
+        'driver-register', 'probe-entry', 'regmap',
         'pll-configure', 'clock-register', 'probe-complete'
     ],
     'pstore_blk_capability_enabled': 'CONFIG_PSTORE_BLK=y' in config,

--- a/scripts/183_ci.sh
+++ b/scripts/183_ci.sh
@@ -28,7 +28,7 @@ git -C "$ROOT" diff --check
 
 # The phase-182 capture proved that the DSI controller consumes clocks from
 # dispcc, but the final configuration did not build the Lagoon dispcc driver.
-"$ROOT/scripts/config" --file "$BUILD/.config" --enable SDM_DISPCC_LAGOON
+"$ROOT/scripts/config" --file "$BUILD/.config" --enable DISP_CC_LAGOON
 
 # Enable block-backed pstore capability only. No blkdev, partition or size is
 # configured, so this cannot write to storage in this candidate.
@@ -48,7 +48,7 @@ make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
   > "$OUT/logs/phase183-olddefconfig.log" 2>&1
 cp "$BUILD/.config" "$OUT/config/final.config"
 
-grep -Fqx 'CONFIG_SDM_DISPCC_LAGOON=y' "$BUILD/.config"
+grep -Fqx 'CONFIG_DISP_CC_LAGOON=y' "$BUILD/.config"
 if grep -q '^config PSTORE_BLK' "$ROOT/fs/pstore/Kconfig"; then
   grep -Fqx 'CONFIG_PSTORE_BLK=y' "$BUILD/.config"
 fi
@@ -111,10 +111,10 @@ FLASH ONLY:
 
 Phase 182 proved that drm_dsi_ctrl stops in dsi_ctrl_clocks_init() after its
 unavailable qcom,dispcc supplier was dropped. The previous final config built
-CONFIG_SDM_GCC_LAGOON but omitted CONFIG_SDM_DISPCC_LAGOON.
+CONFIG_SDM_GCC_LAGOON but omitted CONFIG_DISP_CC_LAGOON.
 
 Phase 183:
-  - enables CONFIG_SDM_DISPCC_LAGOON=y
+  - enables CONFIG_DISP_CC_LAGOON=y
   - records disp_cc-lagoon driver init and every major probe stage
   - preserves normal -EPROBE_DEFER handling for qcom,dsi-ctrl-hw-v2.4
   - does not drop the DSI controller's unresolved supplier links
@@ -143,7 +143,7 @@ audit.update({
     'flashable_candidate': True,
     'functional_change_from_phase182': True,
     'root_cause_hypothesis': 'Lagoon display clock controller omitted from final config',
-    'sdm_dispcc_lagoon_enabled': 'CONFIG_SDM_DISPCC_LAGOON=y' in config,
+    'disp_cc_lagoon_enabled': 'CONFIG_DISP_CC_LAGOON=y' in config,
     'dsi_controller_supplier_bypass_disabled': True,
     'dsi_controller_normal_defer_preserved': True,
     'dispcc_probe_stages': [
@@ -164,7 +164,7 @@ audit.update({
     'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
     'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
 })
-assert audit['sdm_dispcc_lagoon_enabled'] is True
+assert audit['disp_cc_lagoon_enabled'] is True
 assert audit['dtb_preserved'] is True
 assert audit['ramdisk_preserved'] is True
 assert audit['recovery_dtbo_preserved'] is True


### PR DESCRIPTION
## Evidence from phase 182

The recovered phase-182 trace reaches `dsi_ctrl_clocks_init()` and stops before its exit marker. Supplier identity records show that the forced display bypass dropped `qcom,dispcc@af00000`, whose device had no bound driver.

The audited phase-182 configuration contains `CONFIG_SDM_GCC_LAGOON=y` but leaves `CONFIG_DISP_CC_LAGOON` disabled, even though the DSI controller consumes clocks from the Lagoon display clock controller.

## Phase 183

This phase makes one controlled functional correction and adds narrow diagnostics:

- enables `CONFIG_DISP_CC_LAGOON=y`
- records `disp_cc-lagoon` driver registration and probe entry/exit around regmap mapping, PLL setup and clock registration
- preserves the normal `-EPROBE_DEFER` path for `qcom,dsi-ctrl-hw-v2.4`
- prevents the phase-181 helper from dropping the DSI controller's unresolved suppliers
- retains phase-182 supplier identity and DSI checkpoint recording

## Persistent recorder

Phase 183 leaves every existing PSTORE option unchanged and verifies the before/after PSTORE configuration is identical. No block-backed pstore target or storage-writing path is added. RAMOOPS remains the active persistent recorder.

## Controlled scope

No panel commands, display timing, display mode, regulator voltage, DTB, ramdisk, recovery DTBO, ESD policy or storage backend are changed.

## Hardware validation

Flash only the generated `package/boot.img`. After reproduction, collect the untouched raw 1 MiB RAMOOPS ZIP before flashing another kernel.