### PR TITLE
Trace Lagoon GPIO-core registration stages

### DIFF
--- a/.github/workflows/189-a52-gpiolib-stage-trace.yml
+++ b/.github/workflows/189-a52-gpiolib-stage-trace.yml
@@ -1,0 +1,144 @@
+name: 189 - A52 GKI 5.10 GPIO core stage trace
+
+run-name: Build GKI 5.10 A52 GPIO-core stage-trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-gpiolib-stage-trace-v1
+    paths:
+      - .github/workflows/189-a52-gpiolib-stage-trace.yml
+      - scripts/189_apply.py
+      - scripts/189_ci.sh
+      - scripts/188_apply.py
+      - scripts/188_decode_near_header.py
+      - scripts/188_ci.sh
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-pinctrl-stage-trace-v1
+    paths:
+      - .github/workflows/189-a52-gpiolib-stage-trace.yml
+      - scripts/189_apply.py
+      - scripts/189_ci.sh
+      - scripts/188_apply.py
+      - scripts/188_decode_near_header.py
+      - scripts/188_ci.sh
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-gpiolib-stage-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-189 GPIO-core stage-trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-189 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 189
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/189_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-gpiolib-stage-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-gpiolib-stage-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-189 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-gpiolib-stage-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-gpiolib-stage-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/RAMOOPS-PHASE188-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE188-HARDWARE-RESULT.md
@@ -1,0 +1,17 @@
+Phase 188 hardware capture 2026-07-30 23:27 Asia/Jerusalem
+
+Decoded 141 fresh mirrored records from the untouched 1 MiB RAMOOPS snapshot. The console persistent-RAM signature required one-bit recovery; all 141 records decoded without sequence gaps.
+
+Last confirmed stages:
+
+- Lagoon PDC probe exit rc=0
+- QPNP AMOLED registration exit rc=0
+- normal DSI/display EPROBE_DEFER preserved
+- Lagoon TLMM allocation, MMIO mapping, PM/reset setup, IRQ lookup and pinctrl registration completed
+- wakeup-parent domain found
+- GPIO IRQ parent allocation completed
+- final record: `PINCTRL gpio chip-add enter irq=176`
+
+The persistent-RAM header reported 36,043 used bytes in a 256 KiB bank. The trace did not fill the physical recorder region, so the final record is a real stopping point rather than capacity exhaustion.
+
+TouchGrass comparison: its 4.19 GPIO-core registration initializes GPIO descriptor direction flags without reading every GPIO register. Common 5.10 calls `gc->get_direction()` for every valid GPIO during `gpiochip_add_data_with_key()`. Phase 189 will instrument the generic GPIO-core path to identify whether the reset occurs during OF registration, valid-mask initialization, an eager direction read, IRQ-chip setup or GPIO device setup before applying any compatibility change.

--- a/scripts/189_NOTES.txt
+++ b/scripts/189_NOTES.txt
@@ -1,0 +1,1 @@
+Phase 189 is instrumentation-only. It does not skip or alter the common-5.10 eager GPIO direction scan. The hardware decision point is the last GPIOCORE marker recovered from RAMOOPS.

