### PR TITLE
Trace A52 SDE RSCC registration and probe

### DIFF
--- a/.github/workflows/192-a52-sde-rscc-probe-trace.yml
+++ b/.github/workflows/192-a52-sde-rscc-probe-trace.yml
@@ -1,0 +1,98 @@
+name: 192 - A52 GKI 5.10 SDE RSCC probe trace
+
+run-name: Build GKI 5.10 A52 SDE RSCC probe trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-sde-rscc-probe-trace-v1
+    paths:
+      - .github/workflows/192-a52-sde-rscc-probe-trace.yml
+      - scripts/192_apply.py
+      - scripts/192_ci.sh
+      - scripts/192_NOTES.txt
+      - RAMOOPS-PHASE191-HARDWARE-RESULT.md
+  pull_request:
+    branches:
+      - agent/a52-display-component-trace-v2
+    paths:
+      - .github/workflows/192-a52-sde-rscc-probe-trace.yml
+      - scripts/192_apply.py
+      - scripts/192_ci.sh
+      - scripts/192_NOTES.txt
+      - RAMOOPS-PHASE191-HARDWARE-RESULT.md
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-sde-rscc-probe-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-192 SDE RSCC probe trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-192 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 192
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/192_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-sde-rscc-probe-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-sde-rscc-probe-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-192 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-sde-rscc-probe-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-sde-rscc-probe-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/RAMOOPS-PHASE191-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE191-HARDWARE-RESULT.md
@@ -1,0 +1,53 @@
+# Phase 191 hardware result
+
+## Evidence integrity
+
+The 2026-07-31 capture preserved identical early and later 1 MiB RAMOOPS snapshots. Both have SHA-256 `e6bea10f71d9435ff4441e8a6d48cd85df0fcd2d85c7ce0f5479f0580e3d05f9`.
+
+The exact phase 191 Reed-Solomon decoder recovered 810 records. `BOOT_READY` was reached and the kernel heartbeat continued through 62.496 seconds, so this remained a live black-screen boot rather than a kernel crash.
+
+## Component result
+
+The active SDE `connectors` list contains:
+
+1. `qcom,wb-display@0`
+2. `qcom,dsi-display-primary`
+3. `qcom,sde_rscc`
+4. `qcom,dp_display@ae90000`
+
+DisplayPort is intentionally skipped when `CONFIG_SEC_DISPLAYPORT` is disabled. The component master therefore has three match slots.
+
+At master registration:
+
+```text
+COMP slot i=0 found=1 dev=soc:qcom,wb-display@0 bound=0 dup=0
+COMP slot i=1 found=0 dev=- bound=0 dup=0
+COMP slot i=2 found=0 dev=- bound=0 dup=0
+```
+
+After primary DSI successfully probes and calls `component_add()`:
+
+```text
+COMP slot i=1 found=1 dev=soc:qcom,dsi-display-primary bound=0 dup=0
+COMP slot i=2 found=0 dev=- bound=0 dup=0
+```
+
+The only missing component is slot 2, `qcom,sde_rscc`, compatible `qcom,sde-rsc`.
+
+## Consequence
+
+Because RSCC never registers as a component, the component framework never invokes the DRM master bind callback. KMS initialization, DSI bridge attach, panel prepare/enable, backlight enable and atomic display commits do not run.
+
+## Phase 192 scope
+
+Instrument `drivers/a52_display/msm/sde_rsc.c` only:
+
+- RPMh and main RSCC driver registration
+- DT node and platform-device presence
+- RPMh child probe
+- every main probe stage and exact failure code
+- cleanup
+- `component_add()`
+- component bind
+
+Do not force a retry, change an errno, bypass RSCC, remove it from the component list, or modify display hardware behavior yet.

