### PR TITLE
Reserve Lagoon secure-fingerprint GPIOs 13-16

### DIFF
--- a/.github/workflows/190-a52-lagoon-fingerprint-gpio-reserve.yml
+++ b/.github/workflows/190-a52-lagoon-fingerprint-gpio-reserve.yml
@@ -1,0 +1,148 @@
+name: 190 - A52 Lagoon secure fingerprint GPIO reserve
+
+run-name: Build GKI 5.10 A52 Lagoon secure-fingerprint GPIO reserve candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-lagoon-fingerprint-gpio-reserve-v1
+    paths:
+      - .github/workflows/190-a52-lagoon-fingerprint-gpio-reserve.yml
+      - scripts/190_apply.py
+      - scripts/190_ci.sh
+      - scripts/189_apply.py
+      - scripts/189_ci.sh
+      - scripts/188_apply.py
+      - scripts/188_decode_near_header.py
+      - scripts/188_ci.sh
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+  pull_request:
+    branches:
+      - agent/a52-gpiolib-stage-trace-v1
+    paths:
+      - .github/workflows/190-a52-lagoon-fingerprint-gpio-reserve.yml
+      - scripts/190_apply.py
+      - scripts/190_ci.sh
+      - scripts/189_apply.py
+      - scripts/189_ci.sh
+      - scripts/188_apply.py
+      - scripts/188_decode_near_header.py
+      - scripts/188_ci.sh
+      - scripts/187_apply.py
+      - scripts/187_ci.sh
+      - scripts/186_apply.py
+      - scripts/186_ci.sh
+      - scripts/185_apply.py
+      - scripts/185_ci.sh
+      - scripts/183_apply.py
+      - scripts/183_ci.sh
+      - scripts/182_apply.py
+      - scripts/182_ci.sh
+      - scripts/181_apply.py
+      - scripts/181_ci.sh
+      - scripts/181_ci_v2.sh
+      - scripts/180_ci.sh
+      - scripts/180_apply.py
+      - scripts/180_payloads/**
+      - scripts/179_ci.sh
+      - scripts/179_payloads/**
+      - scripts/177_ci.sh
+      - scripts/177_ci_exact.sh
+      - scripts/177_patch_payload_chunks/**
+      - scripts/38_repack_a52_p1_boot.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-lagoon-fingerprint-gpio-reserve-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-190 Lagoon secure-fingerprint GPIO reserve candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-190 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, fix, trace, package and audit phase 190
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/190_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-lagoon-fingerprint-gpio-reserve-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-lagoon-fingerprint-gpio-reserve
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-190 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-lagoon-fingerprint-gpio-reserve-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-lagoon-fingerprint-gpio-reserve
+          if-no-files-found: error
+          retention-days: 30

--- a/RAMOOPS-PHASE189-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE189-HARDWARE-RESULT.md
@@ -1,0 +1,42 @@
+# A52 phase 189 hardware result
+
+Capture time: 2026-07-31 10:13 Asia/Jerusalem.
+
+The raw collector produced an untouched 1 MiB frozen RAMOOPS snapshot. The later
+raw export is byte-for-byte identical to the frozen copy. The ZIP command
+reported return code 4, but the resulting archive is readable and contains both
+raw images and the pstore evidence.
+
+The near-header Reed-Solomon decoder recovered 166 consecutive records,
+sequences 17 through 182, with no gaps in that recovered range. The console
+persistent-RAM signature required the same one-bit repair used in phase 188. The
+ftrace signature was intact.
+
+GPIO-core registration completed these stages:
+
+- GPIO device and descriptor allocation
+- global GPIO list insertion
+- line-name setup
+- valid-mask allocation
+- OF GPIO-chip registration
+- valid-mask initialization
+- direction-scan entry
+
+Every eager direction read from GPIO 0 through GPIO 12 returned normally with
+`rc=1`. The final persistent record is:
+
+`GPIOCORE dir-read enter pin=13`
+
+There is no matching `GPIOCORE dir-read exit pin=13 ...` record. The stop is
+therefore inside the Lagoon `get_direction()` MMIO access for GPIO 13, whose
+control-register offset is `0x0d000` from the TLMM base.
+
+The Lagoon vendor source already groups GPIOs 13-16 under the secure-fingerprint
+reservation. In the GKI reconstruction, the Samsung-only
+`CONFIG_FINGERPRINT_SECURE` and `CONFIG_SEC_FACTORY` symbols are absent, so that
+reservation compiles out and generic Linux 5.10 attempts to read GPIO 13 during
+`gpiochip_add_data_with_key()`.
+
+Phase 190 should restore the reservation for GPIOs 13-16 independently of those
+Samsung-only Kconfig symbols, while retaining the phase-189 trace. The expected
+next trace is pin 12 exit followed by pin 17 entry, with pins 13-16 skipped.

--- a/RAMOOPS-PHASE190-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE190-HARDWARE-RESULT.md
@@ -1,0 +1,46 @@
+# Phase 190 hardware result
+
+Capture: 2026-07-31 11:46 Asia/Jerusalem
+
+The early frozen and later raw RAMOOPS images are both 1,048,576 bytes and are byte-for-byte identical. The mirrored recorder decoded 816 records, with the final heartbeat at 61,468.096 ms.
+
+## GPIO result
+
+The phase-190 reservation is active:
+
+`PINCTRL Lagoon reserved secure=13-16`
+
+The scan completed GPIO 12 and resumed at GPIO 17. No reads were issued for GPIOs 13-16. GPIOs 86 and 87 both returned normally.
+
+GPIO and TLMM registration completed:
+
+- `GPIOCORE dir-scan exit`
+- `GPIOCORE add success`
+- `PINCTRL gpio chip-add exit rc=0`
+- `PINCTRL msm probe exit rc=0`
+- `PINCTRL Lagoon probe exit rc=0 bound=lagoon-pinctrl`
+
+Phase 190 therefore fixes the GPIO 13 boot blocker.
+
+## New hardware state
+
+The device no longer enters the previous early crash/reset state. It remains alive for at least 61 seconds, reaches `BOOT_READY`, and records Android userspace QSEE/ION activity. The user observed an initially distorted Samsung logo, followed by a black screen after about 20 seconds, and then manually forced a restart.
+
+There is no panic, watchdog reset, synchronous abort, or kernel hang in the capture.
+
+## Display finding
+
+Display platform probes completed, but none of the existing lifecycle scopes for the aggregate DRM pipeline were recorded, including:
+
+- `msm_drm_bind`
+- `msm_drm_init`
+- `dsi_display_bind`
+- `dsi_display_drm_bridge_init`
+- `dsi_bridge_attach`
+- `sde_kms_init`
+- `sde_kms_prepare_commit`
+- `sde_kms_commit`
+- `dsi_panel_drv_init`
+- `ss_panel_init`
+
+The platform devices probed, but the DRM component master did not assemble and call its bind callback. The next phase must trace component-match construction and the component framework. It should not change panel commands, reset timing, clocks, regulators, backlight, or display modes yet.

--- a/scripts/190_NOTES.txt
+++ b/scripts/190_NOTES.txt
@@ -1,0 +1,16 @@
+Phase 190 is the narrow functional response to phase 189 hardware evidence.
+
+Recovered phase-189 records are consecutive from sequence 17 through 182. GPIO
+registration reached the eager direction scan. GPIOs 0-12 returned rc=1. The
+final record is `GPIOCORE dir-read enter pin=13`; there is no matching exit.
+
+The Lagoon vendor table already identifies GPIOs 13-16 as secure-fingerprint
+reserved lines, but only when Samsung-only Kconfig symbols are defined. Those
+symbols are absent from the reconstructed common GKI configuration, so the valid
+mask incorrectly exposed the secure lines to generic 5.10 registration-time
+MMIO reads.
+
+This phase reserves only GPIOs 13-16 unconditionally for this Lagoon port. It
+keeps the phase-189 trace and all runtime GPIO direction operations for valid
+lines. GPIOs 86-87 remain conditional because the hardware evidence has not yet
+reached them.

--- a/scripts/190_apply.py
+++ b/scripts/190_apply.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_lagoon(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    old_reserved = '''static const int lagoon_reserved_gpios[] = {
+#if defined(CONFIG_FINGERPRINT_SECURE) && !defined(CONFIG_SEC_FACTORY)
+\t13, 14, 15, 16,
+#endif
+#if defined(CONFIG_MST_LDO)
+        86, 87,
+#endif
+\t-1
+};
+'''
+    new_reserved = '''static const int lagoon_reserved_gpios[] = {
+\t/*
+\t * The A52 production firmware owns the secure-fingerprint TLMM lines.
+\t * Phase 189 stopped synchronously on the first registration-time read of
+\t * GPIO 13. Keep the vendor reservation even though the downstream Samsung
+\t * fingerprint Kconfig symbols are not available in this GKI source tree.
+\t */
+\t13, 14, 15, 16,
+#if defined(CONFIG_MST_LDO)
+        86, 87,
+#endif
+\t-1
+};
+'''
+    text = one(
+        text,
+        old_reserved,
+        new_reserved,
+        "reserve secure fingerprint GPIOs independently of Samsung Kconfig",
+    )
+
+    old_probe = '''static int lagoon_pinctrl_probe(struct platform_device *pdev)
+{
+\tint rc;
+
+\ta52_ackfr_record("PINCTRL Lagoon probe enter dev=%s node=%s",
+'''
+    new_probe = '''static int lagoon_pinctrl_probe(struct platform_device *pdev)
+{
+\tint rc;
+
+\ta52_ackfr_record("PINCTRL Lagoon reserved secure=13-16");
+\ta52_ackfr_record("PINCTRL Lagoon probe enter dev=%s node=%s",
+'''
+    text = one(text, old_probe, new_probe, "add phase190 reservation marker")
+
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+    patch_lagoon(args.root / "drivers/pinctrl/qcom/pinctrl-lagoon.c")
+    print("phase190 Lagoon secure-fingerprint GPIO reservation applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/190_ci.sh
+++ b/scripts/190_ci.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-gpiolib-stage-trace"
+OUT="$PWD/artifacts/a52xq-lagoon-fingerprint-gpio-reserve"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/189_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase190.config"
+cp "$ROOT/drivers/pinctrl/qcom/pinctrl-lagoon.c" \
+  "$OUT/stage/pinctrl-lagoon-before-phase190.c"
+
+python3 scripts/190_apply.py --root "$ROOT" | tee "$OUT/logs/phase190-apply.log"
+
+cp "$ROOT/drivers/pinctrl/qcom/pinctrl-lagoon.c" \
+  "$OUT/stage/pinctrl-lagoon-after-phase190.c"
+cp scripts/190_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase190.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+lagoon = (root / 'drivers/pinctrl/qcom/pinctrl-lagoon.c').read_text()
+gpio = (root / 'drivers/gpio/gpiolib.c').read_text()
+dd = (root / 'drivers/base/dd.c').read_text()
+audit = (root / 'drivers/a52_secure/a52_display_bind_audit.c').read_text()
+reserved = lagoon.split('static const int lagoon_reserved_gpios[] = {', 1)[1].split('};', 1)[0]
+assert '13, 14, 15, 16,' in reserved
+assert 'CONFIG_FINGERPRINT_SECURE' not in reserved
+assert 'CONFIG_SEC_FACTORY' not in reserved
+assert 'PINCTRL Lagoon reserved secure=13-16' in lagoon
+assert 'GPIOCORE dir-read enter pin=%u' in gpio
+assert 'direction = gc->get_direction(gc, i);' in gpio
+assert 'DISP RP bypass' not in dd
+assert dd.count('a52_device_links_force_probe(dev, &kept, &dropped);') == 1
+assert 'retry_all(' not in audit
+assert 'device_attach(' not in audit
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase190-lagoon-fingerprint-gpio-reserve.patch"
+test -s "$OUT/stage/phase190-lagoon-fingerprint-gpio-reserve.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase190-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase190-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase190-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase190-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/pinctrl/qcom/pinctrl-lagoon.o' \
+  "$OUT/logs/phase190-compile.log"
+
+for marker in \
+  'PINCTRL Lagoon reserved secure=13-16' \
+  'GPIOCORE dir-scan enter' \
+  'GPIOCORE dir-read enter pin=%u' \
+  'GPIOCORE dir-read exit pin=%u rc=%d'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+if grep -aFq 'DISP RP bypass' "$BUILD/arch/arm64/boot/Image"; then
+  echo 'forbidden display supplier-bypass marker remains in Image'
+  exit 1
+fi
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 190 Lagoon secure-fingerprint GPIO reservation candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase-189 hardware evidence:
+  - generic GPIO-core setup completed through valid-mask initialization
+  - eager direction reads succeeded for GPIOs 0 through 12
+  - the final persistent record was GPIOCORE dir-read enter pin=13
+  - no matching pin=13 exit record was written
+
+Phase 190 restores the vendor reservation for secure-fingerprint GPIOs 13-16
+without relying on Samsung-only Kconfig symbols that are absent from the GKI
+source tree. The phase-189 GPIO-core trace remains enabled.
+
+Expected proof in the next RAMOOPS capture:
+  - PINCTRL Lagoon reserved secure=13-16
+  - GPIOCORE dir-read exit pin=12 rc=...
+  - the scan skips pins 13-16
+  - GPIOCORE dir-read enter pin=17
+
+This candidate does not disable runtime get_direction(), does not skip the full
+GPIO direction scan, and does not change the DTB, panel commands, display timing,
+refresh modes, regulator voltages, ramdisk or recovery DTBO. Compile-audited,
+not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-lagoon-fingerprint-gpio-reserve')
+base = json.loads(Path('artifacts/a52xq-gpiolib-stage-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+lagoon = (root / 'stage/pinctrl-lagoon-after-phase190.c').read_text()
+gpio = (root / 'stage/gpiolib-after-phase189.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+reserved = lagoon.split('static const int lagoon_reserved_gpios[] = {', 1)[1].split('};', 1)[0]
+audit = dict(base)
+audit.update({
+    'status': 'a52-lagoon-fingerprint-gpio-reserve-audited',
+    'phase': 190,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase189': True,
+    'phase189_last_record': 'GPIOCORE dir-read enter pin=13',
+    'secure_fingerprint_gpios_reserved':
+        '13, 14, 15, 16,' in reserved and
+        'CONFIG_FINGERPRINT_SECURE' not in reserved,
+    'phase189_gpiolib_trace_preserved':
+        'GPIOCORE dir-read enter pin=%u' in gpio,
+    'runtime_get_direction_preserved':
+        'direction = gc->get_direction(gc, i);' in gpio,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'secure_fingerprint_gpios_reserved',
+    'phase189_gpiolib_trace_preserved',
+    'runtime_get_direction_preserved',
+    'dtb_preserved',
+    'ramdisk_preserved',
+    'recovery_dtbo_preserved',
+):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(
+    json.dumps(audit, indent=2, sort_keys=True) + '\n'
+)
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase-189 hardware evidence

The untouched 1 MiB RAMOOPS capture from 2026-07-31 10:13 Asia/Jerusalem decoded 166 consecutive records from sequence 17 through 182 with no gaps in that recovered range.

GPIO-core registration completed allocation, OF registration and valid-mask initialization. Eager direction reads returned normally for GPIOs 0 through 12. The final persistent record is:

`GPIOCORE dir-read enter pin=13`

There is no matching exit record, so execution stops inside the Lagoon `get_direction()` MMIO read for GPIO 13 at TLMM offset `0x0d000`.

## Root cause

The Lagoon vendor table already reserves GPIOs 13-16 for secure fingerprint, but that reservation is guarded by Samsung-only `CONFIG_FINGERPRINT_SECURE` and `CONFIG_SEC_FACTORY` symbols. Those symbols are absent from the reconstructed common GKI configuration, so generic Linux 5.10 incorrectly treats the secure lines as valid and reads GPIO 13 during `gpiochip_add_data_with_key()`.

## Phase 190 change

- reserve GPIOs 13-16 unconditionally in this Lagoon GKI port
- retain the existing conditional handling for MST GPIOs 86-87
- preserve phase-189 GPIO-core tracing
- preserve runtime `get_direction()` behavior for every valid GPIO
- add a persistent marker confirming the secure reservation is compiled in

Expected hardware proof is a scan that exits pin 12 and resumes at pin 17, skipping pins 13-16.

## Safety and scope

- no full GPIO direction-scan bypass
- no removal of `get_direction()`
- no DTB, panel command, timing, refresh-mode or regulator-voltage change
- no supplier bypass or forced display retry
- normal `-EPROBE_DEFER` remains intact
- no ramdisk or recovery-DTBO change

The workflow rebuilds the complete phase-189 chain, applies only this narrow reservation fix, compiles and audits the kernel, repacks BOOT while preserving non-kernel components, and runs all recorder decoder self-tests.

This PR is a draft and is not hardware validated.