--- a/scripts/189_apply.py
+++ b/scripts/189_apply.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def add_include_and_helper(text: str) -> str:
+    text = one(
+        text,
+        '#include <linux/gpio/machine.h>\n',
+        '#include <linux/gpio/machine.h>\n#include <linux/of.h>\n',
+        'add OF include',
+    )
+    anchor = 'static bool gpiolib_initialized;\n'
+    helper = '''static bool gpiolib_initialized;\n\nextern void a52_ackfr_record(const char *fmt, ...);\n\nstatic bool a52_gpio_core_trace(const struct gpio_chip *gc)\n{\n\treturn gc && gc->parent && gc->parent->of_node &&\n\t\tof_device_is_compatible(gc->parent->of_node,\n\t\t\t\t\t"qcom,lagoon-pinctrl");\n}\n\n#define A52_GPIOCORE_TRACE(gc, fmt, ...) do { \\\n\tif (a52_gpio_core_trace(gc)) \\\n\t\ta52_ackfr_record(fmt, ##__VA_ARGS__); \\\n} while (0)\n'''
+    return one(text, anchor, helper, 'add Lagoon GPIO-core trace helper')
+
+
+def patch_gpiochip_add(path: Path) -> None:
+    text = path.read_text(encoding='utf-8')
+    text = add_include_and_helper(text)
+
+    text = one(
+        text,
+        '''\tbool\t\tblock_gpio_read = false;\n\n\t/*\n\t * First: allocate and populate the internal stat container, and\n''',
+        '''\tbool\t\tblock_gpio_read = false;\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE add enter ng=%u base=%d",\n\t\t\t   gc->ngpio, base);\n\n\t/*\n\t * First: allocate and populate the internal stat container, and\n''',
+        'trace gpiochip add entry',
+    )
+
+    text = one(
+        text,
+        '''\tgdev = kzalloc(sizeof(*gdev), GFP_KERNEL);\n\tif (!gdev)\n\t\treturn -ENOMEM;\n\tgdev->dev.bus = &gpio_bus_type;\n''',
+        '''\tgdev = kzalloc(sizeof(*gdev), GFP_KERNEL);\n\tif (!gdev)\n\t\treturn -ENOMEM;\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE gdev-alloc ok=1");\n\tgdev->dev.bus = &gpio_bus_type;\n''',
+        'trace gdev allocation',
+    )
+
+    text = one(
+        text,
+        '''\tof_gpio_dev_init(gc, gdev);\n\n\t/*\n''',
+        '''\tof_gpio_dev_init(gc, gdev);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE of-dev-init done");\n\n\t/*\n''',
+        'trace OF device init',
+    )
+
+    text = one(
+        text,
+        '''\tgdev->descs = kcalloc(gc->ngpio, sizeof(gdev->descs[0]), GFP_KERNEL);\n\tif (!gdev->descs) {\n''',
+        '''\tgdev->descs = kcalloc(gc->ngpio, sizeof(gdev->descs[0]), GFP_KERNEL);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE desc-alloc ok=%u", !!gdev->descs);\n\tif (!gdev->descs) {\n''',
+        'trace descriptor allocation',
+    )
+
+    text = one(
+        text,
+        '''\tspin_unlock_irqrestore(&gpio_lock, flags);\n\n\tBLOCKING_INIT_NOTIFIER_HEAD(&gdev->notifier);\n''',
+        '''\tspin_unlock_irqrestore(&gpio_lock, flags);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE list-add done base=%d", gdev->base);\n\n\tBLOCKING_INIT_NOTIFIER_HEAD(&gdev->notifier);\n''',
+        'trace global GPIO list insertion',
+    )
+
+    text = one(
+        text,
+        '''\tif (gc->names)\n\t\tret = gpiochip_set_desc_names(gc);\n\telse\n\t\tret = devprop_gpiochip_set_names(gc);\n\tif (ret)\n\t\tgoto err_remove_from_list;\n\n\tret = gpiochip_alloc_valid_mask(gc);\n''',
+        '''\tA52_GPIOCORE_TRACE(gc, "GPIOCORE names enter explicit=%u", !!gc->names);\n\tif (gc->names)\n\t\tret = gpiochip_set_desc_names(gc);\n\telse\n\t\tret = devprop_gpiochip_set_names(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE names exit rc=%d", ret);\n\tif (ret)\n\t\tgoto err_remove_from_list;\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE valid-alloc enter");\n\tret = gpiochip_alloc_valid_mask(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE valid-alloc exit rc=%d mask=%u",\n\t\t\t   ret, !!gc->valid_mask);\n''',
+        'trace names and valid-mask allocation',
+    )
+
+    text = one(
+        text,
+        '''\tif (ret)\n\t\tgoto err_remove_from_list;\n\n\tret = of_gpiochip_add(gc);\n\tif (ret)\n\t\tgoto err_free_gpiochip_mask;\n\n\tret = gpiochip_init_valid_mask(gc);\n\tif (ret)\n\t\tgoto err_remove_of_chip;\n\n\ttrace_android_vh_gpio_block_read(gdev, &block_gpio_read);\n\tif (!block_gpio_read) {\n\t\tfor (i = 0; i < gc->ngpio; i++) {\n\t\t\tstruct gpio_desc *desc = &gdev->descs[i];\n\n\t\t\tif (gc->get_direction && gpiochip_line_is_valid(gc, i)) {\n\t\t\t\tassign_bit(FLAG_IS_OUT,\n\t\t\t\t\t   &desc->flags, !gc->get_direction(gc, i));\n\t\t\t} else {\n\t\t\t\tassign_bit(FLAG_IS_OUT,\n\t\t\t\t\t   &desc->flags, !gc->direction_input);\n\t\t\t}\n\t\t}\n\t}\n\n\tret = gpiochip_add_pin_ranges(gc);\n''',
+        '''\tif (ret)\n\t\tgoto err_remove_from_list;\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE of-add enter");\n\tret = of_gpiochip_add(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE of-add exit rc=%d", ret);\n\tif (ret)\n\t\tgoto err_free_gpiochip_mask;\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE valid-init enter");\n\tret = gpiochip_init_valid_mask(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE valid-init exit rc=%d", ret);\n\tif (ret)\n\t\tgoto err_remove_of_chip;\n\n\ttrace_android_vh_gpio_block_read(gdev, &block_gpio_read);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE dir-scan enter block=%u",\n\t\t\t   block_gpio_read);\n\tif (!block_gpio_read) {\n\t\tfor (i = 0; i < gc->ngpio; i++) {\n\t\t\tstruct gpio_desc *desc = &gdev->descs[i];\n\n\t\t\tif (gc->get_direction && gpiochip_line_is_valid(gc, i)) {\n\t\t\t\tint direction;\n\n\t\t\t\tA52_GPIOCORE_TRACE(gc,\n\t\t\t\t\t"GPIOCORE dir-read enter pin=%u", i);\n\t\t\t\tdirection = gc->get_direction(gc, i);\n\t\t\t\tA52_GPIOCORE_TRACE(gc,\n\t\t\t\t\t"GPIOCORE dir-read exit pin=%u rc=%d",\n\t\t\t\t\ti, direction);\n\t\t\t\tassign_bit(FLAG_IS_OUT, &desc->flags, !direction);\n\t\t\t} else {\n\t\t\t\tassign_bit(FLAG_IS_OUT,\n\t\t\t\t\t   &desc->flags, !gc->direction_input);\n\t\t\t}\n\t\t}\n\t}\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE dir-scan exit");\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE pin-ranges enter");\n\tret = gpiochip_add_pin_ranges(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE pin-ranges exit rc=%d", ret);\n''',
+        'trace OF, valid mask, direction scan and pin ranges',
+    )
+
+    text = one(
+        text,
+        '''\tret = gpiochip_irqchip_init_valid_mask(gc);\n\tif (ret)\n\t\tgoto err_free_hogs;\n\n\tret = gpiochip_irqchip_init_hw(gc);\n\tif (ret)\n\t\tgoto err_remove_irqchip_mask;\n\n\tret = gpiochip_add_irqchip(gc, lock_key, request_key);\n\tif (ret)\n\t\tgoto err_remove_irqchip_mask;\n''',
+        '''\tA52_GPIOCORE_TRACE(gc, "GPIOCORE irq-valid enter");\n\tret = gpiochip_irqchip_init_valid_mask(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE irq-valid exit rc=%d", ret);\n\tif (ret)\n\t\tgoto err_free_hogs;\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE irq-hw enter");\n\tret = gpiochip_irqchip_init_hw(gc);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE irq-hw exit rc=%d", ret);\n\tif (ret)\n\t\tgoto err_remove_irqchip_mask;\n\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE irq-add enter");\n\tret = gpiochip_add_irqchip(gc, lock_key, request_key);\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE irq-add exit rc=%d", ret);\n\tif (ret)\n\t\tgoto err_remove_irqchip_mask;\n''',
+        'trace IRQ-chip registration',
+    )
+
+    text = one(
+        text,
+        '''\tif (gpiolib_initialized) {\n\t\tret = gpiochip_setup_dev(gdev);\n\t\tif (ret)\n\t\t\tgoto err_remove_irqchip;\n\t}\n\treturn 0;\n''',
+        '''\tA52_GPIOCORE_TRACE(gc, "GPIOCORE setup-dev enter init=%u",\n\t\t\t   gpiolib_initialized);\n\tif (gpiolib_initialized) {\n\t\tret = gpiochip_setup_dev(gdev);\n\t\tA52_GPIOCORE_TRACE(gc, "GPIOCORE setup-dev exit rc=%d", ret);\n\t\tif (ret)\n\t\t\tgoto err_remove_irqchip;\n\t}\n\tA52_GPIOCORE_TRACE(gc, "GPIOCORE add success");\n\treturn 0;\n''',
+        'trace GPIO device setup and success',
+    )
+
+    path.write_text(text, encoding='utf-8')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path, required=True)
+    args = parser.parse_args()
+    patch_gpiochip_add(args.root / 'drivers/gpio/gpiolib.c')
+    print('phase189 Lagoon GPIO-core stage trace applied')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/189_ci.sh
+++ b/scripts/189_ci.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-pinctrl-stage-trace"
+OUT="$PWD/artifacts/a52xq-gpiolib-stage-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/188_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase189.config"
+cp "$ROOT/drivers/gpio/gpiolib.c" "$OUT/stage/gpiolib-before-phase189.c"
+
+python3 scripts/189_apply.py --root "$ROOT" | tee "$OUT/logs/phase189-apply.log"
+
+cp "$ROOT/drivers/gpio/gpiolib.c" "$OUT/stage/gpiolib-after-phase189.c"
+cp scripts/189_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase189.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+gpio = (root / 'drivers/gpio/gpiolib.c').read_text()
+dd = (root / 'drivers/base/dd.c').read_text()
+audit = (root / 'drivers/a52_secure/a52_display_bind_audit.c').read_text()
+markers = (
+    'GPIOCORE add enter',
+    'GPIOCORE of-add enter',
+    'GPIOCORE valid-init enter',
+    'GPIOCORE dir-scan enter',
+    'GPIOCORE dir-read enter pin=%u',
+    'GPIOCORE dir-read exit pin=%u rc=%d',
+    'GPIOCORE irq-add enter',
+    'GPIOCORE setup-dev enter',
+    'GPIOCORE add success',
+)
+for marker in markers:
+    assert marker in gpio, marker
+assert 'direction = gc->get_direction(gc, i);' in gpio
+assert 'trace_android_vh_gpio_block_read' in gpio
+assert 'DISP RP bypass' not in dd
+assert dd.count('a52_device_links_force_probe(dev, &kept, &dropped);') == 1
+assert 'retry_all(' not in audit
+assert 'device_attach(' not in audit
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase189-gpiolib-stage-trace.patch"
+test -s "$OUT/stage/phase189-gpiolib-stage-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase189-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase189-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase189-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase189-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/gpio/gpiolib.o' "$OUT/logs/phase189-compile.log"
+
+for marker in \
+  'PINCTRL gpio chip-add enter' \
+  'GPIOCORE add enter' \
+  'GPIOCORE of-add enter' \
+  'GPIOCORE valid-init enter' \
+  'GPIOCORE dir-scan enter' \
+  'GPIOCORE dir-read enter pin=%u' \
+  'GPIOCORE irq-add enter' \
+  'GPIOCORE add success'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+if grep -aFq 'DISP RP bypass' "$BUILD/arch/arm64/boot/Image"; then
+  echo 'forbidden display supplier-bypass marker remains in Image'
+  exit 1
+fi
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 189 Lagoon GPIO-core stage-trace candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase-188 hardware evidence:
+  - PDC and AMOLED provider initialization completed
+  - TLMM allocation, MMIO mapping, parent IRQ lookup and pinctrl registration completed
+  - wakeup-parent domain lookup and GPIO parent allocation completed
+  - the final persistent record was GPIO chip registration entry
+
+Phase 189 is instrumentation-only. It traces the generic 5.10 GPIO-core
+registration path, including OF registration, valid-mask setup, every eager GPIO
+direction read, pin ranges, IRQ-chip setup and GPIO device setup.
+
+TouchGrass does not eagerly read every GPIO direction during chip registration,
+while common 5.10 does. This candidate does not change that behavior yet. It
+identifies whether the reset occurs before the scan, at a specific GPIO register
+read, or later in IRQ/device registration.
+
+No DTB, panel command, timing, refresh mode, regulator voltage, supplier-link
+handling, ramdisk or recovery DTBO is changed. Compile-audited, not hardware
+validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-gpiolib-stage-trace')
+base = json.loads(Path('artifacts/a52xq-pinctrl-stage-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+gpio = (root / 'stage/gpiolib-after-phase189.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-gpiolib-stage-trace-audited',
+    'phase': 189,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase188': False,
+    'gpiolib_stage_trace_added': all(x in gpio for x in (
+        'GPIOCORE add enter', 'GPIOCORE of-add enter',
+        'GPIOCORE dir-read enter pin=%u', 'GPIOCORE irq-add enter',
+        'GPIOCORE add success')),
+    'eager_direction_read_behavior_preserved':
+        'direction = gc->get_direction(gc, i);' in gpio,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'gpiolib_stage_trace_added', 'eager_direction_read_behavior_preserved',
+    'dtb_preserved', 'ramdisk_preserved', 'recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase-188 hardware evidence

The untouched 1 MiB RAMOOPS snapshot from the phase-188 hardware test decoded 141 fresh mirrored records with no sequence gaps. The console persistent-RAM signature required one-bit recovery, while the ftrace signature was intact.

Confirmed completed stages:

- Lagoon PDC probe completed with `rc=0`
- QPNP AMOLED OLEDB/AB/IBB registration completed with `rc=0`
- normal display `-EPROBE_DEFER` handling remained intact
- Lagoon TLMM allocation and SoC setup completed
- MMIO resource mapping completed
- parent IRQ lookup returned IRQ 176
- pinctrl-core registration completed
- wakeup-parent domain lookup completed
- GPIO IRQ-parent allocation completed

The last persistent record is:

`PINCTRL gpio chip-add enter irq=176`

The persistent-RAM header reports 36,043 used bytes in a 256 KiB bank, so this was not recorder-capacity exhaustion.

## TouchGrass comparison

TouchGrass 4.19 initializes GPIO descriptor direction flags during `gpiochip_add_data_with_key()` without touching every GPIO register. Common 5.10 calls `gc->get_direction()` for every valid GPIO during the same registration path.

That is a real behavioral difference and a plausible fault source if one Lagoon GPIO register is secure, inaccessible or described incompatibly. However, phase 189 does not skip those reads yet.

## Phase 189

Instrumentation-only tracing inside the generic 5.10 GPIO core around:

- GPIO device allocation and OF initialization
- descriptor allocation and global list insertion
- GPIO line-name handling
- valid-mask allocation
- `of_gpiochip_add()`
- valid-mask initialization
- every eager `get_direction()` call, including exact GPIO index and return value
- pin-range registration
- IRQ valid-mask setup
- IRQ hardware initialization
- IRQ-chip registration
- GPIO device setup and final success

## Safety and scope

- no GPIO-core behavior changed
- eager direction reads remain enabled
- no DTB, panel command, timing, refresh mode or regulator voltage changed
- no supplier bypass or forced display retry restored
- normal `-EPROBE_DEFER` remains intact
- no ramdisk or recovery-DTBO change

The workflow reconstructs the full phase-188 chain, applies this trace only, compiles `drivers/gpio/gpiolib.o`, checks all safety invariants and recorder markers, repacks BOOT preserving non-kernel components, and runs all recorder decoder self-tests.

This PR is a draft and is not hardware validated.