--- a/scripts/192_NOTES.txt
+++ b/scripts/192_NOTES.txt
@@ -1,0 +1,21 @@
+Phase 192: SDE RSCC registration and probe trace
+
+Hardware evidence from phase 191:
+- DRM component match slot 0 (writeback) was found.
+- Match slot 1 became found when primary DSI called component_add().
+- Match slot 2 remained missing.
+- Slot 2 maps to qcom,sde_rscc, compatible qcom,sde-rsc.
+- The kernel remained alive through 62.496 seconds behind a black screen.
+
+Scope:
+- instrument sde_rsc.c only
+- record RPMh and main driver registration
+- record DT/platform-device presence and current binding
+- record each RPMh and main probe stage
+- record cleanup, component_add, and component bind
+
+No behavior change:
+- no forced probe
+- no errno conversion
+- no component-list bypass
+- no panel, clock, regulator, reset, mode, DTB, ramdisk, or recovery-DTBO change

--- a/scripts/192_apply.py
+++ b/scripts/192_apply.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_sde_rsc(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    text = one(
+        text,
+        '#include <linux/msm-bus.h>\n',
+        '#include <linux/msm-bus.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'add RSCC recorder include',
+    )
+
+    old = '''static struct sde_rsc_priv *rsc_prv_list[MAX_RSC_COUNT];
+static struct device *rpmh_dev[MAX_RSC_COUNT];
+'''
+    new = '''static struct sde_rsc_priv *rsc_prv_list[MAX_RSC_COUNT];
+static struct device *rpmh_dev[MAX_RSC_COUNT];
+
+static void a52_rscc_record_registration_state(const char *stage,
+\t\t\t\t\t       const char *compatible)
+{
+\tstruct device_node *np;
+\tstruct platform_device *pdev;
+\tconst char *bound = "-";
+
+\tnp = of_find_compatible_node(NULL, NULL, compatible);
+\tpdev = np ? of_find_device_by_node(np) : NULL;
+\tif (pdev && pdev->dev.driver && pdev->dev.driver->name)
+\t\tbound = pdev->dev.driver->name;
+\ta52_ackfr_record("RSCC state=%s compat=%s node=%u pdev=%u bound=%s",
+\t\t\t stage, compatible, !!np, !!pdev, bound);
+\tif (pdev)
+\t\tput_device(&pdev->dev);
+\tof_node_put(np);
+}
+'''
+    text = one(text, old, new, 'add RSCC registration-state helper')
+
+    old = '''static int sde_rsc_bind(struct device *dev,
+\t\tstruct device *master,
+\t\tvoid *data)
+{
+\tstruct sde_rsc_priv *rsc;
+\tstruct drm_device *drm;
+\tstruct platform_device *pdev = to_platform_device(dev);
+
+\tif (!dev || !pdev || !master) {
+'''
+    new = '''static int sde_rsc_bind(struct device *dev,
+\t\tstruct device *master,
+\t\tvoid *data)
+{
+\tstruct sde_rsc_priv *rsc;
+\tstruct drm_device *drm;
+\tstruct platform_device *pdev = to_platform_device(dev);
+
+\ta52_ackfr_record("RSCC bind enter dev=%s master=%s",
+\t\t\t dev ? dev_name(dev) : "-",
+\t\t\t master ? dev_name(master) : "-");
+\tif (!dev || !pdev || !master) {
+\t\ta52_ackfr_record("RSCC bind exit rc=%d stage=args", -EINVAL);
+'''
+    text = one(text, old, new, 'trace RSCC bind entry')
+
+    old = '''\tif (!drm || !rsc) {
+\t\tpr_err("invalid param(s), drm %pK, rsc %pK\\n",
+\t\t\t\tdrm, rsc);
+\t\treturn -EINVAL;
+\t}
+'''
+    new = '''\tif (!drm || !rsc) {
+\t\tpr_err("invalid param(s), drm %pK, rsc %pK\\n",
+\t\t\t\tdrm, rsc);
+\t\ta52_ackfr_record("RSCC bind exit rc=%d stage=drvdata drm=%u rsc=%u",
+\t\t\t\t   -EINVAL, !!drm, !!rsc);
+\t\treturn -EINVAL;
+\t}
+'''
+    text = one(text, old, new, 'trace RSCC bind drvdata failure')
+
+    old = '''\tsde_dbg_reg_register_base(SDE_RSC_WRAPPER_DBG_NAME,
+\t\t\t\trsc->wrapper_io.base, rsc->wrapper_io.len);
+\treturn 0;
+}
+'''
+    new = '''\tsde_dbg_reg_register_base(SDE_RSC_WRAPPER_DBG_NAME,
+\t\t\t\trsc->wrapper_io.base, rsc->wrapper_io.len);
+\ta52_ackfr_record("RSCC bind exit rc=0");
+\treturn 0;
+}
+'''
+    text = one(text, old, new, 'trace RSCC bind success')
+
+    old = '''static int sde_rsc_probe(struct platform_device *pdev)
+{
+\tint ret;
+\tstruct sde_rsc_priv *rsc;
+\tstatic int counter;
+\tchar  name[MAX_RSC_CLIENT_NAME_LEN];
+
+\tif (counter >= MAX_RSC_COUNT) {
+'''
+    new = '''static int sde_rsc_probe(struct platform_device *pdev)
+{
+\tint ret;
+\tint stage_rc = 0;
+\tconst char *stage = "enter";
+\tstruct sde_rsc_priv *rsc;
+\tstatic int counter;
+\tchar  name[MAX_RSC_CLIENT_NAME_LEN];
+
+\ta52_ackfr_record("RSCC probe enter dev=%s node=%s counter=%d rpmh=%u",
+\t\t\t dev_name(&pdev->dev),
+\t\t\t pdev->dev.of_node ? pdev->dev.of_node->full_name : "-",
+\t\t\t counter, counter < MAX_RSC_COUNT &&
+\t\t\t !!rpmh_dev[SDE_RSC_INDEX + counter]);
+\tif (counter >= MAX_RSC_COUNT) {
+\t\ta52_ackfr_record("RSCC probe exit rc=%d stage=max-count", -EINVAL);
+'''
+    text = one(text, old, new, 'trace RSCC probe entry')
+
+    old = '''\trsc = kzalloc(sizeof(*rsc), GFP_KERNEL);
+\tif (!rsc) {
+\t\tret = -ENOMEM;
+\t\tgoto rsc_alloc_fail;
+\t}
+'''
+    new = '''\tstage = "alloc";
+\trsc = kzalloc(sizeof(*rsc), GFP_KERNEL);
+\tif (!rsc) {
+\t\tret = -ENOMEM;
+\t\tstage_rc = ret;
+\t\ta52_ackfr_record("RSCC probe stage=alloc rc=%d", ret);
+\t\tgoto rsc_alloc_fail;
+\t}
+\ta52_ackfr_record("RSCC probe stage=alloc rc=0");
+'''
+    text = one(text, old, new, 'trace RSCC allocation')
+
+    old = '''\tof_property_read_u32(pdev->dev.of_node, "qcom,sde-rsc-version",
+\t\t\t\t\t\t\t\t&rsc->version);
+
+\tif (rsc->version == SDE_RSC_REV_2)
+'''
+    new = '''\tof_property_read_u32(pdev->dev.of_node, "qcom,sde-rsc-version",
+\t\t\t\t\t\t\t\t&rsc->version);
+\ta52_ackfr_record("RSCC probe stage=version value=%u", rsc->version);
+
+\tif (rsc->version == SDE_RSC_REV_2)
+'''
+    text = one(text, old, new, 'trace RSCC version')
+
+    old = '''\tret = sde_power_resource_init(pdev, &rsc->phandle);
+\tif (ret) {
+\t\tpr_err("sde rsc:power resource init failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\trsc->rpmh_dev = rpmh_dev[SDE_RSC_INDEX + counter];
+'''
+    new = '''\tstage = "power-init";
+\tret = sde_power_resource_init(pdev, &rsc->phandle);
+\tstage_rc = ret;
+\ta52_ackfr_record("RSCC probe stage=power-init rc=%d", ret);
+\tif (ret) {
+\t\tpr_err("sde rsc:power resource init failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tstage = "rpmh-link";
+\trsc->rpmh_dev = rpmh_dev[SDE_RSC_INDEX + counter];
+'''
+    text = one(text, old, new, 'trace RSCC power init')
+
+    old = '''\tif (IS_ERR_OR_NULL(rsc->rpmh_dev)) {
+\t\tret = !rsc->rpmh_dev ? -EINVAL : PTR_ERR(rsc->rpmh_dev);
+\t\trsc->rpmh_dev = NULL;
+\t\tpr_err("rpmh device node is not available ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tret = msm_dss_ioremap_byname(pdev, &rsc->wrapper_io, "wrapper");
+'''
+    new = '''\tif (IS_ERR_OR_NULL(rsc->rpmh_dev)) {
+\t\tret = !rsc->rpmh_dev ? -EINVAL : PTR_ERR(rsc->rpmh_dev);
+\t\tstage_rc = ret;
+\t\ta52_ackfr_record("RSCC probe stage=rpmh-link rc=%d present=%u",
+\t\t\t\t   ret, !!rsc->rpmh_dev);
+\t\trsc->rpmh_dev = NULL;
+\t\tpr_err("rpmh device node is not available ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+\ta52_ackfr_record("RSCC probe stage=rpmh-link rc=0 dev=%s",
+\t\t\t dev_name(rsc->rpmh_dev));
+
+\tstage = "map-wrapper";
+\tret = msm_dss_ioremap_byname(pdev, &rsc->wrapper_io, "wrapper");
+'''
+    text = one(text, old, new, 'trace RSCC RPMh link')
+
+    old = '''\tif (ret) {
+\t\tpr_err("sde rsc: wrapper io data mapping failed ret=%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tret = msm_dss_ioremap_byname(pdev, &rsc->drv_io, "drv");
+'''
+    new = '''\tstage_rc = ret;
+\ta52_ackfr_record("RSCC probe stage=map-wrapper rc=%d", ret);
+\tif (ret) {
+\t\tpr_err("sde rsc: wrapper io data mapping failed ret=%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tstage = "map-drv";
+\tret = msm_dss_ioremap_byname(pdev, &rsc->drv_io, "drv");
+'''
+    text = one(text, old, new, 'trace RSCC wrapper map')
+
+    old = '''\tif (ret) {
+\t\tpr_err("sde rsc: drv io data mapping failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\trsc->fs = devm_regulator_get(&pdev->dev, "vdd");
+\tif (IS_ERR_OR_NULL(rsc->fs)) {
+\t\trsc->fs = NULL;
+\t\tpr_err("unable to get regulator\\n");
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tif (rsc->version >= SDE_RSC_REV_3)
+'''
+    new = '''\tstage_rc = ret;
+\ta52_ackfr_record("RSCC probe stage=map-drv rc=%d", ret);
+\tif (ret) {
+\t\tpr_err("sde rsc: drv io data mapping failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tstage = "get-vdd";
+\trsc->fs = devm_regulator_get(&pdev->dev, "vdd");
+\tif (IS_ERR_OR_NULL(rsc->fs)) {
+\t\tstage_rc = rsc->fs ? PTR_ERR(rsc->fs) : -ENODEV;
+\t\ta52_ackfr_record("RSCC probe stage=get-vdd rc=%d", stage_rc);
+\t\trsc->fs = NULL;
+\t\tpr_err("unable to get regulator\\n");
+\t\tgoto sde_rsc_fail;
+\t}
+\ta52_ackfr_record("RSCC probe stage=get-vdd rc=0");
+
+\tstage = "hw-register";
+\tif (rsc->version >= SDE_RSC_REV_3)
+'''
+    text = one(text, old, new, 'trace RSCC driver map and regulator')
+
+    old = '''\tif (ret) {
+\t\tpr_err("sde rsc: hw register failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tret = regulator_enable(rsc->fs);
+'''
+    new = '''\tstage_rc = ret;
+\ta52_ackfr_record("RSCC probe stage=hw-register rc=%d", ret);
+\tif (ret) {
+\t\tpr_err("sde rsc: hw register failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tstage = "vdd-enable";
+\tret = regulator_enable(rsc->fs);
+'''
+    text = one(text, old, new, 'trace RSCC hardware registration')
+
+    old = '''\tif (ret) {
+\t\tpr_err("sde rsc: fs on failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\trsc->sw_fs_enabled = true;
+
+\tret = sde_rsc_resource_enable(rsc);
+'''
+    new = '''\tstage_rc = ret;
+\ta52_ackfr_record("RSCC probe stage=vdd-enable rc=%d", ret);
+\tif (ret) {
+\t\tpr_err("sde rsc: fs on failed ret:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\trsc->sw_fs_enabled = true;
+
+\tstage = "resource-enable";
+\tret = sde_rsc_resource_enable(rsc);
+'''
+    text = one(text, old, new, 'trace RSCC regulator enable')
+
+    old = '''\tif (ret < 0) {
+\t\tpr_err("failed to enable sde rsc power resources rc:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tif (sde_rsc_timer_calculate(rsc, NULL, SDE_RSC_IDLE_STATE))
+\t\tgoto sde_rsc_fail;
+
+\tsde_rsc_resource_disable(rsc);
+'''
+    new = '''\tstage_rc = ret;
+\ta52_ackfr_record("RSCC probe stage=resource-enable rc=%d", ret);
+\tif (ret < 0) {
+\t\tpr_err("failed to enable sde rsc power resources rc:%d\\n", ret);
+\t\tgoto sde_rsc_fail;
+\t}
+
+\tstage = "timer-calc";
+\tstage_rc = sde_rsc_timer_calculate(rsc, NULL, SDE_RSC_IDLE_STATE);
+\ta52_ackfr_record("RSCC probe stage=timer-calc rc=%d", stage_rc);
+\tif (stage_rc)
+\t\tgoto sde_rsc_fail;
+
+\tsde_rsc_resource_disable(rsc);
+\ta52_ackfr_record("RSCC probe stage=resource-disable done=1");
+'''
+    text = one(text, old, new, 'trace RSCC resource and timer stages')
+
+    old = '''\tret = component_add(&pdev->dev, &sde_rsc_comp_ops);
+\tif (ret)
+\t\tpr_debug("component add failed, ret=%d\\n", ret);
+\tret = 0;
+
+\treturn ret;
+
+sde_rsc_fail:
+\tsde_rsc_deinit(pdev, rsc);
+rsc_alloc_fail:
+\treturn ret;
+'''
+    new = '''\tstage = "component-add";
+\ta52_ackfr_record("RSCC component-add enter dev=%s",
+\t\t\t dev_name(&pdev->dev));
+\tret = component_add(&pdev->dev, &sde_rsc_comp_ops);
+\tstage_rc = ret;
+\ta52_ackfr_record("RSCC component-add exit rc=%d", ret);
+\tif (ret)
+\t\tpr_debug("component add failed, ret=%d\\n", ret);
+\tret = 0;
+
+\ta52_ackfr_record("RSCC probe exit rc=0 component_rc=%d counter=%d",
+\t\t\t stage_rc, counter);
+\treturn ret;
+
+sde_rsc_fail:
+\ta52_ackfr_record("RSCC probe fail stage=%s stage_rc=%d return_rc=%d",
+\t\t\t stage, stage_rc, ret);
+\ta52_ackfr_record("RSCC cleanup enter stage=%s", stage);
+\tsde_rsc_deinit(pdev, rsc);
+\ta52_ackfr_record("RSCC cleanup exit stage=%s", stage);
+rsc_alloc_fail:
+\ta52_ackfr_record("RSCC probe exit rc=%d stage=%s stage_rc=%d",
+\t\t\t ret, stage, stage_rc);
+\treturn ret;
+'''
+    text = one(text, old, new, 'trace RSCC component add and failure')
+
+    old = '''static int sde_rsc_rpmh_probe(struct platform_device *pdev)
+{
+\tint ret = 0;
+\tuint32_t index = 0;
+
+\tret = of_property_read_u32(pdev->dev.of_node, "cell-index", &index);
+'''
+    new = '''static int sde_rsc_rpmh_probe(struct platform_device *pdev)
+{
+\tint ret = 0;
+\tuint32_t index = 0;
+
+\ta52_ackfr_record("RSCC rpmh-probe enter dev=%s node=%s",
+\t\t\t dev_name(&pdev->dev),
+\t\t\t pdev->dev.of_node ? pdev->dev.of_node->full_name : "-");
+\tret = of_property_read_u32(pdev->dev.of_node, "cell-index", &index);
+'''
+    text = one(text, old, new, 'trace RSCC RPMh probe entry')
+
+    old = '''\tif (ret) {
+\t\tpr_err("unable to find sde rsc cell index\\n");
+\t\treturn ret;
+\t} else if (index >= MAX_RSC_COUNT) {
+\t\tpr_err("invalid cell index for sde rsc:%d\\n", index);
+\t\treturn -EINVAL;
+\t}
+
+\trpmh_dev[index] = &pdev->dev;
+\treturn 0;
+'''
+    new = '''\tif (ret) {
+\t\tpr_err("unable to find sde rsc cell index\\n");
+\t\ta52_ackfr_record("RSCC rpmh-probe exit rc=%d stage=cell-index", ret);
+\t\treturn ret;
+\t} else if (index >= MAX_RSC_COUNT) {
+\t\tpr_err("invalid cell index for sde rsc:%d\\n", index);
+\t\ta52_ackfr_record("RSCC rpmh-probe exit rc=%d index=%u",
+\t\t\t\t   -EINVAL, index);
+\t\treturn -EINVAL;
+\t}
+
+\trpmh_dev[index] = &pdev->dev;
+\ta52_ackfr_record("RSCC rpmh-probe exit rc=0 index=%u dev=%s",
+\t\t\t index, dev_name(&pdev->dev));
+\treturn 0;
+'''
+    text = one(text, old, new, 'trace RSCC RPMh probe result')
+
+    old = '''static int __init sde_rsc_register(void)
+{
+\treturn platform_driver_register(&sde_rsc_platform_driver);
+}
+'''
+    new = '''static int __init sde_rsc_register(void)
+{
+\tint ret;
+
+\ta52_ackfr_record("RSCC main-register enter");
+\ta52_rscc_record_registration_state("main-before", "qcom,sde-rsc");
+\tret = platform_driver_register(&sde_rsc_platform_driver);
+\ta52_ackfr_record("RSCC main-register exit rc=%d", ret);
+\ta52_rscc_record_registration_state("main-after", "qcom,sde-rsc");
+\treturn ret;
+}
+'''
+    text = one(text, old, new, 'trace RSCC main driver registration')
+
+    old = '''static int __init sde_rsc_rpmh_register(void)
+{
+\treturn platform_driver_register(&sde_rsc_rpmh_driver);
+}
+'''
+    new = '''static int __init sde_rsc_rpmh_register(void)
+{
+\tint ret;
+
+\ta52_ackfr_record("RSCC rpmh-register enter");
+\ta52_rscc_record_registration_state("rpmh-before", "qcom,sde-rsc-rpmh");
+\tret = platform_driver_register(&sde_rsc_rpmh_driver);
+\ta52_ackfr_record("RSCC rpmh-register exit rc=%d", ret);
+\ta52_rscc_record_registration_state("rpmh-after", "qcom,sde-rsc-rpmh");
+\treturn ret;
+}
+'''
+    text = one(text, old, new, 'trace RSCC RPMh driver registration')
+
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path, required=True)
+    args = parser.parse_args()
+    patch_sde_rsc(args.root / 'drivers/a52_display/msm/sde_rsc.c')
+    print('phase192 SDE RSCC registration and probe trace applied')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/192_ci.sh
+++ b/scripts/192_ci.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-display-component-trace"
+OUT="$PWD/artifacts/a52xq-sde-rscc-probe-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/191_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase192.config"
+cp "$ROOT/drivers/a52_display/msm/sde_rsc.c" "$OUT/stage/sde-rsc-before-phase192.c"
+
+python3 scripts/192_apply.py --root "$ROOT" | tee "$OUT/logs/phase192-apply.log"
+
+cp "$ROOT/drivers/a52_display/msm/sde_rsc.c" "$OUT/stage/sde-rsc-after-phase192.c"
+cp scripts/192_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase192.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+rsc = (root / 'drivers/a52_display/msm/sde_rsc.c').read_text()
+msm = (root / 'drivers/a52_display/msm/msm_drv.c').read_text()
+comp = (root / 'drivers/base/component.c').read_text()
+lagoon = (root / 'drivers/pinctrl/qcom/pinctrl-lagoon.c').read_text()
+for marker in (
+    'RSCC main-register enter',
+    'RSCC rpmh-register enter',
+    'RSCC state=%s compat=%s node=%u pdev=%u bound=%s',
+    'RSCC rpmh-probe enter',
+    'RSCC probe enter dev=%s node=%s counter=%d rpmh=%u',
+    'RSCC probe stage=power-init rc=%d',
+    'RSCC probe stage=rpmh-link rc=%d present=%u',
+    'RSCC probe stage=map-wrapper rc=%d',
+    'RSCC probe stage=map-drv rc=%d',
+    'RSCC probe stage=get-vdd rc=%d',
+    'RSCC probe stage=hw-register rc=%d',
+    'RSCC probe stage=vdd-enable rc=%d',
+    'RSCC probe stage=resource-enable rc=%d',
+    'RSCC probe stage=timer-calc rc=%d',
+    'RSCC component-add exit rc=%d',
+    'RSCC probe fail stage=%s stage_rc=%d return_rc=%d',
+    'RSCC bind enter dev=%s master=%s',
+):
+    assert marker in rsc, marker
+assert rsc.count('ret = component_add(&pdev->dev, &sde_rsc_comp_ops);') == 1
+assert rsc.count('ret = platform_driver_register(&sde_rsc_platform_driver);') == 1
+assert rsc.count('ret = platform_driver_register(&sde_rsc_rpmh_driver);') == 1
+assert 'DRMCOMP connector i=%u' in msm
+assert 'COMP slot i=%zu' in comp
+reserved = lagoon.split('static const int lagoon_reserved_gpios[] = {', 1)[1].split('};', 1)[0]
+assert '13, 14, 15, 16,' in reserved
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase192-sde-rscc-probe-trace.patch"
+test -s "$OUT/stage/phase192-sde-rscc-probe-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase192-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase192-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase192-compile.log" || true
+  exit "$rc"
+fi
+
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase192-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/a52_display/msm/sde_rsc.o' "$OUT/logs/phase192-compile.log"
+
+for marker in \
+  'RSCC main-register enter' \
+  'RSCC rpmh-register enter' \
+  'RSCC state=%s compat=%s node=%u pdev=%u bound=%s' \
+  'RSCC probe stage=rpmh-link rc=%d present=%u' \
+  'RSCC probe stage=timer-calc rc=%d' \
+  'RSCC component-add exit rc=%d' \
+  'RSCC bind exit rc=0' \
+  'DRMCOMP connectors prop=%u len=%d' \
+  'COMP slot i=%zu found=%u dev=%s bound=%u dup=%u' \
+  'PINCTRL Lagoon reserved secure=13-16'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 192 SDE RSCC registration/probe trace candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 191 hardware result:
+  - the active DRM master requires writeback, primary DSI, and SDE RSCC
+  - writeback was already present
+  - primary DSI later registered successfully
+  - SDE RSCC remained the only missing component
+  - DRM master bind and KMS initialization therefore never ran
+  - BOOT_READY was reached and the kernel stayed alive through 62.496 seconds
+
+Phase 192 is instrumentation-only. It records:
+  - SDE RSCC and RSCC-RPMh driver registration
+  - DT node and platform-device presence
+  - RPMh child probe and cell index
+  - every main RSCC probe stage and exact failure code
+  - cleanup, component_add(), and component bind
+
+It does not force probe, change an errno, remove RSCC from the component list,
+change display commands, timing, backlight, clocks, regulators, DTB, ramdisk,
+or recovery DTBO. Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-sde-rscc-probe-trace')
+base = json.loads(Path('artifacts/a52xq-display-component-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+rsc = (root / 'stage/sde-rsc-after-phase192.c').read_text()
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-sde-rscc-probe-trace-audited',
+    'phase': 192,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase191': False,
+    'phase191_hardware_validated': True,
+    'phase191_kernel_alive_ms': 62496.028,
+    'phase191_missing_component': 'qcom,sde_rscc / qcom,sde-rsc',
+    'rscc_registration_trace_added': 'RSCC main-register enter' in rsc,
+    'rscc_rpmh_trace_added': 'RSCC rpmh-probe enter' in rsc,
+    'rscc_probe_stage_trace_added': 'RSCC probe stage=timer-calc rc=%d' in rsc,
+    'rscc_component_trace_added': 'RSCC component-add exit rc=%d' in rsc,
+    'rscc_bind_trace_added': 'RSCC bind exit rc=0' in rsc,
+    'component_control_flow_changed': False,
+    'probe_return_values_changed': False,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase191_hardware_validated',
+    'rscc_registration_trace_added',
+    'rscc_rpmh_trace_added',
+    'rscc_probe_stage_trace_added',
+    'rscc_component_trace_added',
+    'rscc_bind_trace_added',
+    'dtb_preserved', 'ramdisk_preserved', 'recovery_dtbo_preserved',
+):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(
+    json.dumps(audit, indent=2, sort_keys=True) + '\n'
+)
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase 191 hardware evidence

The untouched 1 MiB RAMOOPS capture shows that the DRM master has three required components:

1. writeback
2. primary DSI
3. SDE RSCC

Writeback was already present. Primary DSI later called `component_add()` successfully and filled its match slot. The final match slot remained missing and maps to `qcom,sde_rscc`, compatible `qcom,sde-rsc`.

The kernel reached `BOOT_READY` and remained healthy through a 62.496 second heartbeat behind the black screen. No panic, watchdog reset or kernel lockup was recorded.

## Phase 192

Instrumentation-only tracing in `drivers/a52_display/msm/sde_rsc.c`:

- main RSCC and RSCC-RPMh driver registration
- DT-node and platform-device presence
- current driver binding state
- RPMh child probe and cell index
- every main probe stage and exact failure code
- cleanup
- `component_add()`
- component bind

This will distinguish a missing driver registration, missing DT device, missing RPMh child, a specific probe-stage failure, component registration failure, or bind failure.

## Safety and scope

- no forced probe or retry
- no errno conversion
- no component-list bypass
- no removal of RSCC from the DRM match list
- no panel, reset, backlight, clock, regulator or mode change
- no DTB, ramdisk or recovery-DTBO change
- phase 190 secure GPIO reservation preserved
- phase 191 component tracing preserved

This PR is a draft and is not hardware validated.