### PR TITLE
Remove forced display supplier bypass after phase 186 regression

### DIFF
--- a/.github/workflows/187-a52-display-defer-safety.yml
+++ b/.github/workflows/187-a52-display-defer-safety.yml
@@ -1,0 +1,134 @@
+name: 187 - A52 GKI 5.10 display deferred-probe safety
+
+run-name: Build GKI 5.10 A52 display defer-safety candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-display-defer-safety-v1
+    paths:
+      - .github/workflows/187-a52-display-defer-safety.yml
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-amoled-power-chain-v1
+    paths:
+      - .github/workflows/187-a52-display-defer-safety.yml
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-display-defer-safety-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-187 display defer-safety candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-187 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit phase 187
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/187_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-display-defer-safety-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-display-defer-safety
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-187 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-display-defer-safety-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-display-defer-safety
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/187_apply.py
+++ b/scripts/187_apply.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_driver_core(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    text = one(
+        text,
+        'static bool a52_legacy_fw_devlink_consumer(const struct device *dev)\n'
+        '{\n'
+        '\tconst char *name;\n\n'
+        '\tif (!dev)\n'
+        '\t\treturn false;\n'
+        '\tname = dev_name(dev);\n'
+        '\treturn name && (!strcmp(name, "1d84000.ufshc") ||\n'
+        '\t\t\t!strcmp(name, "f100000.pinctrl"));\n'
+        '}\n',
+        'static bool a52_legacy_fw_devlink_consumer(const struct device *dev)\n'
+        '{\n'
+        '\tconst char *name;\n\n'
+        '\tif (!dev)\n'
+        '\t\treturn false;\n'
+        '\tname = dev_name(dev);\n'
+        '\treturn name && !strcmp(name, "1d84000.ufshc");\n'
+        '}\n',
+        "restrict legacy supplier override to UFS",
+    )
+
+    text = one(
+        text,
+        '\tif (ret == -EPROBE_DEFER && dev->of_node &&\n'
+        '\t    of_device_is_compatible(dev->of_node, "qcom,dsi-ctrl-hw-v2.4"))\n'
+        '\t\ta52_ackfr_record("DISP RP defer-preserved dev=%s rc=%d",\n'
+        '\t\t\tdev_name(dev), ret);\n'
+        '\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev) &&\n'
+        '\t    !(dev->of_node && of_device_is_compatible(dev->of_node,\n'
+        '\t\t\t\t\t\t "qcom,dsi-ctrl-hw-v2.4"))) {\n'
+        '\t\tunsigned int kept = 0;\n'
+        '\t\tunsigned int dropped = 0;\n\n'
+        '\t\ta52_device_links_force_probe(dev, &kept, &dropped);\n'
+        '\t\ta52_ackfr_record("DISP RP bypass dev=%s kept=%u drop=%u",\n'
+        '\t\t\tdev_name(dev), kept, dropped);\n'
+        '\t\tret = 0;\n'
+        '\t}\n',
+        '\tif (ret == -EPROBE_DEFER && a52_display_probe_device(dev))\n'
+        '\t\ta52_ackfr_record("DISP RP defer-preserved dev=%s rc=%d",\n'
+        '\t\t\tdev_name(dev), ret);\n',
+        "remove display supplier bypass",
+    )
+
+    path.write_text(text, encoding="utf-8")
+
+
+def patch_display_audit(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    text = one(
+        text,
+        '/* Existing phase-177 helper. Phase 180 invokes it only on three display nodes. */\n'
+        'extern void a52_device_links_force_probe(struct device *dev,\n'
+        '\t\t\t\t\t unsigned int *kept,\n'
+        '\t\t\t\t\t unsigned int *dropped);\n\n',
+        '',
+        "remove display force-probe declaration",
+    )
+
+    text = one(
+        text,
+        '/* Probe dependency order: controller, display aggregator, then SDE/DRM. */\n'
+        'static const unsigned int retry_order[] = { 2, 1, 0 };\n\n',
+        '',
+        "remove display retry order",
+    )
+
+    text = one(
+        text,
+        'static void retry_compat(const struct a52_bind_target *target,\n'
+        '\t\t\t unsigned int pass, bool force_links)\n'
+        '{\n'
+        '\tstruct device_node *node = NULL;\n'
+        '\tunsigned int index = 0;\n\n'
+        '\tfor_each_compatible_node(node, NULL, target->compatible) {\n'
+        '\t\tstruct platform_device *pdev = of_find_device_by_node(node);\n'
+        '\t\tunsigned int kept = 0, dropped = 0;\n'
+        '\t\tint match = -ENOENT;\n'
+        '\t\tint rc = -ENODEV;\n\n'
+        '\t\tif (!pdev) {\n'
+        '\t\t\ta52_ackfr_record("DISP RETRY p=%u c=%s n=%u force=%u pdev=0 rc=%d",\n'
+        '\t\t\t\tpass, target->tag, index, force_links, rc);\n'
+        '\t\t\tindex++;\n'
+        '\t\t\tcontinue;\n'
+        '\t\t}\n\n'
+        '\t\tmatch = target_driver_match(target, pdev, pass);\n'
+        '\t\tif (!pdev->dev.driver && match > 0) {\n'
+        '\t\t\tif (force_links)\n'
+        '\t\t\t\ta52_device_links_force_probe(&pdev->dev, &kept, &dropped);\n'
+        '\t\t\trc = device_attach(&pdev->dev);\n'
+        '\t\t} else if (pdev->dev.driver) {\n'
+        '\t\t\trc = 1;\n'
+        '\t\t} else {\n'
+        '\t\t\trc = 0;\n'
+        '\t\t}\n\n'
+        '\t\ta52_ackfr_record("DISP RETRY p=%u c=%s n=%u force=%u match=%d kept=%u drop=%u rc=%d drv=%s",\n'
+        '\t\t\tpass, target->tag, index, force_links, match, kept, dropped,\n'
+        '\t\t\trc, bound_driver(pdev));\n'
+        '\t\tput_device(&pdev->dev);\n'
+        '\t\tindex++;\n'
+        '\t}\n'
+        '}\n\n'
+        'static void retry_all(unsigned int pass, bool force_links)\n'
+        '{\n'
+        '\tunsigned int i;\n\n'
+        '\tfor (i = 0; i < ARRAY_SIZE(retry_order); i++)\n'
+        '\t\tretry_compat(&targets[retry_order[i]], pass, force_links);\n'
+        '}\n',
+        '',
+        "remove forced display retry",
+    )
+
+    text = one(
+        text,
+        '\t/* First retry is normal. Second retry removes only unresolved managed links. */\n'
+        '\tif (pass == 1)\n'
+        '\t\tretry_all(pass, false);\n'
+        '\telse if (pass == 2)\n'
+        '\t\tretry_all(pass, true);\n',
+        '',
+        "remove display retry schedule",
+    )
+
+    text = one(
+        text,
+        'a52_ackfr_record("DISP CORE phase=180 audit=start retry=normal,force");',
+        'a52_ackfr_record("DISP CORE phase=187 audit=read-only");',
+        "phase187 audit marker",
+    )
+
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    patch_driver_core(args.root / "drivers/base/dd.c")
+    patch_display_audit(args.root / "drivers/a52_display/180_a52_display_bind_audit.c")
+    print("phase187 normal deferred-probe safety restoration applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/187_ci.sh
+++ b/scripts/187_ci.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-amoled-power-chain"
+OUT="$PWD/artifacts/a52xq-display-defer-safety"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct phase 186 exactly, including the PDC and AMOLED provider fixes.
+bash scripts/186_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools,hardware-evidence}
+
+cp "$BUILD/.config" "$OUT/config/before-phase187.config"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-before-phase187.c"
+cp "$ROOT/drivers/a52_display/180_a52_display_bind_audit.c" \
+  "$OUT/stage/display-bind-audit-before-phase187.c"
+
+python3 scripts/187_apply.py --root "$ROOT" | tee "$OUT/logs/phase187-apply.log"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-after-phase187.c"
+cp "$ROOT/drivers/a52_display/180_a52_display_bind_audit.c" \
+  "$OUT/stage/display-bind-audit-after-phase187.c"
+cp scripts/187_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+# Phase 187 changes source behavior only. Preserve the complete phase-186 config.
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase187.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+
+dd = Path('gki/common/drivers/base/dd.c').read_text()
+audit = Path('gki/common/drivers/a52_display/180_a52_display_bind_audit.c').read_text()
+
+assert 'DISP RP bypass' not in dd
+assert 'ret = 0;\n\t}\n\tif (ret == -EPROBE_DEFER)\n\t\tdriver_deferred_probe_add_trigger' not in dd
+assert 'DISP RP defer-preserved' in dd
+
+start = dd.index('static bool a52_legacy_fw_devlink_consumer')
+end = dd.index('static bool a52_legacy_ufs_named_reset_pinctrl', start)
+legacy = dd[start:end]
+assert '1d84000.ufshc' in legacy
+assert 'f100000.pinctrl' not in legacy
+
+assert 'a52_device_links_force_probe' not in audit
+assert 'device_attach(' not in audit
+assert 'DISP RETRY' not in audit
+assert 'retry=normal,force' not in audit
+assert 'DISP CORE phase=187 audit=read-only' in audit
+PY
+
+for symbol in \
+  CONFIG_SPMI_MSM_PMIC_ARB=y \
+  CONFIG_MFD_SPMI_PMIC=y \
+  CONFIG_REGULATOR_QPNP_AMOLED=y \
+  CONFIG_QCOM_PDC=y \
+  CONFIG_PINCTRL_LAGOON=y \
+  CONFIG_DISP_CC_LAGOON=y; do
+  grep -Fqx "$symbol" "$BUILD/.config"
+done
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase187-display-defer-safety.patch"
+test -s "$OUT/stage/phase187-display-defer-safety.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase187-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase187-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase187-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase187-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'CC      drivers/base/dd.o' "$OUT/logs/phase187-compile.log"
+grep -Fq 'CC      drivers/a52_display/180_a52_display_bind_audit.o' \
+  "$OUT/logs/phase187-compile.log"
+
+for marker in \
+  'DISP RP defer-preserved' \
+  'DISP CORE phase=187 audit=read-only' \
+  'qcom,lagoon-pdc' \
+  'qcom,qpnp-amoled-regulator' \
+  'AMOLED probe exit'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+for forbidden in \
+  'DISP RP bypass' \
+  'DISP CORE phase=180 audit=start retry=normal,force'; do
+  if grep -aFq "$forbidden" "$BUILD/arch/arm64/boot/Image"; then
+    echo "forbidden phase187 image marker remains: $forbidden" >&2
+    exit 1
+  fi
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+cat > "$OUT/hardware-evidence/PHASE186-REGRESSION.txt" <<'EOF'
+Phase 186 hardware regression evidence
+
+User-observed result:
+  - early kernel panic roughly five seconds after boot
+  - restoring a previous kernel image alone did not recover the installation
+  - dirty-flashing the custom ROM was required
+
+Recovered phase-186 recorder sequence:
+  - f100000.pinctrl dropped unresolved supplier b220000.interrupt-controller
+  - Lagoon PDC later probed successfully, rc=0
+  - QPNP AMOLED regmap, DT parsing and OLEDB/AB/IBB registration succeeded, rc=0
+  - dsi-display-primary supplier check returned -EPROBE_DEFER
+  - its pinctrl supplier f100000.pinctrl was unbound and forcibly dropped
+  - the diagnostic path recorded "DISP RP bypass", changed ret to 0 and completed
+    really_probe with no bound display driver
+
+The exact later panic stack was not present in the preserved pstore dmesg record.
+Phase 187 therefore removes the directly recorded invalid forced-success path rather
+than claiming a specific unrecorded faulting instruction.
+EOF
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 187 display deferred-probe safety candidate
+
+IMPORTANT:
+  Phase 186 caused an early hardware panic and has been withdrawn.
+
+FLASHABLE FILE, ONLY AFTER REVIEW:
+  package/boot.img -> BOOT partition
+
+Phase 187 preserves the working-source PDC and AMOLED provider additions, but removes
+all inherited display supplier bypass behavior:
+  - TLMM is no longer treated as a legacy fw_devlink override target
+  - display -EPROBE_DEFER results remain deferred
+  - no display supplier device link is dropped
+  - the display audit is read-only and never calls device_attach
+  - the UFS-only legacy workaround is preserved unchanged
+  - no DTB, panel command, timing, refresh mode, voltage, ramdisk or recovery DTBO changes
+
+This artifact is compile-audited and NOT hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+root = Path('artifacts/a52xq-display-defer-safety')
+base = json.loads(Path('artifacts/a52xq-amoled-power-chain/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+config_before = (root / 'config/before-phase187.config').read_bytes()
+config_after = (root / 'config/final.config').read_bytes()
+dd = (root / 'stage/dd-after-phase187.c').read_text()
+audit_source = (root / 'stage/display-bind-audit-after-phase187.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+legacy = dd[dd.index('static bool a52_legacy_fw_devlink_consumer'):
+            dd.index('static bool a52_legacy_ufs_named_reset_pinctrl')]
+
+audit = dict(base)
+audit.update({
+    'status': 'a52-display-defer-safety-audited',
+    'phase': 187,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'phase186_hardware_regression': True,
+    'phase186_user_observed_panic_seconds_approx': 5,
+    'phase186_exact_panic_stack_captured': False,
+    'display_supplier_bypass_removed': 'DISP RP bypass' not in dd,
+    'display_defer_preserved': 'DISP RP defer-preserved' in dd,
+    'pinctrl_legacy_supplier_override_removed': 'f100000.pinctrl' not in legacy,
+    'ufs_legacy_supplier_override_preserved': '1d84000.ufshc' in legacy,
+    'display_audit_read_only': (
+        'DISP CORE phase=187 audit=read-only' in audit_source and
+        'a52_device_links_force_probe' not in audit_source and
+        'device_attach(' not in audit_source),
+    'phase186_configuration_preserved': config_before == config_after,
+    'pdc_fix_preserved': b'qcom,lagoon-pdc' in image.read_bytes(),
+    'amoled_provider_preserved': b'qcom,qpnp-amoled-regulator' in image.read_bytes(),
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'display_supplier_bypass_removed', 'display_defer_preserved',
+    'pinctrl_legacy_supplier_override_removed',
+    'ufs_legacy_supplier_override_preserved', 'display_audit_read_only',
+    'phase186_configuration_preserved', 'pdc_fix_preserved',
+    'amoled_provider_preserved', 'dtb_preserved', 'ramdisk_preserved',
+    'recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Hardware regression evidence

Phase 186 caused an early kernel panic roughly five seconds after boot. Restoring a previous kernel image alone did not recover the installation, and the custom ROM had to be dirty-flashed again. Phase 186 PR #87 has been closed and marked **DO NOT FLASH**.

The recovered phase-186 recorder does not contain the exact later panic stack, but it directly records an invalid driver-core sequence:

- `f100000.pinctrl` dropped its unresolved `b220000.interrupt-controller` link before Lagoon PDC probed
- Lagoon PDC later completed with `rc=0`
- QPNP AMOLED regmap, DT parsing and OLEDB/AB/IBB registration completed with `rc=0`
- `dsi-display-primary` still returned `-EPROBE_DEFER` because pinctrl was unbound
- inherited diagnostic code dropped the TLMM supplier link, recorded `DISP RP bypass`, changed `ret` to zero and completed probe without a bound display driver

## Phase 187 safety correction

- remove TLMM from the legacy fw_devlink override target list
- preserve all display `-EPROBE_DEFER` results
- remove the display path that drops supplier links and forces `ret = 0`
- make the periodic display audit read-only
- remove all display-side `device_attach()` and forced supplier mutation
- preserve the UFS-only legacy workaround unchanged
- preserve the phase-185 Lagoon PDC and phase-186 AMOLED provider additions

## Controlled scope

No DTB, panel command, timing, refresh mode, regulator voltage, ramdisk or recovery DTBO is changed. This branch is a compile and safety audit first, not a claim of hardware success.