### PR TITLE
Restore normal TLMM and display deferred probing

### DIFF
--- a/.github/workflows/187-a52-normal-display-defer.yml
+++ b/.github/workflows/187-a52-normal-display-defer.yml
@@ -1,0 +1,134 @@
+name: 187 - A52 GKI 5.10 normal display defer
+
+run-name: Build GKI 5.10 A52 normal deferred-probe candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-restore-deferred-probe-v1
+    paths:
+      - .github/workflows/187-a52-normal-display-defer.yml
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-amoled-power-chain-v1
+    paths:
+      - .github/workflows/187-a52-normal-display-defer.yml
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-normal-display-defer-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-187 normal deferred-probe candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-187 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 187
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/187_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-normal-display-defer-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-normal-display-defer
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-187 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-normal-display-defer-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-normal-display-defer
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/187_apply.py
+++ b/scripts/187_apply.py
@@ -29,9 +29,23 @@ def patch_driver_core(path: Path) -> None:
 
     text = one(
         text,
+        "static bool a52_legacy_fw_devlink_consumer(const struct device *dev)\n"
+        "{\n"
+        "\tconst char *name;\n\n"
+        "\tif (!dev)\n"
+        "\t\treturn false;\n"
+        "\tname = dev_name(dev);\n"
         "\treturn name && (!strcmp(name, \"1d84000.ufshc\") ||\n"
-        "\t\t\t!strcmp(name, \"f100000.pinctrl\"));\n",
-        "\treturn name && !strcmp(name, \"1d84000.ufshc\");\n",
+        "\t\t\t!strcmp(name, \"f100000.pinctrl\"));\n"
+        "}\n",
+        "static bool a52_legacy_fw_devlink_consumer(const struct device *dev)\n"
+        "{\n"
+        "\tconst char *name;\n\n"
+        "\tif (!dev)\n"
+        "\t\treturn false;\n"
+        "\tname = dev_name(dev);\n"
+        "\treturn name && !strcmp(name, \"1d84000.ufshc\");\n"
+        "}\n",
         "remove TLMM from legacy supplier bypass",
     )
 

