### PR TITLE
Bind Samsung Lagoon PDC before TLMM and display

### DIFF
--- a/.github/workflows/185-a52-pdc-lagoon-compat.yml
+++ b/.github/workflows/185-a52-pdc-lagoon-compat.yml
@@ -1,0 +1,106 @@
+name: 185 - A52 GKI 5.10 Lagoon PDC compatibility
+
+run-name: Build GKI 5.10 Lagoon PDC compatibility candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-pdc-lagoon-compat-v1
+    paths:
+      - .github/workflows/185-a52-pdc-lagoon-compat.yml
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-dispcc-probe-trace-v1
+    paths:
+      - .github/workflows/185-a52-pdc-lagoon-compat.yml
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-pdc-lagoon-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-185 Lagoon PDC candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-185 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Build, trace, package and audit phase 185
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/185_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-pdc-lagoon-compat-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-pdc-lagoon-compat
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-185 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-pdc-lagoon-compat-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-pdc-lagoon-compat
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/185_apply.py
+++ b/scripts/185_apply.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def add_recorder_decl(text: str) -> str:
+    declaration = "extern void a52_ackfr_record(const char *fmt, ...);\n"
+    if declaration in text:
+        return text
+    includes = list(re.finditer(r"^#include[^\n]*\n", text, flags=re.MULTILINE))
+    if not includes:
+        raise SystemExit("qcom-pdc includes: no include block found")
+    pos = includes[-1].end()
+    return text[:pos] + "\n" + declaration + text[pos:]
+
+
+def patch_pdc(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = add_recorder_decl(text)
+
+    text = one(
+        text,
+        "static int qcom_pdc_probe(struct platform_device *pdev)\n"
+        "{\n"
+        "\tstruct device_node *np = pdev->dev.of_node;\n"
+        "\tstruct device_node *parent = of_irq_find_parent(np);\n\n"
+        "\treturn qcom_pdc_init(np, parent);\n"
+        "}\n",
+        "static int qcom_pdc_probe(struct platform_device *pdev)\n"
+        "{\n"
+        "\tstruct device_node *np = pdev->dev.of_node;\n"
+        "\tstruct device_node *parent = of_irq_find_parent(np);\n"
+        "\tint rc;\n\n"
+        "\ta52_ackfr_record(\"PDC probe enter dev=%s node=%s parent=%s\",\n"
+        "\t\tdev_name(&pdev->dev), np ? np->full_name : \"none\",\n"
+        "\t\tparent ? parent->full_name : \"none\");\n"
+        "\trc = qcom_pdc_init(np, parent);\n"
+        "\ta52_ackfr_record(\"PDC probe exit rc=%d\", rc);\n"
+        "\tof_node_put(parent);\n"
+        "\treturn rc;\n"
+        "}\n",
+        "PDC platform probe trace",
+    )
+
+    text = one(
+        text,
+        "static const struct of_device_id qcom_pdc_match_table[] = {\n"
+        "\t{ .compatible = \"qcom,pdc\" },\n"
+        "\t{}\n"
+        "};\n",
+        "static const struct of_device_id qcom_pdc_match_table[] = {\n"
+        "\t{ .compatible = \"qcom,pdc\" },\n"
+        "\t{ .compatible = \"qcom,lagoon-pdc\" },\n"
+        "\t{}\n"
+        "};\n",
+        "Lagoon PDC compatible",
+    )
+
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    path = args.root / "drivers/irqchip/qcom-pdc.c"
+    patch_pdc(path)
+    print("phase185 Lagoon PDC compatibility and probe trace applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/185_ci.sh
+++ b/scripts/185_ci.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-dispcc-probe-trace"
+OUT="$PWD/artifacts/a52xq-pdc-lagoon-compat"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct the hardware-tested phase 183 source and build state first.
+bash scripts/183_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$ROOT/drivers/irqchip/qcom-pdc.c" "$OUT/stage/qcom-pdc-before-phase185.c"
+cp "$BUILD/.config" "$OUT/config/before-phase185.config"
+python3 scripts/185_apply.py --root "$ROOT" | tee "$OUT/logs/phase185-apply.log"
+cp "$ROOT/drivers/irqchip/qcom-pdc.c" "$OUT/stage/qcom-pdc-after-phase185.c"
+cp scripts/185_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+# Phase 185 is a source compatibility correction only. Preserve the complete
+# phase-183 configuration, including RAMOOPS and all display settings.
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase185.config" "$OUT/config/final.config"
+grep -Fqx 'CONFIG_QCOM_PDC=y' "$BUILD/.config"
+grep -Fqx 'CONFIG_PINCTRL_LAGOON=y' "$BUILD/.config"
+grep -Fqx 'CONFIG_DISP_CC_LAGOON=y' "$BUILD/.config"
+
+for marker in \
+  'qcom,lagoon-pdc' \
+  'PDC probe enter' \
+  'PDC probe exit'; do
+  grep -Fq "$marker" "$ROOT/drivers/irqchip/qcom-pdc.c"
+done
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase185-pdc-lagoon-compat.patch"
+test -s "$OUT/stage/phase185-pdc-lagoon-compat.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase185-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase185-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase185-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase185-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'CC      drivers/irqchip/qcom-pdc.o' "$OUT/logs/phase185-compile.log"
+for marker in 'qcom,lagoon-pdc' 'PDC probe enter' 'PDC probe exit'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 185 Lagoon PDC compatibility trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Evidence from the phase-183 hardware capture:
+  - Lagoon display-clock-controller probe completed successfully
+  - the DSI controller probe completed successfully
+  - dsi-display-primary deferred in generic pinctrl setup
+  - f100000.pinctrl depended on unbound b220000.interrupt-controller
+
+TouchGrass source comparison found that the preserved Samsung DTB uses
+compatible "qcom,lagoon-pdc". The generic Android 5.10 PDC platform driver only
+matched "qcom,pdc", while the working TouchGrass kernel explicitly initializes
+"qcom,lagoon-pdc".
+
+Phase 185:
+  - adds qcom,lagoon-pdc to the existing 5.10 PDC driver's match table
+  - records PDC platform probe entry and result
+  - preserves normal supplier deferral for TLMM and the display
+  - changes no panel command, timing, mode, regulator setting or DTB
+  - leaves the complete phase-183 PSTORE/RAMOOPS configuration unchanged
+
+After testing, collect the untouched raw 1 MiB RAMOOPS ZIP before flashing
+another kernel.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-pdc-lagoon-compat')
+base = json.loads(Path('artifacts/a52xq-dispcc-probe-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+config = (root / 'config/final.config').read_text()
+source = (root / 'stage/qcom-pdc-after-phase185.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-pdc-lagoon-compat-audited',
+    'phase': 185,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase183': True,
+    'root_cause_hypothesis': 'Samsung DTB qcom,lagoon-pdc compatible was unmatched by generic 5.10 PDC platform driver',
+    'touchgrass_reference_commit': '6bf351bdf18bdb228db79e66f14a7a9c0178e5d7',
+    'phase183_reference_commit': 'a609d255be282311a86b94fd285a5dcbbf3935b0',
+    'qcom_pdc_enabled': 'CONFIG_QCOM_PDC=y' in config,
+    'pinctrl_lagoon_enabled': 'CONFIG_PINCTRL_LAGOON=y' in config,
+    'disp_cc_lagoon_enabled': 'CONFIG_DISP_CC_LAGOON=y' in config,
+    'lagoon_pdc_compatible_added': '{ .compatible = "qcom,lagoon-pdc" },' in source,
+    'pdc_probe_trace_added': 'PDC probe enter' in source and 'PDC probe exit' in source,
+    'pinctrl_supplier_bypass_added': False,
+    'display_supplier_bypass_added': False,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+assert audit['qcom_pdc_enabled'] is True
+assert audit['pinctrl_lagoon_enabled'] is True
+assert audit['disp_cc_lagoon_enabled'] is True
+assert audit['lagoon_pdc_compatible_added'] is True
+assert audit['pdc_probe_trace_added'] is True
+assert audit['dtb_preserved'] is True
+assert audit['ramdisk_preserved'] is True
+assert audit['recovery_dtbo_preserved'] is True
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Evidence

The phase-183 hardware capture shows that Lagoon DISPCC and the DSI controller now complete probe, but `dsi-display-primary` defers in pinctrl setup. The TLMM node `f100000.pinctrl` depends on the unbound `b220000.interrupt-controller`.

The preserved Samsung DTB identifies that interrupt controller as `qcom,lagoon-pdc`. The working TouchGrass kernel explicitly initializes that compatible, while the generic Android 5.10 PDC platform driver matches only `qcom,pdc`.

## Phase 185

- add `qcom,lagoon-pdc` to the existing 5.10 PDC match table
- trace PDC platform probe entry and result through RAMOOPS
- preserve normal TLMM and display supplier deferral
- preserve the complete phase-183 kernel configuration and recorder

## Controlled scope

No DTB, panel command, display timing, mode, regulator, ramdisk, recovery DTBO, storage backend, or supplier bypass is changed.