### PR TITLE
[HARDWARE REGRESSION - DO NOT FLASH] Restore the A52 AMOLED PMIC power chain

### DIFF
--- a/.github/workflows/186-a52-amoled-power-chain.yml
+++ b/.github/workflows/186-a52-amoled-power-chain.yml
@@ -1,0 +1,130 @@
+name: 186 - A52 GKI 5.10 AMOLED power chain
+
+run-name: Build GKI 5.10 A52 AMOLED power-chain candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-amoled-power-chain-v1
+    paths:
+      - .github/workflows/186-a52-amoled-power-chain.yml
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-pdc-lagoon-compat-v1
+    paths:
+      - .github/workflows/186-a52-amoled-power-chain.yml
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-amoled-power-chain-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-186 AMOLED power-chain candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-186 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 186
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/186_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-amoled-power-chain-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-amoled-power-chain
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-186 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-amoled-power-chain-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-amoled-power-chain
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/186_apply.py
+++ b/scripts/186_apply.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def install_driver(root: Path, touchgrass: Path) -> None:
+    src = touchgrass / "drivers/regulator/qpnp-amoled-regulator.c"
+    dst = root / "drivers/regulator/qpnp-amoled-regulator.c"
+    if not src.is_file():
+        raise SystemExit(f"missing TouchGrass source: {src}")
+    shutil.copyfile(src, dst)
+
+    text = dst.read_text(encoding="utf-8")
+    include_anchor = "#include <linux/regulator/machine.h>\n"
+    text = one(
+        text,
+        include_anchor,
+        include_anchor + "\nextern void a52_ackfr_record(const char *fmt, ...);\n",
+        "AMOLED recorder declaration",
+    )
+    text = one(
+        text,
+        "\tnode = pdev->dev.of_node;\n"
+        "\tif (!node) {\n"
+        "\t\tpr_err(\"No nodes defined\\n\");\n"
+        "\t\treturn -ENODEV;\n"
+        "\t}\n",
+        "\tnode = pdev->dev.of_node;\n"
+        "\ta52_ackfr_record(\"AMOLED probe enter dev=%s node=%s parent=%s\",\n"
+        "\t\tdev_name(&pdev->dev), node ? node->full_name : \"none\",\n"
+        "\t\tpdev->dev.parent ? dev_name(pdev->dev.parent) : \"none\");\n"
+        "\tif (!node) {\n"
+        "\t\tpr_err(\"No nodes defined\\n\");\n"
+        "\t\ta52_ackfr_record(\"AMOLED probe exit rc=%d stage=no-node\", -ENODEV);\n"
+        "\t\treturn -ENODEV;\n"
+        "\t}\n",
+        "AMOLED probe entry",
+    )
+    text = one(
+        text,
+        "\tchip = devm_kzalloc(&pdev->dev, sizeof(*chip), GFP_KERNEL);\n"
+        "\tif (!chip)\n"
+        "\t\treturn -ENOMEM;\n",
+        "\tchip = devm_kzalloc(&pdev->dev, sizeof(*chip), GFP_KERNEL);\n"
+        "\tif (!chip) {\n"
+        "\t\ta52_ackfr_record(\"AMOLED probe exit rc=%d stage=alloc\", -ENOMEM);\n"
+        "\t\treturn -ENOMEM;\n"
+        "\t}\n",
+        "AMOLED allocation trace",
+    )
+    text = one(
+        text,
+        "\tchip->regmap = dev_get_regmap(pdev->dev.parent, NULL);\n"
+        "\tif (!chip->regmap) {\n"
+        "\t\tdev_err(&pdev->dev, \"Failed to get the regmap handle\\n\");\n"
+        "\t\trc = -EINVAL;\n"
+        "\t\tgoto error;\n"
+        "\t}\n",
+        "\tchip->regmap = dev_get_regmap(pdev->dev.parent, NULL);\n"
+        "\tif (!chip->regmap) {\n"
+        "\t\tdev_err(&pdev->dev, \"Failed to get the regmap handle\\n\");\n"
+        "\t\trc = -EINVAL;\n"
+        "\t\ta52_ackfr_record(\"AMOLED probe stage=regmap rc=%d\", rc);\n"
+        "\t\tgoto error;\n"
+        "\t}\n"
+        "\ta52_ackfr_record(\"AMOLED probe stage=regmap rc=0\");\n",
+        "AMOLED regmap trace",
+    )
+    text = one(
+        text,
+        "\trc = qpnp_amoled_parse_dt(chip);\n"
+        "\tif (rc < 0) {\n"
+        "\t\tdev_err(chip->dev, \"Failed to parse DT params rc=%d\\n\", rc);\n"
+        "\t\tgoto error;\n"
+        "\t}\n",
+        "\trc = qpnp_amoled_parse_dt(chip);\n"
+        "\ta52_ackfr_record(\"AMOLED probe stage=parse-dt rc=%d\", rc);\n"
+        "\tif (rc < 0) {\n"
+        "\t\tdev_err(chip->dev, \"Failed to parse DT params rc=%d\\n\", rc);\n"
+        "\t\tgoto error;\n"
+        "\t}\n",
+        "AMOLED parse trace",
+    )
+    text = one(
+        text,
+        "\trc = qpnp_amoled_hw_init(chip);\n"
+        "\tif (rc < 0)\n"
+        "\t\tdev_err(chip->dev, \"Failed to initialize HW rc=%d\\n\", rc);\n\n"
+        "error:\n"
+        "\treturn rc;\n",
+        "\trc = qpnp_amoled_hw_init(chip);\n"
+        "\ta52_ackfr_record(\"AMOLED probe stage=register-rails rc=%d\", rc);\n"
+        "\tif (rc < 0)\n"
+        "\t\tdev_err(chip->dev, \"Failed to initialize HW rc=%d\\n\", rc);\n\n"
+        "error:\n"
+        "\ta52_ackfr_record(\"AMOLED probe exit rc=%d\", rc);\n"
+        "\treturn rc;\n",
+        "AMOLED completion trace",
+    )
+    dst.write_text(text, encoding="utf-8")
+
+
+def patch_kconfig(root: Path) -> None:
+    path = root / "drivers/regulator/Kconfig"
+    text = path.read_text(encoding="utf-8")
+    block = """config REGULATOR_QPNP_AMOLED
+\ttristate \"Qualcomm QPNP AMOLED regulator support\"
+\tdepends on SPMI && MFD_SPMI_PMIC
+\thelp
+\t  Support the OLEDB, AB and IBB power rails used by Qualcomm
+\t  SPMI PMIC based AMOLED display panels.
+
+"""
+    anchor = "config REGULATOR_QCOM_LABIBB\n"
+    if "config REGULATOR_QPNP_AMOLED\n" not in text:
+        text = one(text, anchor, block + anchor, "AMOLED Kconfig insertion")
+    path.write_text(text, encoding="utf-8")
+
+
+def patch_makefile(root: Path) -> None:
+    path = root / "drivers/regulator/Makefile"
+    text = path.read_text(encoding="utf-8")
+    line = "obj-$(CONFIG_REGULATOR_QPNP_AMOLED) += qpnp-amoled-regulator.o\n"
+    anchor = "obj-$(CONFIG_REGULATOR_QCOM_LABIBB) += qcom-labibb-regulator.o\n"
+    if line not in text:
+        text = one(text, anchor, line + anchor, "AMOLED Makefile insertion")
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--touchgrass", type=Path, required=True)
+    args = parser.parse_args()
+
+    install_driver(args.root, args.touchgrass)
+    patch_kconfig(args.root)
+    patch_makefile(args.root)
+    print("phase186 TouchGrass AMOLED power-chain provider applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/186_ci.sh
+++ b/scripts/186_ci.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-pdc-lagoon-compat"
+OUT="$PWD/artifacts/a52xq-amoled-power-chain"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+TG="$PWD/workspace/touchgrass-a52xq"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct phase 185 first so this candidate contains the proven PDC fix.
+bash scripts/185_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+test -d "$TG/.git"
+test "$(git -C "$TG" rev-parse HEAD)" = "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7"
+test -f "$TG/drivers/regulator/qpnp-amoled-regulator.c"
+
+cp "$BUILD/.config" "$OUT/config/before-phase186.config"
+cp "$ROOT/drivers/regulator/Kconfig" "$OUT/stage/regulator-Kconfig-before-phase186"
+cp "$ROOT/drivers/regulator/Makefile" "$OUT/stage/regulator-Makefile-before-phase186"
+cp "$ROOT/drivers/mfd/qcom-spmi-pmic.c" "$OUT/stage/qcom-spmi-pmic-reference.c"
+cp "$ROOT/drivers/spmi/spmi-pmic-arb.c" "$OUT/stage/spmi-pmic-arb-reference.c"
+cp "$TG/drivers/regulator/qpnp-amoled-regulator.c" "$OUT/stage/qpnp-amoled-regulator-touchgrass.c"
+
+python3 scripts/186_apply.py --root "$ROOT" --touchgrass "$TG" | tee "$OUT/logs/phase186-apply.log"
+cp "$ROOT/drivers/regulator/qpnp-amoled-regulator.c" "$OUT/stage/qpnp-amoled-regulator-after-phase186.c"
+cp "$ROOT/drivers/regulator/Kconfig" "$OUT/stage/regulator-Kconfig-after-phase186"
+cp "$ROOT/drivers/regulator/Makefile" "$OUT/stage/regulator-Makefile-after-phase186"
+cp scripts/186_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+"$ROOT/scripts/config" --file "$BUILD/.config" \
+  --enable SPMI_MSM_PMIC_ARB \
+  --enable MFD_SPMI_PMIC \
+  --enable REGULATOR_QPNP_AMOLED
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+  > "$OUT/logs/phase186-olddefconfig.log" 2>&1
+cp "$BUILD/.config" "$OUT/config/final.config"
+
+for symbol in \
+  CONFIG_SPMI=y \
+  CONFIG_SPMI_MSM_PMIC_ARB=y \
+  CONFIG_MFD_SPMI_PMIC=y \
+  CONFIG_REGMAP_SPMI=y \
+  CONFIG_REGULATOR_QPNP_AMOLED=y \
+  CONFIG_QCOM_PDC=y \
+  CONFIG_PINCTRL_LAGOON=y \
+  CONFIG_DISP_CC_LAGOON=y; do
+  grep -Fqx "$symbol" "$BUILD/.config"
+done
+
+for marker in \
+  'qcom,qpnp-amoled-regulator' \
+  'AMOLED probe enter' \
+  'AMOLED probe stage=regmap' \
+  'AMOLED probe stage=parse-dt' \
+  'AMOLED probe stage=register-rails' \
+  'AMOLED probe exit'; do
+  grep -Fq "$marker" "$ROOT/drivers/regulator/qpnp-amoled-regulator.c"
+done
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase186-amoled-power-chain.patch"
+test -s "$OUT/stage/phase186-amoled-power-chain.patch"
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase186-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase186-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase186-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase186-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for object in \
+  'CC      drivers/spmi/spmi-pmic-arb.o' \
+  'CC      drivers/mfd/qcom-spmi-pmic.o' \
+  'CC      drivers/regulator/qpnp-amoled-regulator.o'; do
+  grep -Fq "$object" "$OUT/logs/phase186-compile.log"
+done
+for marker in \
+  'qcom,lagoon-pdc' \
+  'qcom,spmi-pmic' \
+  'qcom,qpnp-amoled-regulator' \
+  'AMOLED probe enter' \
+  'AMOLED probe exit'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 186 AMOLED power-chain candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+TouchGrass comparison found that the A52 primary DSI display consumes AB and
+IBB AMOLED bias rails supplied by compatible "qcom,qpnp-amoled-regulator".
+The phase-185 image had SPMI core support but did not build the PMIC arbiter,
+the SPMI PMIC parent, or the AMOLED regulator provider.
+
+Phase 186:
+  - preserves the phase-185 Lagoon PDC compatibility fix
+  - enables the existing 5.10 Qualcomm SPMI PMIC arbiter
+  - enables the existing 5.10 Qualcomm SPMI PMIC parent/regmap provider
+  - ports the exact TouchGrass qpnp-amoled-regulator driver
+  - registers OLEDB, AB and IBB regulator rails through the normal framework
+  - records AMOLED probe stages in the existing RAMOOPS recorder
+  - changes no DTB, panel command, timing, refresh mode or regulator voltage
+  - adds no supplier bypass
+
+This artifact is compile-audited, not hardware validated. After testing,
+collect the untouched raw 1 MiB RAMOOPS ZIP before flashing another kernel.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-amoled-power-chain')
+base = json.loads(Path('artifacts/a52xq-pdc-lagoon-compat/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+config = (root / 'config/final.config').read_text()
+source = (root / 'stage/qpnp-amoled-regulator-after-phase186.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-amoled-power-chain-audited',
+    'phase': 186,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase185': True,
+    'root_cause_hypothesis': 'A52 AMOLED AB/IBB supply provider chain was absent from phase 185',
+    'touchgrass_reference_commit': '6bf351bdf18bdb228db79e66f14a7a9c0178e5d7',
+    'phase185_reference_commit': '05d416b3cbf0676fb16540181d754a977e272527',
+    'spmi_pmic_arb_enabled': 'CONFIG_SPMI_MSM_PMIC_ARB=y' in config,
+    'mfd_spmi_pmic_enabled': 'CONFIG_MFD_SPMI_PMIC=y' in config,
+    'regmap_spmi_enabled': 'CONFIG_REGMAP_SPMI=y' in config,
+    'qpnp_amoled_enabled': 'CONFIG_REGULATOR_QPNP_AMOLED=y' in config,
+    'qpnp_amoled_compatible_present': 'qcom,qpnp-amoled-regulator' in source,
+    'amoled_probe_trace_added': all(x in source for x in (
+        'AMOLED probe enter', 'AMOLED probe stage=regmap',
+        'AMOLED probe stage=parse-dt', 'AMOLED probe stage=register-rails',
+        'AMOLED probe exit')),
+    'pdc_fix_preserved': 'qcom,lagoon-pdc' in image.read_bytes().decode('latin1'),
+    'display_supplier_bypass_added': False,
+    'pinctrl_supplier_bypass_added': False,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in ('spmi_pmic_arb_enabled', 'mfd_spmi_pmic_enabled',
+            'regmap_spmi_enabled', 'qpnp_amoled_enabled',
+            'qpnp_amoled_compatible_present', 'amoled_probe_trace_added',
+            'pdc_fix_preserved', 'dtb_preserved', 'ramdisk_preserved',
+            'recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Hardware result

**DO NOT FLASH THE PHASE 186 ARTIFACT.**

Hardware testing produced an early kernel panic roughly five seconds after boot. Restoring a previous kernel image alone did not recover the installation, and the custom ROM had to be dirty-flashed again.

The new RAMOOPS recorder evidence shows that the PDC and AMOLED provider changes themselves initialized successfully, but an older diagnostic supplier-bypass remained active:

- TLMM `f100000.pinctrl` dropped its unresolved `b220000.interrupt-controller` device link before Lagoon PDC probed
- the AMOLED provider later registered OLEDB, AB and IBB successfully
- `dsi-display-primary` still received `-EPROBE_DEFER` from pinctrl
- the diagnostic code dropped the unresolved TLMM link, forced `ret = 0`, and allowed display registration to continue unbound

This is a regression caused by the inherited forced-probe instrumentation, not a successful hardware result. The exact panic stack was not preserved in the captured dmesg record, so the precise later dereference cannot be claimed, but the invalid forced-success path is directly recorded and is being removed in the next phase.

## Original phase 186 scope

- preserve the Lagoon PDC compatible fix
- enable `CONFIG_SPMI_MSM_PMIC_ARB=y`
- enable `CONFIG_MFD_SPMI_PMIC=y`
- port and enable `CONFIG_REGULATOR_QPNP_AMOLED=y`

These provider changes compiled and their probes returned success on hardware, but the resulting artifact is unsafe because of the older display/TLMM bypass inherited from phases 177-183.

Artifact `a52xq-amoled-power-chain-2-NOT-HARDWARE-VALIDATED` is withdrawn from testing.