--- a/scripts/187_apply.py
+++ b/scripts/187_apply.py
@@ -51,6 +51,22 @@ def patch_driver_core(path: Path) -> None:
 
     text = one(
         text,
+        "static bool a52_run40_preprobe_target(const struct device *dev)\n"
+        "{\n"
+        "\tconst char *name = dev ? dev_name(dev) : NULL;\n\n"
+        "\treturn name && (!strcmp(name, \"1d84000.ufshc\") ||\n"
+        "\t\t\t!strcmp(name, \"f100000.pinctrl\"));\n"
+        "}\n",
+        "static bool a52_run40_preprobe_target(const struct device *dev)\n"
+        "{\n"
+        "\tconst char *name = dev ? dev_name(dev) : NULL;\n\n"
+        "\treturn name && !strcmp(name, \"1d84000.ufshc\");\n"
+        "}\n",
+        "remove TLMM from legacy preprobe tracing target",
+    )
+
+    text = one(
+        text,
         "\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev) &&\n"
         "\t    !(dev->of_node && of_device_is_compatible(dev->of_node,\n"
         "\t\t\t\t\t\t \"qcom,dsi-ctrl-hw-v2.4\"))) {\n"

--- a/scripts/187_apply.py
+++ b/scripts/187_apply.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def add_recorder_decl(text: str, label: str) -> str:
+    declaration = "extern void a52_ackfr_record(const char *fmt, ...);\n"
+    if declaration in text:
+        return text
+    includes = list(re.finditer(r"^#include[^\n]*\n", text, flags=re.MULTILINE))
+    if not includes:
+        raise SystemExit(f"{label}: no include block found")
+    pos = includes[-1].end()
+    return text[:pos] + "\n" + declaration + text[pos:]
+
+
+def patch_driver_core(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    text = one(
+        text,
+        "\treturn name && (!strcmp(name, \"1d84000.ufshc\") ||\n"
+        "\t\t\t!strcmp(name, \"f100000.pinctrl\"));\n",
+        "\treturn name && !strcmp(name, \"1d84000.ufshc\");\n",
+        "remove TLMM from legacy supplier bypass",
+    )
+
+    text = one(
+        text,
+        "\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev) &&\n"
+        "\t    !(dev->of_node && of_device_is_compatible(dev->of_node,\n"
+        "\t\t\t\t\t\t \"qcom,dsi-ctrl-hw-v2.4\"))) {\n"
+        "\t\tunsigned int kept = 0;\n"
+        "\t\tunsigned int dropped = 0;\n\n"
+        "\t\ta52_device_links_force_probe(dev, &kept, &dropped);\n"
+        "\t\ta52_ackfr_record(\"DISP RP bypass dev=%s kept=%u drop=%u\",\n"
+        "\t\t\tdev_name(dev), kept, dropped);\n"
+        "\t\tret = 0;\n"
+        "\t}\n",
+        "\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"DISP RP defer-normal dev=%s rc=%d\",\n"
+        "\t\t\tdev_name(dev), ret);\n",
+        "remove display supplier bypass",
+    )
+
+    path.write_text(text, encoding="utf-8")
+
+
+def patch_display_audit(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    text = one(
+        text,
+        "\t\tif (!pdev->dev.driver && match > 0) {\n"
+        "\t\t\tif (force_links)\n"
+        "\t\t\t\ta52_device_links_force_probe(&pdev->dev, &kept, &dropped);\n"
+        "\t\t\trc = device_attach(&pdev->dev);\n",
+        "\t\tif (!pdev->dev.driver && match > 0) {\n"
+        "\t\t\tif (force_links)\n"
+        "\t\t\t\ta52_ackfr_record(\"DISP RETRY force-disabled p=%u c=%s\",\n"
+        "\t\t\t\t\tpass, target->tag);\n"
+        "\t\t\trc = device_attach(&pdev->dev);\n",
+        "disable dormant forced-link retry",
+    )
+
+    text = one(
+        text,
+        "\taudit_all(pass);\n"
+        "\t/* First retry is normal. Second retry removes only unresolved managed links. */\n"
+        "\tif (pass == 1)\n"
+        "\t\tretry_all(pass, false);\n"
+        "\telse if (pass == 2)\n"
+        "\t\tretry_all(pass, true);\n"
+        "\taudit_all(pass + 100);\n\n"
+        "\tif (pass < 4)\n"
+        "\t\tschedule_delayed_work(&audit_work,\n"
+        "\t\t\tmsecs_to_jiffies(pass == 1 ? 2000 : pass == 2 ? 8000 : 20000));\n",
+        "\taudit_all(pass);\n"
+        "\ta52_ackfr_record(\"DISP CORE phase=187 observe-only pass=%u\", pass);\n",
+        "make display audit observe-only",
+    )
+
+    text = one(
+        text,
+        "\ta52_ackfr_record(\"DISP CORE phase=180 audit=start retry=normal,force\");\n",
+        "\ta52_ackfr_record(\"DISP CORE phase=187 audit=observe-only normal-defer\");\n",
+        "audit mode marker",
+    )
+
+    path.write_text(text, encoding="utf-8")
+
+
+def patch_lagoon_pinctrl(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = add_recorder_decl(text, "pinctrl-lagoon includes")
+
+    old = (
+        "static int lagoon_pinctrl_probe(struct platform_device *pdev)\n"
+        "{\n"
+        "\treturn msm_pinctrl_probe(pdev, &lagoon_pinctrl);\n"
+        "}\n"
+    )
+    new = (
+        "static int lagoon_pinctrl_probe(struct platform_device *pdev)\n"
+        "{\n"
+        "\tint rc;\n\n"
+        "\ta52_ackfr_record(\"PINCTRL Lagoon probe enter dev=%s node=%s\",\n"
+        "\t\tdev_name(&pdev->dev), pdev->dev.of_node ?\n"
+        "\t\tpdev->dev.of_node->full_name : \"none\");\n"
+        "\trc = msm_pinctrl_probe(pdev, &lagoon_pinctrl);\n"
+        "\ta52_ackfr_record(\"PINCTRL Lagoon probe exit rc=%d bound=%s\", rc,\n"
+        "\t\tpdev->dev.driver && pdev->dev.driver->name ?\n"
+        "\t\tpdev->dev.driver->name : \"none\");\n"
+        "\treturn rc;\n"
+        "}\n"
+    )
+    text = one(text, old, new, "Lagoon pinctrl probe trace")
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    patch_driver_core(args.root / "drivers/base/dd.c")
+    patch_display_audit(args.root / "drivers/a52_secure/a52_display_bind_audit.c")
+    patch_lagoon_pinctrl(args.root / "drivers/pinctrl/qcom/pinctrl-lagoon.c")
+    print("phase187 normal deferred-probe restoration applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/187_apply.py
+++ b/scripts/187_apply.py
@@ -91,17 +91,29 @@ def patch_display_audit(path: Path) -> None:
 
     text = one(
         text,
-        "\t\tif (!pdev->dev.driver && match > 0) {\n"
-        "\t\t\tif (force_links)\n"
-        "\t\t\t\ta52_device_links_force_probe(&pdev->dev, &kept, &dropped);\n"
-        "\t\t\trc = device_attach(&pdev->dev);\n",
-        "\t\tif (!pdev->dev.driver && match > 0) {\n"
-        "\t\t\tif (force_links)\n"
-        "\t\t\t\ta52_ackfr_record(\"DISP RETRY force-disabled p=%u c=%s\",\n"
-        "\t\t\t\t\tpass, target->tag);\n"
-        "\t\t\trc = device_attach(&pdev->dev);\n",
-        "disable dormant forced-link retry",
+        "/* Existing phase-177 helper. Phase 180 invokes it only on three display nodes. */\n"
+        "extern void a52_device_links_force_probe(struct device *dev,\n"
+        "\t\t\t\t\t unsigned int *kept,\n"
+        "\t\t\t\t\t unsigned int *dropped);\n\n",
+        "",
+        "remove display force-probe declaration",
     )
+
+    text = one(
+        text,
+        "/* Probe dependency order: controller, display aggregator, then SDE/DRM. */\n"
+        "static const unsigned int retry_order[] = { 2, 1, 0 };\n\n",
+        "",
+        "remove retry order",
+    )
+
+    retry_pattern = (
+        r"static void retry_compat\(.*?\n}\n\n"
+        r"static void retry_all\(.*?\n}\n\n"
+    )
+    text, count = re.subn(retry_pattern, "", text, count=1, flags=re.DOTALL)
+    if count != 1:
+        raise SystemExit(f"remove retry implementation: expected one match, found {count}")
 
     text = one(
         text,

--- a/scripts/187_ci.sh
+++ b/scripts/187_ci.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-amoled-power-chain"
+OUT="$PWD/artifacts/a52xq-normal-display-defer"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct the complete phase-186 source first, including the proven Lagoon
+# PDC match and the working TouchGrass AMOLED PMIC provider chain.
+bash scripts/186_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase187.config"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-before-phase187.c"
+cp "$ROOT/drivers/a52_secure/a52_display_bind_audit.c" "$OUT/stage/display-bind-audit-before-phase187.c"
+cp "$ROOT/drivers/pinctrl/qcom/pinctrl-lagoon.c" "$OUT/stage/pinctrl-lagoon-before-phase187.c"
+
+python3 scripts/187_apply.py --root "$ROOT" | tee "$OUT/logs/phase187-apply.log"
+
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-after-phase187.c"
+cp "$ROOT/drivers/a52_secure/a52_display_bind_audit.c" "$OUT/stage/display-bind-audit-after-phase187.c"
+cp "$ROOT/drivers/pinctrl/qcom/pinctrl-lagoon.c" "$OUT/stage/pinctrl-lagoon-after-phase187.c"
+cp scripts/187_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+# This phase changes source behavior only. Preserve all phase-186 configuration,
+# boot logging, PDC and AMOLED provider settings exactly.
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase187.config" "$OUT/config/final.config"
+
+for symbol in \
+  CONFIG_SPMI=y \
+  CONFIG_SPMI_MSM_PMIC_ARB=y \
+  CONFIG_MFD_SPMI_PMIC=y \
+  CONFIG_REGMAP_SPMI=y \
+  CONFIG_REGULATOR_QPNP_AMOLED=y \
+  CONFIG_QCOM_PDC=y \
+  CONFIG_PINCTRL_LAGOON=y \
+  CONFIG_DISP_CC_LAGOON=y; do
+  grep -Fqx "$symbol" "$BUILD/.config"
+done
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+dd = (root / 'drivers/base/dd.c').read_text()
+audit = (root / 'drivers/a52_secure/a52_display_bind_audit.c').read_text()
+pinctrl = (root / 'drivers/pinctrl/qcom/pinctrl-lagoon.c').read_text()
+
+assert 'return name && !strcmp(name, "1d84000.ufshc");' in dd
+assert 'f100000.pinctrl"));' not in dd
+assert 'DISP RP bypass' not in dd
+assert 'DISP RP defer-normal' in dd
+# One active force-probe call remains in really_probe, for UFS only.
+assert dd.count('a52_device_links_force_probe(dev, &kept, &dropped);') == 1
+
+assert 'a52_device_links_force_probe(&pdev->dev, &kept, &dropped);' not in audit
+assert 'DISP CORE phase=187 audit=observe-only normal-defer' in audit
+assert 'DISP CORE phase=187 observe-only pass=%u' in audit
+assert 'retry_all(pass, false);' not in audit
+assert 'retry_all(pass, true);' not in audit
+
+assert 'PINCTRL Lagoon probe enter' in pinctrl
+assert 'PINCTRL Lagoon probe exit' in pinctrl
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase187-normal-display-defer.patch"
+test -s "$OUT/stage/phase187-normal-display-defer.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase187-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase187-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase187-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase187-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for object in \
+  'drivers/base/dd.o' \
+  'drivers/a52_secure/a52_display_bind_audit.o' \
+  'drivers/pinctrl/qcom/pinctrl-lagoon.o'; do
+  grep -Fq "$object" "$OUT/logs/phase187-compile.log"
+done
+
+for marker in \
+  'qcom,lagoon-pdc' \
+  'qcom,qpnp-amoled-regulator' \
+  'DISP RP defer-normal' \
+  'DISP CORE phase=187 audit=observe-only normal-defer' \
+  'PINCTRL Lagoon probe enter' \
+  'PINCTRL Lagoon probe exit'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+if grep -aFq 'DISP RP bypass' "$BUILD/arch/arm64/boot/Image"; then
+  echo 'forbidden display supplier-bypass marker remains in Image'
+  exit 1
+fi
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 187 normal deferred-probe candidate
+
+DO NOT USE PHASE 186 AGAIN.
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Hardware evidence from phase 186:
+  - Lagoon PDC probe completed with rc=0
+  - QPNP AMOLED parent regmap, DT parsing and OLEDB/AB/IBB registration all
+    completed with rc=0
+  - f100000.pinctrl remained unbound because inherited diagnostic code removed
+    its unresolved PDC supplier link before PDC became available
+  - inherited display diagnostics later removed the display-to-TLMM dependency
+    and forced display registration to continue without pinctrl
+  - the phone entered a visible kernel-panic state several seconds later
+
+Phase 187:
+  - preserves the successful PDC and AMOLED provider fixes
+  - removes f100000.pinctrl from the legacy forced-supplier path
+  - removes the display supplier bypass from really_probe()
+  - disables the delayed forced display retry and leaves it observation-only
+  - restores normal -EPROBE_DEFER handling so PDC binding can reprobe TLMM and
+    TLMM binding can reprobe the DSI display naturally
+  - traces the Lagoon pinctrl probe entry and result
+  - leaves only the existing UFS forced-link exception required for boot storage
+  - changes no DTB, panel command, timing, refresh mode or regulator voltage
+
+This artifact is compile-audited, not hardware validated. Because phase 186
+required a ROM dirty flash to recover, make a current recovery backup and keep
+the exact ROM package available before testing another candidate.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-normal-display-defer')
+base = json.loads(Path('artifacts/a52xq-amoled-power-chain/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+dd = (root / 'stage/dd-after-phase187.c').read_text()
+audit_src = (root / 'stage/display-bind-audit-after-phase187.c').read_text()
+pinctrl = (root / 'stage/pinctrl-lagoon-after-phase187.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-normal-display-defer-audited',
+    'phase': 187,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase186': True,
+    'phase186_hardware_result': 'visible kernel panic after approximately five seconds; exact panic text not preserved',
+    'root_cause_evidence': 'inherited diagnostics dropped TLMM-to-PDC and display-to-TLMM managed supplier links',
+    'pdc_fix_preserved': 'qcom,lagoon-pdc' in image.read_bytes().decode('latin1'),
+    'amoled_fix_preserved': 'qcom,qpnp-amoled-regulator' in image.read_bytes().decode('latin1'),
+    'tlmm_supplier_bypass_removed': 'f100000.pinctrl"));' not in dd,
+    'display_supplier_bypass_removed': 'DISP RP bypass' not in dd,
+    'normal_display_defer_marker_present': 'DISP RP defer-normal' in dd,
+    'forced_display_retry_removed': 'a52_device_links_force_probe(&pdev->dev, &kept, &dropped);' not in audit_src,
+    'display_audit_observe_only': 'phase=187 audit=observe-only normal-defer' in audit_src,
+    'lagoon_pinctrl_probe_trace_added': all(x in pinctrl for x in (
+        'PINCTRL Lagoon probe enter', 'PINCTRL Lagoon probe exit')),
+    'ufs_forced_link_exception_preserved': dd.count('a52_device_links_force_probe(dev, &kept, &dropped);') == 1,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'pdc_fix_preserved', 'amoled_fix_preserved',
+    'tlmm_supplier_bypass_removed', 'display_supplier_bypass_removed',
+    'normal_display_defer_marker_present', 'forced_display_retry_removed',
+    'display_audit_observe_only', 'lagoon_pinctrl_probe_trace_added',
+    'ufs_forced_link_exception_preserved', 'dtb_preserved',
+    'ramdisk_preserved', 'recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Hardware evidence

The phase-186 hardware capture proves that the new provider fixes worked:

- `qcom,lagoon-pdc` probed with `rc=0`
- the QPNP AMOLED driver obtained its parent regmap
- AMOLED DT parsing completed with `rc=0`
- OLEDB, AB and IBB rail registration completed with `rc=0`

However, inherited diagnostic code changed normal driver-core dependency handling:

1. `f100000.pinctrl` deferred before PDC was available.
2. The legacy forced-link path treated TLMM like UFS and dropped its unresolved PDC supplier link.
3. PDC later bound successfully, but TLMM no longer had the managed dependency needed for automatic reprobe.
4. The display path then dropped its unresolved TLMM supplier link and continued registration without pinctrl.
5. The phone entered a visible kernel-panic state several seconds later.

The raw recorder did not preserve the final panic text because its early trace capacity was exhausted, but it preserved the complete dependency sequence above.

## Phase 187

- preserve the successful Lagoon PDC compatibility fix
- preserve the complete SPMI PMIC and AMOLED OLEDB/AB/IBB provider chain
- remove `f100000.pinctrl` from the legacy forced-supplier path
- remove `f100000.pinctrl` from the old preprobe tracing target
- remove the display supplier bypass from `really_probe()`
- delete the complete delayed retry implementation, including `retry_order`, `retry_compat`, `retry_all`, `device_attach()` and its force-link declaration
- make the display audit observation-only
- restore normal `-EPROBE_DEFER` handling
- trace Lagoon pinctrl probe entry and result
- leave the existing UFS-only forced-link exception unchanged

## Successful audited build

Workflow run: `30517395136`

Artifact: `a52xq-normal-display-defer-8-NOT-HARDWARE-VALIDATED`

Artifact ZIP SHA-256:

`a128dcccb2e3475c610b5fe8d3319a126ffe773b3448616cdd6a1793efebe940`

Flash candidate inside the artifact:

`package/boot.img`

BOOT SHA-256:

`92491484715c22d013712be4fea7bbd56d9c5b05686a576558e9c05e65d745d9`

The completed audit confirms:

- Lagoon PDC and QPNP AMOLED support remain built in
- TLMM supplier bypass removed
- display supplier bypass removed
- forced display retry removed
- display audit observation-only
- only the UFS force-link exception remains
- DTB, ramdisk and recovery DTBO preserved
- no panel command, timing, refresh mode or regulator voltage changed

`final-audit.json` retains historical phase-180/181 fields from its base audit. The phase-187 current-state fields are authoritative: `tlmm_supplier_bypass_removed`, `display_supplier_bypass_removed`, `forced_display_retry_removed`, `display_audit_observe_only`, and `ufs_forced_link_exception_preserved`.

## Controlled hardware test

Because phase 186 required a ROM dirty flash to recover:

1. back up the exact current post-dirty-flash BOOT partition
2. keep the exact custom-ROM package available
3. flash only `package/boot.img` to BOOT
4. allow one boot attempt only
5. on panic or reboot, enter recovery immediately
6. collect untouched raw 1 MiB RAMOOPS before restoring anything
7. restore the exact BOOT backup, not a generic kernel installer

No DTB, DTBO, panel command, timing, refresh mode, regulator voltage, ramdisk or recovery DTBO is changed. This candidate is compile-audited and not hardware validated.