### PR TITLE
Trace the Qualcomm TLMM probe stages

### DIFF
--- a/.github/workflows/188-a52-pinctrl-stage-trace.yml
+++ b/.github/workflows/188-a52-pinctrl-stage-trace.yml
@@ -1,0 +1,140 @@
+name: 188 - A52 GKI 5.10 pinctrl stage trace
+
+run-name: Build GKI 5.10 A52 Qualcomm pinctrl stage-trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-pinctrl-stage-trace-v1
+    paths:
+      - .github/workflows/188-a52-pinctrl-stage-trace.yml
+      - scripts/188_apply.py
+      - scripts/188_decode_near_header.py
+      - scripts/188_ci.sh
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-restore-deferred-probe-v1
+    paths:
+      - .github/workflows/188-a52-pinctrl-stage-trace.yml
+      - scripts/188_apply.py
+      - scripts/188_decode_near_header.py
+      - scripts/188_ci.sh
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-pinctrl-stage-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-188 Qualcomm pinctrl stage-trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-188 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 188
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/188_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-pinctrl-stage-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-pinctrl-stage-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-188 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-pinctrl-stage-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-pinctrl-stage-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/188_apply.py
+++ b/scripts/188_apply.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def add_recorder_decl(text: str) -> str:
+    declaration = "extern void a52_ackfr_record(const char *fmt, ...);\n"
+    if declaration in text:
+        return text
+    includes = list(re.finditer(r"^#include[^\n]*\n", text, flags=re.MULTILINE))
+    if not includes:
+        raise SystemExit("pinctrl-msm includes: no include block found")
+    pos = includes[-1].end()
+    return text[:pos] + "\n" + declaration + text[pos:]
+
+
+def patch_trace_helper(text: str) -> str:
+    return one(
+        text,
+        "};\n\n#define MSM_ACCESSOR(name) \\\n",
+        "};\n\n"
+        "static bool a52_lagoon_pinctrl_trace(const struct msm_pinctrl *pctrl)\n"
+        "{\n"
+        "\treturn pctrl && pctrl->dev && pctrl->dev->of_node &&\n"
+        "\t\tof_device_is_compatible(pctrl->dev->of_node,\n"
+        "\t\t\t\t\t\"qcom,lagoon-pinctrl\");\n"
+        "}\n\n"
+        "#define A52_PINTRACE(pctrl, fmt, ...) do { \\\n"
+        "\tif (a52_lagoon_pinctrl_trace(pctrl)) \\\n"
+        "\t\ta52_ackfr_record(fmt, ##__VA_ARGS__); \\\n"
+        "} while (0)\n\n"
+        "#define MSM_ACCESSOR(name) \\\n",
+        "Lagoon trace helper",
+    )
+
+
+def patch_gpio_init(text: str) -> str:
+    text = one(
+        text,
+        "\tbool skip;\n\n\tif (WARN_ON(ngpio > MAX_NR_GPIO))\n\t\treturn -EINVAL;\n",
+        "\tbool skip;\n\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio enter ng=%u\", ngpio);\n"
+        "\tif (WARN_ON(ngpio > MAX_NR_GPIO)) {\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio invalid-ng rc=%d\", -EINVAL);\n"
+        "\t\treturn -EINVAL;\n"
+        "\t}\n",
+        "gpio entry",
+    )
+
+    text = one(
+        text,
+        "\tif (msm_gpio_needs_valid_mask(pctrl))\n\t\tchip->init_valid_mask = msm_gpio_init_valid_mask;\n\n\tpctrl->irq_chip.name = \"msmgpio\";\n",
+        "\tif (msm_gpio_needs_valid_mask(pctrl))\n"
+        "\t\tchip->init_valid_mask = msm_gpio_init_valid_mask;\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio template mask=%u\",\n"
+        "\t\tchip->init_valid_mask != NULL);\n\n"
+        "\tpctrl->irq_chip.name = \"msmgpio\";\n",
+        "gpio template",
+    )
+
+    text = one(
+        text,
+        "\tnp = of_parse_phandle(pctrl->dev->of_node, \"wakeup-parent\", 0);\n"
+        "\tif (np) {\n"
+        "\t\tchip->irq.parent_domain = irq_find_matching_host(np,\n"
+        "\t\t\t\t\t\t DOMAIN_BUS_WAKEUP);\n"
+        "\t\tof_node_put(np);\n"
+        "\t\tif (!chip->irq.parent_domain)\n"
+        "\t\t\treturn -EPROBE_DEFER;\n"
+        "\t\tchip->irq.child_to_parent_hwirq = msm_gpio_wakeirq;\n"
+        "\t\tpctrl->irq_chip.irq_eoi = irq_chip_eoi_parent;\n",
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio wake-parse enter\");\n"
+        "\tnp = of_parse_phandle(pctrl->dev->of_node, \"wakeup-parent\", 0);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio wake-parse np=%u\", np != NULL);\n"
+        "\tif (np) {\n"
+        "\t\tchip->irq.parent_domain = irq_find_matching_host(np,\n"
+        "\t\t\t\t\t\t DOMAIN_BUS_WAKEUP);\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio wake-domain ok=%u\",\n"
+        "\t\t\tchip->irq.parent_domain != NULL);\n"
+        "\t\tof_node_put(np);\n"
+        "\t\tif (!chip->irq.parent_domain) {\n"
+        "\t\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio wake-domain rc=%d\",\n"
+        "\t\t\t\t-EPROBE_DEFER);\n"
+        "\t\t\treturn -EPROBE_DEFER;\n"
+        "\t\t}\n"
+        "\t\tchip->irq.child_to_parent_hwirq = msm_gpio_wakeirq;\n"
+        "\t\tpctrl->irq_chip.irq_eoi = irq_chip_eoi_parent;\n",
+        "wakeup parent",
+    )
+
+    text = one(
+        text,
+        "\t\tskip = irq_domain_qcom_handle_wakeup(chip->irq.parent_domain);\n"
+        "\t\tfor (i = 0; skip && i < pctrl->soc->nwakeirq_map; i++) {\n",
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio wake-handle enter\");\n"
+        "\t\tskip = irq_domain_qcom_handle_wakeup(chip->irq.parent_domain);\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio wake-handle skip=%u map=%u\",\n"
+        "\t\t\tskip, pctrl->soc->nwakeirq_map);\n"
+        "\t\tfor (i = 0; skip && i < pctrl->soc->nwakeirq_map; i++) {\n",
+        "wakeup handling",
+    )
+
+    text = one(
+        text,
+        "\tgirq->parents = devm_kcalloc(pctrl->dev, 1, sizeof(*girq->parents),\n"
+        "\t\t\t\t     GFP_KERNEL);\n"
+        "\tif (!girq->parents)\n"
+        "\t\treturn -ENOMEM;\n",
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio parent-alloc enter\");\n"
+        "\tgirq->parents = devm_kcalloc(pctrl->dev, 1, sizeof(*girq->parents),\n"
+        "\t\t\t\t     GFP_KERNEL);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio parent-alloc ok=%u\",\n"
+        "\t\tgirq->parents != NULL);\n"
+        "\tif (!girq->parents)\n"
+        "\t\treturn -ENOMEM;\n",
+        "IRQ parent allocation",
+    )
+
+    text = one(
+        text,
+        "\tret = gpiochip_add_data(&pctrl->chip, pctrl);\n"
+        "\tif (ret) {\n",
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio chip-add enter irq=%d\",\n"
+        "\t\tpctrl->irq);\n"
+        "\tret = gpiochip_add_data(&pctrl->chip, pctrl);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio chip-add exit rc=%d\", ret);\n"
+        "\tif (ret) {\n",
+        "gpiochip registration",
+    )
+
+    text = one(
+        text,
+        "\tif (!of_property_read_bool(pctrl->dev->of_node, \"gpio-ranges\")) {\n"
+        "\t\tret = gpiochip_add_pin_range(&pctrl->chip,\n"
+        "\t\t\tdev_name(pctrl->dev), 0, 0, chip->ngpio);\n"
+        "\t\tif (ret) {\n",
+        "\tif (!of_property_read_bool(pctrl->dev->of_node, \"gpio-ranges\")) {\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio range-add enter\");\n"
+        "\t\tret = gpiochip_add_pin_range(&pctrl->chip,\n"
+        "\t\t\tdev_name(pctrl->dev), 0, 0, chip->ngpio);\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL gpio range-add exit rc=%d\", ret);\n"
+        "\t\tif (ret) {\n",
+        "pin range registration",
+    )
+
+    text = one(
+        text,
+        "\t}\n\n\treturn 0;\n}\n\nstatic int msm_ps_hold_restart",
+        "\t}\n\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL gpio exit rc=0\");\n"
+        "\treturn 0;\n"
+        "}\n\n"
+        "static int msm_ps_hold_restart",
+        "gpio completion",
+    )
+    return text
+
+
+def patch_probe(text: str) -> str:
+    text = one(
+        text,
+        "\tpctrl = devm_kzalloc(&pdev->dev, sizeof(*pctrl), GFP_KERNEL);\n"
+        "\tif (!pctrl)\n"
+        "\t\treturn -ENOMEM;\n",
+        "\tpctrl = devm_kzalloc(&pdev->dev, sizeof(*pctrl), GFP_KERNEL);\n"
+        "\tif (!pctrl)\n"
+        "\t\treturn -ENOMEM;\n"
+        "\tif (pdev->dev.of_node && of_device_is_compatible(\n"
+        "\t\t\tpdev->dev.of_node, \"qcom,lagoon-pinctrl\"))\n"
+        "\t\ta52_ackfr_record(\"PINCTRL msm alloc ok=1\");\n",
+        "probe allocation",
+    )
+
+    text = one(
+        text,
+        "\traw_spin_lock_init(&pctrl->lock);\n\n\tif (soc_data->tiles) {\n",
+        "\traw_spin_lock_init(&pctrl->lock);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm state np=%u ng=%u tiles=%u\",\n"
+        "\t\tpctrl->soc->npins, pctrl->soc->ngpios, pctrl->soc->ntiles);\n\n"
+        "\tif (soc_data->tiles) {\n",
+        "probe state",
+    )
+
+    text = one(
+        text,
+        "\t\tfor (i = 0; i < soc_data->ntiles; i++) {\n"
+        "\t\t\tres = platform_get_resource_byname(pdev, IORESOURCE_MEM,\n"
+        "\t\t\t\t\t\t\t   soc_data->tiles[i]);\n"
+        "\t\t\tpctrl->regs[i] = devm_ioremap_resource(&pdev->dev, res);\n"
+        "\t\t\tif (IS_ERR(pctrl->regs[i]))\n"
+        "\t\t\t\treturn PTR_ERR(pctrl->regs[i]);\n"
+        "\t\t}\n",
+        "\t\tfor (i = 0; i < soc_data->ntiles; i++) {\n"
+        "\t\t\tres = platform_get_resource_byname(pdev, IORESOURCE_MEM,\n"
+        "\t\t\t\t\t\t\t   soc_data->tiles[i]);\n"
+        "\t\t\tA52_PINTRACE(pctrl, \"PINCTRL msm map tile=%d res=%u\",\n"
+        "\t\t\t\ti, res != NULL);\n"
+        "\t\t\tpctrl->regs[i] = devm_ioremap_resource(&pdev->dev, res);\n"
+        "\t\t\tA52_PINTRACE(pctrl, \"PINCTRL msm map tile=%d rc=%ld\", i,\n"
+        "\t\t\t\tIS_ERR(pctrl->regs[i]) ? PTR_ERR(pctrl->regs[i]) : 0L);\n"
+        "\t\t\tif (IS_ERR(pctrl->regs[i]))\n"
+        "\t\t\t\treturn PTR_ERR(pctrl->regs[i]);\n"
+        "\t\t}\n",
+        "tile mapping",
+    )
+
+    text = one(
+        text,
+        "\t} else {\n"
+        "\t\tres = platform_get_resource(pdev, IORESOURCE_MEM, 0);\n"
+        "\t\tpctrl->regs[0] = devm_ioremap_resource(&pdev->dev, res);\n"
+        "\t\tif (IS_ERR(pctrl->regs[0]))\n"
+        "\t\t\treturn PTR_ERR(pctrl->regs[0]);\n\n"
+        "\t\tpctrl->phys_base[0] = res->start;\n"
+        "\t}\n\n"
+        "\tmsm_pinctrl_setup_pm_reset(pctrl);\n",
+        "\t} else {\n"
+        "\t\tres = platform_get_resource(pdev, IORESOURCE_MEM, 0);\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL msm map single res=%u\", res != NULL);\n"
+        "\t\tpctrl->regs[0] = devm_ioremap_resource(&pdev->dev, res);\n"
+        "\t\tA52_PINTRACE(pctrl, \"PINCTRL msm map single rc=%ld\",\n"
+        "\t\t\tIS_ERR(pctrl->regs[0]) ? PTR_ERR(pctrl->regs[0]) : 0L);\n"
+        "\t\tif (IS_ERR(pctrl->regs[0]))\n"
+        "\t\t\treturn PTR_ERR(pctrl->regs[0]);\n\n"
+        "\t\tpctrl->phys_base[0] = res->start;\n"
+        "\t}\n\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm pmreset enter\");\n"
+        "\tmsm_pinctrl_setup_pm_reset(pctrl);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm pmreset exit\");\n",
+        "single map and PM reset",
+    )
+
+    text = one(
+        text,
+        "\tpctrl->irq = platform_get_irq(pdev, 0);\n"
+        "\tif (pctrl->irq < 0)\n"
+        "\t\treturn pctrl->irq;\n",
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm irq enter\");\n"
+        "\tpctrl->irq = platform_get_irq(pdev, 0);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm irq exit rc=%d\", pctrl->irq);\n"
+        "\tif (pctrl->irq < 0)\n"
+        "\t\treturn pctrl->irq;\n",
+        "platform IRQ",
+    )
+
+    text = one(
+        text,
+        "\tpctrl->pctrl = devm_pinctrl_register(&pdev->dev, &pctrl->desc, pctrl);\n"
+        "\tif (IS_ERR(pctrl->pctrl)) {\n",
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm pctl-register enter\");\n"
+        "\tpctrl->pctrl = devm_pinctrl_register(&pdev->dev, &pctrl->desc, pctrl);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm pctl-register exit rc=%ld\",\n"
+        "\t\tIS_ERR(pctrl->pctrl) ? PTR_ERR(pctrl->pctrl) : 0L);\n"
+        "\tif (IS_ERR(pctrl->pctrl)) {\n",
+        "pinctrl registration",
+    )
+
+    text = one(
+        text,
+        "\tret = msm_gpio_init(pctrl);\n"
+        "\tif (ret)\n"
+        "\t\treturn ret;\n\n"
+        "\tplatform_set_drvdata(pdev, pctrl);\n",
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm gpio-init enter\");\n"
+        "\tret = msm_gpio_init(pctrl);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm gpio-init exit rc=%d\", ret);\n"
+        "\tif (ret)\n"
+        "\t\treturn ret;\n\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm drvdata enter\");\n"
+        "\tplatform_set_drvdata(pdev, pctrl);\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm drvdata exit\");\n",
+        "GPIO init and drvdata",
+    )
+
+    text = one(
+        text,
+        "\tdev_dbg(&pdev->dev, \"Probed Qualcomm pinctrl driver\\n\");\n\n"
+        "\treturn 0;\n",
+        "\tdev_dbg(&pdev->dev, \"Probed Qualcomm pinctrl driver\\n\");\n"
+        "\tA52_PINTRACE(pctrl, \"PINCTRL msm probe exit rc=0\");\n\n"
+        "\treturn 0;\n",
+        "probe completion",
+    )
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    path = args.root / "drivers/pinctrl/qcom/pinctrl-msm.c"
+    text = path.read_text(encoding="utf-8")
+    text = add_recorder_decl(text)
+    text = patch_trace_helper(text)
+    text = patch_gpio_init(text)
+    text = patch_probe(text)
+    path.write_text(text, encoding="utf-8")
+    print("phase188 Qualcomm pinctrl stage instrumentation applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/188_ci.sh
+++ b/scripts/188_ci.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-normal-display-defer"
+OUT="$PWD/artifacts/a52xq-pinctrl-stage-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+# Reconstruct the complete phase-187 source first. This preserves the working
+# PDC and AMOLED providers and normal deferred probing without supplier bypasses.
+bash scripts/187_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase188.config"
+cp "$ROOT/drivers/pinctrl/qcom/pinctrl-msm.c" "$OUT/stage/pinctrl-msm-before-phase188.c"
+
+python3 scripts/188_apply.py --root "$ROOT" | tee "$OUT/logs/phase188-apply.log"
+
+cp "$ROOT/drivers/pinctrl/qcom/pinctrl-msm.c" "$OUT/stage/pinctrl-msm-after-phase188.c"
+cp scripts/188_apply.py "$OUT/stage/"
+cp scripts/188_decode_near_header.py "$OUT/tools/decode-a52-r188-near-header.py"
+chmod +x "$OUT/tools/decode-a52-r188-near-header.py"
+git -C "$ROOT" diff --check
+
+# Instrumentation only. Configuration must stay byte-for-byte identical to phase 187.
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase188.config" "$OUT/config/final.config"
+
+for symbol in \
+  CONFIG_SPMI=y \
+  CONFIG_SPMI_MSM_PMIC_ARB=y \
+  CONFIG_MFD_SPMI_PMIC=y \
+  CONFIG_REGMAP_SPMI=y \
+  CONFIG_REGULATOR_QPNP_AMOLED=y \
+  CONFIG_QCOM_PDC=y \
+  CONFIG_PINCTRL_LAGOON=y \
+  CONFIG_DISP_CC_LAGOON=y; do
+  grep -Fqx "$symbol" "$BUILD/.config"
+done
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+msm = (root / 'drivers/pinctrl/qcom/pinctrl-msm.c').read_text()
+dd = (root / 'drivers/base/dd.c').read_text()
+audit = (root / 'drivers/a52_secure/a52_display_bind_audit.c').read_text()
+markers = (
+    'PINCTRL msm alloc ok=1',
+    'PINCTRL msm state np=%u ng=%u tiles=%u',
+    'PINCTRL msm map tile=%d res=%u',
+    'PINCTRL msm map single res=%u',
+    'PINCTRL msm pmreset enter',
+    'PINCTRL msm irq exit rc=%d',
+    'PINCTRL msm pctl-register enter',
+    'PINCTRL msm pctl-register exit rc=%ld',
+    'PINCTRL msm gpio-init enter',
+    'PINCTRL msm gpio-init exit rc=%d',
+    'PINCTRL gpio wake-parse enter',
+    'PINCTRL gpio wake-domain ok=%u',
+    'PINCTRL gpio wake-handle enter',
+    'PINCTRL gpio parent-alloc enter',
+    'PINCTRL gpio chip-add enter irq=%d',
+    'PINCTRL gpio range-add enter',
+    'PINCTRL gpio exit rc=0',
+    'PINCTRL msm probe exit rc=0',
+)
+for marker in markers:
+    assert marker in msm, marker
+assert 'qcom,lagoon-pinctrl' in msm
+assert 'return name && !strcmp(name, "1d84000.ufshc");' in dd
+assert 'DISP RP bypass' not in dd
+assert dd.count('a52_device_links_force_probe(dev, &kept, &dropped);') == 1
+assert 'device_attach(' not in audit
+assert 'retry_all(' not in audit
+assert 'a52_device_links_force_probe(&pdev->dev' not in audit
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase188-pinctrl-stage-trace.patch"
+test -s "$OUT/stage/phase188-pinctrl-stage-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase188-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase188-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase188-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase188-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/pinctrl/qcom/pinctrl-msm.o' "$OUT/logs/phase188-compile.log"
+for marker in \
+  'qcom,lagoon-pdc' \
+  'qcom,qpnp-amoled-regulator' \
+  'PINCTRL msm alloc ok=1' \
+  'PINCTRL msm pctl-register enter' \
+  'PINCTRL msm gpio-init enter' \
+  'PINCTRL gpio wake-domain ok=%u' \
+  'PINCTRL gpio chip-add enter irq=%d' \
+  'PINCTRL msm probe exit rc=0'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+if grep -aFq 'DISP RP bypass' "$BUILD/arch/arm64/boot/Image"; then
+  echo 'forbidden display supplier-bypass marker remains in Image'
+  exit 1
+fi
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 188 Qualcomm pinctrl stage-trace candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Fresh phase-187 hardware evidence, recovered from the correct 0x40000 console
+and ftrace banks with one-bit persistent-header recovery, shows:
+  - Lagoon PDC completed with rc=0
+  - QPNP AMOLED parent, DT parsing and OLEDB/AB/IBB registration completed
+  - DSI controller and primary display deferred normally without link dropping
+  - f100000.pinctrl entered lagoon_pinctrl_probe around 997 ms
+  - no Lagoon pinctrl probe-exit record was produced
+
+Therefore the previous dependency bypass is fixed. The current blocker is inside
+the generic 5.10 msm_pinctrl_probe() path.
+
+Phase 188 is instrumentation-only. It records checkpoints around:
+  - Qualcomm pinctrl allocation and state setup
+  - TLMM MMIO resource lookup and mapping
+  - PM-reset registration
+  - parent IRQ lookup
+  - pinctrl core registration
+  - GPIO/IRQ-chip initialization
+  - wakeup-parent IRQ-domain resolution
+  - Qualcomm direct-wakeup handling
+  - IRQ-parent allocation
+  - gpiochip and pin-range registration
+  - final driver-data setup and probe completion
+
+It also includes decode-a52-r188-near-header.py, which accepts a persistent RAM
+signature with at most one damaged bit and records that recovery in summary.json.
+
+No driver behavior, DTB, panel command, display timing, refresh mode, regulator
+voltage, ramdisk or recovery DTBO is changed. Normal -EPROBE_DEFER behavior and
+the phase-187 removal of display/TLMM supplier bypasses are preserved.
+
+Because recent failed boots dirtied F2FS metadata, back up the exact current BOOT
+partition, allow one boot attempt only, and collect untouched raw 1 MiB RAMOOPS
+before restoring the exact BOOT backup.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-pinctrl-stage-trace')
+base = json.loads(Path('artifacts/a52xq-normal-display-defer/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+source = (root / 'stage/pinctrl-msm-after-phase188.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-pinctrl-stage-trace-audited',
+    'phase': 188,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase187': False,
+    'instrumentation_change_from_phase187': True,
+    'phase187_hardware_result': 'visible reset/panic after approximately five seconds',
+    'phase187_last_fresh_record': 'PINCTRL Lagoon probe enter dev=f100000.pinctrl',
+    'phase187_fresh_record_monotonic_ms': 997.153,
+    'root_cause_scope': 'inside generic msm_pinctrl_probe; exact sub-stage not yet known',
+    'pinctrl_stage_trace_added': all(x in source for x in (
+        'PINCTRL msm alloc ok=1', 'PINCTRL msm pctl-register enter',
+        'PINCTRL msm gpio-init enter', 'PINCTRL gpio wake-domain ok=%u',
+        'PINCTRL gpio chip-add enter irq=%d', 'PINCTRL msm probe exit rc=0')),
+    'near_header_decoder_added': (root / 'tools/decode-a52-r188-near-header.py').is_file(),
+    'pdc_fix_preserved': 'qcom,lagoon-pdc' in image.read_bytes().decode('latin1'),
+    'amoled_fix_preserved': 'qcom,qpnp-amoled-regulator' in image.read_bytes().decode('latin1'),
+    'display_supplier_bypass_removed': 'DISP RP bypass' not in image.read_bytes().decode('latin1'),
+    'normal_deferred_probe_preserved': 'DISP RP defer-normal' in image.read_bytes().decode('latin1'),
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'pinctrl_stage_trace_added', 'near_header_decoder_added',
+    'pdc_fix_preserved', 'amoled_fix_preserved',
+    'display_supplier_bypass_removed', 'normal_deferred_probe_preserved',
+    'dtb_preserved', 'ramdisk_preserved', 'recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/188_decode_near_header.py
+++ b/scripts/188_decode_near_header.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import random
+import struct
+import sys
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+
+def load_soft_decoder():
+    path = Path(__file__).with_name("decode-a52-r180-soft-rs.py")
+    if not path.is_file():
+        raise RuntimeError(f"missing sibling decoder: {path}")
+    spec = importlib.util.spec_from_file_location("a52_r180_soft", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+S = load_soft_decoder()
+M = S.M
+MAX_SIGNATURE_BIT_DISTANCE = 1
+
+
+def signature_bit_distance(signature: int) -> int:
+    return (signature ^ M.PERSISTENT_RAM_SIG).bit_count()
+
+
+def chronological_ring_near_header(bank: bytes) -> tuple[bytes, dict[str, object]]:
+    if len(bank) != M.BANK_BYTES:
+        raise M.DecodeFailure(f"bank has {len(bank)} bytes, expected {M.BANK_BYTES}")
+    signature, start, size = struct.unpack_from("<III", bank, 0)
+    data = bank[M.BANK_HEADER_BYTES:]
+    distance = signature_bit_distance(signature)
+    valid_header = (
+        distance <= MAX_SIGNATURE_BIT_DISTANCE
+        and 0 <= start < len(data)
+        and 0 <= size <= len(data)
+    )
+    if not valid_header:
+        return data, {
+            "signature": f"0x{signature:08x}",
+            "signature_bit_distance": distance,
+            "start": start,
+            "size": size,
+            "header_valid": False,
+            "fallback": "scanned entire bank data area",
+        }
+    begin = (start - size) % len(data)
+    if size == 0:
+        stream = b""
+    elif begin < start:
+        stream = data[begin:start]
+    else:
+        stream = data[begin:] + data[:start]
+    return stream, {
+        "signature": f"0x{signature:08x}",
+        "signature_bit_distance": distance,
+        "signature_recovered": distance != 0,
+        "start": start,
+        "size": size,
+        "header_valid": True,
+        "chronological_begin": begin,
+    }
+
+
+S.M.chronological_ring = chronological_ring_near_header
+
+
+def make_bank(records: list[bytes], *, corrupt_signature: bool) -> bytes:
+    payload = b"".join(records)
+    if len(payload) > M.BANK_DATA_BYTES:
+        raise AssertionError("test payload too large")
+    signature = M.PERSISTENT_RAM_SIG
+    if corrupt_signature:
+        signature ^= 1 << 8
+    start = len(payload)
+    size = len(payload)
+    bank = bytearray(M.BANK_BYTES)
+    struct.pack_into("<III", bank, 0, signature, start, size)
+    bank[M.BANK_HEADER_BYTES:M.BANK_HEADER_BYTES + len(payload)] = payload
+    return bytes(bank)
+
+
+def self_test() -> None:
+    rng = random.Random(0xA52188)
+    records = [
+        M.encode_record_for_test(
+            seq,
+            f"PINCTRL decoder near-header test {seq}",
+            monotonic_ns=seq * 1_000_000,
+        )
+        for seq in range(1, 9)
+    ]
+    left = [bytearray(record) for record in records]
+    right = [bytearray(record) for record in records]
+    for copies in (left, right):
+        for record in copies:
+            for index in range(3, len(record)):
+                if rng.random() < 0.01:
+                    set_bits = [bit for bit in range(8) if record[index] & (1 << bit)]
+                    if set_bits:
+                        record[index] &= ~(1 << rng.choice(set_bits))
+    console = make_bank([bytes(item) for item in left], corrupt_signature=True)
+    ftrace = make_bank([bytes(item) for item in right], corrupt_signature=False)
+    raw = bytearray(M.RAMOOPS_TOTAL_BYTES)
+    raw[M.CONSOLE_OFFSET:M.CONSOLE_OFFSET + M.BANK_BYTES] = console
+    raw[M.FTRACE_OFFSET:M.FTRACE_OFFSET + M.BANK_BYTES] = ftrace
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        snapshot = root / "ramoops.bin"
+        snapshot.write_bytes(raw)
+        summary = S.decode_snapshot(snapshot, root / "decoded")
+        if summary["first_sequence"] != 1 or summary["last_sequence"] != 8:
+            raise AssertionError(summary)
+        console_header = summary["alignment"]["console_header"]
+        if not console_header["header_valid"]:
+            raise AssertionError(console_header)
+        if console_header["signature_bit_distance"] != 1:
+            raise AssertionError(console_header)
+        if not console_header["signature_recovered"]:
+            raise AssertionError(console_header)
+    print("phase188 near-header soft decoder self-test: PASS")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decode A52 two-copy RS records while tolerating one damaged persistent-RAM signature bit"
+    )
+    parser.add_argument("input", type=Path, nargs="?")
+    parser.add_argument("--output", type=Path, default=Path("decoded-a52-r188"))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        self_test()
+        return 0
+    if args.input is None:
+        parser.error("input is required unless --self-test is used")
+    snapshots = M.find_snapshots(args.input)
+    full_snapshots = [path for path in snapshots if path.stat().st_size == M.RAMOOPS_TOTAL_BYTES]
+    if not full_snapshots:
+        raise M.DecodeFailure("no full 1 MiB snapshot found for two-copy soft fusion")
+    summaries = []
+    for index, snapshot in enumerate(full_snapshots):
+        destination = args.output if len(full_snapshots) == 1 else args.output / f"snapshot-{index:02d}"
+        summaries.append(S.decode_snapshot(snapshot, destination))
+    print(json.dumps(summaries[0] if len(summaries) == 1 else summaries, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (M.DecodeFailure, RuntimeError) as exc:
+        print(f"decode error: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Hardware evidence

Phase 187 preserved normal deferred probing and removed all display/TLMM supplier bypasses, but the phone still entered the visible panic/reset state after roughly five seconds.

The fresh RAMOOPS capture is partially damaged at the persistent-RAM headers. Recovering the one-bit-damaged header and decoding the correct console/ftrace banks shows the phase-187 boot reaches:

- Lagoon PDC probe completion with `rc=0`
- QPNP AMOLED parent/regmap, DT parsing and OLEDB/AB/IBB registration completion
- normal DSI/display deferral without supplier-link removal
- `PINCTRL Lagoon probe enter dev=f100000.pinctrl` at about 997 ms

No corresponding Lagoon pinctrl probe-exit record is present. The current blocker is therefore inside the generic 5.10 `msm_pinctrl_probe()` path or a synchronous function called from it.

## Phase 188

This phase is instrumentation-only. It adds Lagoon-scoped recorder checkpoints around:

- pinctrl allocation and SoC state setup
- MMIO resource lookup and mapping
- PM-reset registration
- parent IRQ lookup
- pinctrl core registration
- `msm_gpio_init()` entry and result
- wakeup-parent parsing and IRQ-domain lookup
- Qualcomm wake-domain handling
- IRQ-parent allocation
- gpiochip registration
- pin-range registration
- driver-data setup and final probe completion

It also adds a decoder that accepts a persistent-RAM signature with at most one damaged bit and reports the recovery in `summary.json`.

## Safety and scope

- no functional pinctrl behaviour changed
- no supplier bypass or forced `device_attach()` restored
- normal `-EPROBE_DEFER` remains intact
- no DTB, panel command, timing, refresh mode or regulator voltage change
- no ramdisk or recovery-DTBO change
- the existing UFS-only force-link exception is unchanged

## Validation

The workflow reconstructs the complete phase-187 chain, applies only the stage-trace patch, compiles `drivers/pinctrl/qcom/pinctrl-msm.o`, checks the recorder markers in the final Image, verifies the phase-187 safety invariants, repacks BOOT while preserving its non-kernel components, and runs all recorder decoder self-tests.

This remains a draft and is not hardware validated.