### PR TITLE
Trace A52 RSCC driver-core probe gate

### DIFF
--- a/.github/workflows/193-a52-rscc-drivercore-gate-trace.yml
+++ b/.github/workflows/193-a52-rscc-drivercore-gate-trace.yml
@@ -1,0 +1,91 @@
+name: 193 - A52 GKI 5.10 RSCC driver-core gate trace
+
+run-name: Build GKI 5.10 A52 RSCC driver-core gate trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-rscc-drivercore-gate-trace-v1
+    paths:
+      - .github/workflows/193-a52-rscc-drivercore-gate-trace.yml
+      - scripts/193_apply.py
+      - scripts/193_ci.sh
+      - scripts/193_NOTES.txt
+      - RAMOOPS-PHASE192-HARDWARE-RESULT.md
+  pull_request:
+    branches:
+      - agent/a52-sde-rscc-probe-trace-v1
+    paths:
+      - .github/workflows/193-a52-rscc-drivercore-gate-trace.yml
+      - scripts/193_apply.py
+      - scripts/193_ci.sh
+      - scripts/193_NOTES.txt
+      - RAMOOPS-PHASE192-HARDWARE-RESULT.md
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-rscc-drivercore-gate-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-193 RSCC driver-core gate trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    steps:
+      - name: Check out phase-193 branch
+        uses: actions/checkout@v4
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build, trace, package and audit phase 193
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/193_ci.sh
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-rscc-drivercore-gate-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-rscc-drivercore-gate-trace
+          if-no-files-found: warn
+          retention-days: 7
+      - name: Upload phase-193 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-rscc-drivercore-gate-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-rscc-drivercore-gate-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/RAMOOPS-PHASE192-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE192-HARDWARE-RESULT.md
@@ -1,0 +1,55 @@
+# A52 phase 192 RAMOOPS analysis
+
+## Capture integrity
+
+- Uploaded collector ZIP is readable despite `result_zip_rc=4`.
+- Frozen early snapshot and later raw export are both exactly 1 MiB.
+- They are byte-for-byte identical.
+- SHA-256: `d63c3d21470bebbcbb139143420eb32ed1ad57ce4f0a5a0e7cb2848f93fbb35b`.
+
+## Decoder result
+
+The exact phase-192 artifact decoder recovered 800 unique records from sequence 7 through 7150. Five compared slots were unrecoverable. The last recovered event is heartbeat tick 56 at 58.396 seconds with all eight CPUs online.
+
+## RSCC result
+
+The RPMh helper path is healthy:
+
+```text
+RSCC rpmh-register enter
+RSCC state=rpmh-before compat=qcom,sde-rsc-rpmh node=1 pdev=1 bound=-
+RSCC rpmh-probe enter dev=af20000.rsc:sde_rsc_rpmh
+RSCC rpmh-probe exit rc=0 index=0
+RSCC rpmh-register exit rc=0
+RSCC state=rpmh-after ... bound=sde_rsc_rpmh
+```
+
+The main device and main driver both exist, and driver registration succeeds:
+
+```text
+RSCC main-register enter
+RSCC state=main-before compat=qcom,sde-rsc node=1 pdev=1 bound=-
+RSCC main-register exit rc=0
+```
+
+However, no `RSCC probe enter` record appears. No internal probe stage, cleanup, component-add, or bind record appears either.
+
+This proves that the main RSCC callback is not failing internally. The driver core never invokes it. The remaining gate is before the callback:
+
+1. platform-bus matching returns no match, or
+2. driver core matches the pair but defers it before the callback, most likely at supplier-link checking or another generic pre-probe stage.
+
+## DTB dependencies
+
+The preserved DTB contains `/soc/qcom,sde_rscc`, compatible `qcom,sde-rsc`, with:
+
+- MMIO regions `drv` and `wrapper`
+- `vdd-supply` from `/soc/qcom,gdsc@af01004`
+- three clocks from `/soc/qcom,dispcc@af00000`
+- an RPMh child at `/soc/rsc@af20000/sde_rsc_rpmh`
+
+The RPMh child and DISPCC are already proven bound. Phase 193 should trace the platform match result, the generic `really_probe()` entry, and every supplier device link without changing any link state.
+
+## Display state
+
+The DRM component master still has writeback and primary DSI present, while the RSCC slot remains absent. The kernel reaches `BOOT_READY` and remains alive behind the black screen. No panic, watchdog reset, or lockup is present in the persistent recorder.

--- a/scripts/193_NOTES.txt
+++ b/scripts/193_NOTES.txt
@@ -1,0 +1,11 @@
+Phase 193 - A52 RSCC driver-core gate trace
+
+Hardware proof from phase 192:
+- RSCC-RPMh registered and probed successfully.
+- The qcom,sde-rsc node and platform device exist.
+- platform_driver_register(sde_rsc) returned 0.
+- No sde_rsc_probe() entry was recorded.
+
+Therefore the failure is before the driver callback. This phase records the exact
+match return and every generic pre-probe gate. Supplier-link enumeration is
+strictly read-only. No probe, link, component or display behavior is changed.

--- a/scripts/193_apply.py
+++ b/scripts/193_apply.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{label}: expected one match, found {n}")
+    return text.replace(old, new, 1)
+
+
+def patch_core(path: Path) -> None:
+    text = path.read_text()
+    anchor = '''\tif (dropped)\n\t\t*dropped = local_dropped;\n}\n\n\nstatic ssize_t waiting_for_supplier_show'''
+    new = '''\tif (dropped)\n\t\t*dropped = local_dropped;\n}\n\nvoid a52_device_links_trace(struct device *dev, const char *tag);\nvoid a52_device_links_trace(struct device *dev, const char *tag)\n{\n\tstruct device_link *link;\n\tunsigned int link_index = 0;\n\tint idx;\n\n\tif (!dev)\n\t\treturn;\n\ta52_ackfr_record("RSCCCORE links begin tag=%s c=%s status=%u",\n\t\t\t tag ? tag : "-", dev_name(dev),\n\t\t\t (unsigned int)dev->links.status);\n\tidx = device_links_read_lock();\n\tlist_for_each_entry(link, &dev->links.suppliers, c_node) {\n\t\tconst char *sname = link->supplier ? dev_name(link->supplier) : "none";\n\t\tconst char *sdrv = link->supplier && link->supplier->driver &&\n\t\t\tlink->supplier->driver->name ? link->supplier->driver->name : "none";\n\t\tconst char *sof = link->supplier && link->supplier->of_node ?\n\t\t\tlink->supplier->of_node->full_name : "none";\n\n\t\ta52_ackfr_record("RSCCCORE link n=%u s=%s st=%u fl=0x%x",\n\t\t\t\t   link_index, sname,\n\t\t\t\t   (unsigned int)link->status, link->flags);\n\t\ta52_ackfr_record("RSCCCORE link n=%u of=%s drv=%s",\n\t\t\t\t   link_index, sof, sdrv);\n\t\tlink_index++;\n\t}\n\tdevice_links_read_unlock(idx);\n\ta52_ackfr_record("RSCCCORE links end tag=%s count=%u",\n\t\t\t tag ? tag : "-", link_index);\n}\n\n\nstatic ssize_t waiting_for_supplier_show'''
+    text = one(text, anchor, new, "add read-only RSCC link trace")
+    path.write_text(text)
+
+
+def patch_dd(path: Path) -> None:
+    text = path.read_text()
+    text = one(text,
+'''extern void a52_device_links_force_probe(struct device *dev,\n\t\t\t\t\t unsigned int *kept,\n\t\t\t\t\t unsigned int *dropped);\n''',
+'''extern void a52_device_links_force_probe(struct device *dev,\n\t\t\t\t\t unsigned int *kept,\n\t\t\t\t\t unsigned int *dropped);\nextern void a52_device_links_trace(struct device *dev, const char *tag);\n''',
+"declare link trace")
+
+    anchor = '''static bool a52_display_probe_device(const struct device *dev)\n{\n\tif (!dev || !dev->of_node)\n\t\treturn false;\n\n\treturn of_device_is_compatible(dev->of_node, "qcom,sde-kms") ||\n\t       of_device_is_compatible(dev->of_node, "qcom,dsi-display") ||\n\t       of_device_is_compatible(dev->of_node, "qcom,dsi-ctrl-hw-v2.4");\n}\n'''
+    helper = anchor + '''\nstatic bool a52_rscc_probe_device(const struct device *dev)\n{\n\treturn dev && dev->of_node &&\n\t\tof_device_is_compatible(dev->of_node, "qcom,sde-rsc");\n}\n'''
+    text = one(text, anchor, helper, "add RSCC device filter")
+
+    old = '''void driver_deferred_probe_add(struct device *dev)\n{\n\tif (a52_storage_probe_device(dev)) {'''
+    new = '''void driver_deferred_probe_add(struct device *dev)\n{\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE deferred-add dev=%s reason=%s",\n\t\t\tdev_name(dev), dev->p && dev->p->deferred_probe_reason ?\n\t\t\tdev->p->deferred_probe_reason : "-");\n\tif (a52_storage_probe_device(dev)) {'''
+    text = one(text, old, new, "trace RSCC deferred add")
+
+    old = '''\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n\t\t\t   !drv->suppress_bind_attrs;\n\n\tif (a52_display_probe_device(dev))'''
+    new = '''\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n\t\t\t   !drv->suppress_bind_attrs;\n\n\tif (a52_rscc_probe_device(dev)) {\n\t\ta52_ackfr_record("RSCCCORE really-probe enter dev=%s drv=%s",\n\t\t\tdev_name(dev), drv && drv->name ? drv->name : "-");\n\t\ta52_device_links_trace(dev, "really-enter");\n\t}\n\n\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace really_probe entry")
+
+    old = '''\tret = device_links_check_suppliers(dev);\n\tif (ret == -EPROBE_DEFER && a52_legacy_fw_devlink_consumer(dev)) {'''
+    new = '''\tret = device_links_check_suppliers(dev);\n\tif (a52_rscc_probe_device(dev)) {\n\t\tconst char *reason = dev->p && dev->p->deferred_probe_reason ?\n\t\t\tdev->p->deferred_probe_reason : "-";\n\n\t\ta52_ackfr_record("RSCCCORE suppliers dev=%s rc=%d reason=%s",\n\t\t\tdev_name(dev), ret, reason);\n\t\ta52_device_links_trace(dev, "suppliers-checked");\n\t}\n\tif (ret == -EPROBE_DEFER && a52_legacy_fw_devlink_consumer(dev)) {'''
+    text = one(text, old, new, "trace supplier gate")
+
+    old = '''\tret = pinctrl_bind_pins(dev);\n\tif (a52_display_probe_device(dev))'''
+    new = '''\tret = pinctrl_bind_pins(dev);\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE pinctrl dev=%s rc=%d", dev_name(dev), ret);\n\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace RSCC pinctrl")
+
+    old = '''\t\tret = dev->bus->dma_configure(dev);\n\t\tif (a52_display_probe_device(dev))'''
+    new = '''\t\tret = dev->bus->dma_configure(dev);\n\t\tif (a52_rscc_probe_device(dev))\n\t\t\ta52_ackfr_record("RSCCCORE dma dev=%s rc=%d", dev_name(dev), ret);\n\t\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace RSCC DMA")
+
+    old = '''\tret = driver_sysfs_add(dev);\n\tif (a52_display_probe_device(dev))'''
+    new = '''\tret = driver_sysfs_add(dev);\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE sysfs dev=%s rc=%d", dev_name(dev), ret);\n\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace RSCC sysfs")
+
+    old = '''\tif (dev->pm_domain && dev->pm_domain->activate) {\n\t\tret = dev->pm_domain->activate(dev);\n\t\tif (a52_display_probe_device(dev))'''
+    new = '''\tif (dev->pm_domain && dev->pm_domain->activate) {\n\t\tret = dev->pm_domain->activate(dev);\n\t\tif (a52_rscc_probe_device(dev))\n\t\t\ta52_ackfr_record("RSCCCORE pm dev=%s rc=%d", dev_name(dev), ret);\n\t\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace RSCC PM")
+
+    old = '''\tif (dev->bus->probe) {\n\t\tif (a52_run40_preprobe_target(dev)) {'''
+    new = '''\tif (dev->bus->probe) {\n\t\tif (a52_rscc_probe_device(dev))\n\t\t\ta52_ackfr_record("RSCCCORE busprobe enter dev=%s drv=%s",\n\t\t\t\tdev_name(dev), drv && drv->name ? drv->name : "-");\n\t\tif (a52_run40_preprobe_target(dev)) {'''
+    text = one(text, old, new, "trace RSCC bus probe enter")
+
+    old = '''\t\tret = dev->bus->probe(dev);\n\t\tif (a52_display_probe_device(dev))'''
+    new = '''\t\tret = dev->bus->probe(dev);\n\t\tif (a52_rscc_probe_device(dev))\n\t\t\ta52_ackfr_record("RSCCCORE busprobe exit dev=%s rc=%d",\n\t\t\t\tdev_name(dev), ret);\n\t\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace RSCC bus probe exit")
+
+    old = '''done:\n\tif (a52_display_probe_device(dev))'''
+    new = '''done:\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE really-probe done dev=%s rc=%d bound=%s",\n\t\t\tdev_name(dev), ret, dev->driver && dev->driver->name ?\n\t\t\tdev->driver->name : "-");\n\tif (a52_display_probe_device(dev))'''
+    text = one(text, old, new, "trace really_probe completion")
+
+    old = '''int driver_probe_device(struct device_driver *drv, struct device *dev)\n{\n\tint ret = 0;\n\n\tif (!device_is_registered(dev))'''
+    new = '''int driver_probe_device(struct device_driver *drv, struct device *dev)\n{\n\tint ret = 0;\n\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE driver-probe enter dev=%s drv=%s",\n\t\t\tdev_name(dev), drv && drv->name ? drv->name : "-");\n\n\tif (!device_is_registered(dev))'''
+    text = one(text, old, new, "trace driver_probe_device entry")
+
+    old = '''\tpm_runtime_put_suppliers(dev);\n\treturn ret;\n}\n\nstatic inline bool cmdline_requested_async_probing'''
+    new = '''\tpm_runtime_put_suppliers(dev);\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE driver-probe exit dev=%s rc=%d bound=%s",\n\t\t\tdev_name(dev), ret, dev->driver && dev->driver->name ?\n\t\t\tdev->driver->name : "-");\n\treturn ret;\n}\n\nstatic inline bool cmdline_requested_async_probing'''
+    text = one(text, old, new, "trace driver_probe_device exit")
+
+    old = '''\tret = driver_match_device(drv, dev);\n\tif (ret == 0) {\n\t\t/* no match */\n\t\treturn 0;\n'''
+    new = '''\tret = driver_match_device(drv, dev);\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE match path=device-attach dev=%s drv=%s rc=%d",\n\t\t\tdev_name(dev), drv && drv->name ? drv->name : "-", ret);\n\tif (ret == 0) {\n\t\t/* no match */\n\t\treturn 0;\n'''
+    if text.count(old) != 2:
+        raise SystemExit(f"trace device attach match: expected two matches, found {text.count(old)}")
+    text = text.replace(old, new, 1)
+
+    # second occurrence in __driver_attach
+    old2 = '''\tret = driver_match_device(drv, dev);\n\tif (ret == 0) {\n\t\t/* no match */\n\t\treturn 0;\n'''
+    new2 = '''\tret = driver_match_device(drv, dev);\n\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE match path=driver-attach dev=%s drv=%s rc=%d",\n\t\t\tdev_name(dev), drv && drv->name ? drv->name : "-", ret);\n\tif (ret == 0) {\n\t\t/* no match */\n\t\treturn 0;\n'''
+    text = one(text, old2, new2, "trace driver attach match")
+
+    path.write_text(text)
+
+
+def main() -> int:
+    p=argparse.ArgumentParser(); p.add_argument('--root',type=Path,required=True); a=p.parse_args()
+    patch_core(a.root/'drivers/base/core.c')
+    patch_dd(a.root/'drivers/base/dd.c')
+    print('phase193 RSCC driver-core gate trace applied')
+    return 0
+
+if __name__=='__main__': raise SystemExit(main())

--- a/scripts/193_ci.sh
+++ b/scripts/193_ci.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-sde-rscc-probe-trace"
+OUT="$PWD/artifacts/a52xq-rscc-drivercore-gate-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/192_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase193.config"
+cp "$ROOT/drivers/base/core.c" "$OUT/stage/core-before-phase193.c"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-before-phase193.c"
+
+python3 scripts/193_apply.py --root "$ROOT" | tee "$OUT/logs/phase193-apply.log"
+
+cp "$ROOT/drivers/base/core.c" "$OUT/stage/core-after-phase193.c"
+cp "$ROOT/drivers/base/dd.c" "$OUT/stage/dd-after-phase193.c"
+cp scripts/193_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase193.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+core = (root / 'drivers/base/core.c').read_text()
+dd = (root / 'drivers/base/dd.c').read_text()
+rsc = (root / 'drivers/a52_display/msm/sde_rsc.c').read_text()
+for marker in (
+    'RSCCCORE links begin tag=%s c=%s status=%u',
+    'RSCCCORE link n=%u s=%s st=%u fl=0x%x',
+    'RSCCCORE link n=%u of=%s drv=%s',
+    'RSCCCORE links end tag=%s count=%u',
+):
+    assert marker in core, marker
+for marker in (
+    'RSCCCORE match path=device-attach',
+    'RSCCCORE match path=driver-attach',
+    'RSCCCORE driver-probe enter',
+    'RSCCCORE really-probe enter',
+    'RSCCCORE suppliers dev=%s rc=%d reason=%s',
+    'RSCCCORE pinctrl dev=%s rc=%d',
+    'RSCCCORE dma dev=%s rc=%d',
+    'RSCCCORE sysfs dev=%s rc=%d',
+    'RSCCCORE busprobe enter',
+    'RSCCCORE busprobe exit',
+    'RSCCCORE really-probe done',
+):
+    assert marker in dd, marker
+assert dd.count('ret = device_links_check_suppliers(dev);') == 1
+assert dd.count('ret = driver_match_device(drv, dev);') >= 2
+assert 'device_link_drop_managed(link);' in core
+# Phase 193 must not call the mutating helper for RSCC.
+rscc_block = dd.split('static bool a52_rscc_probe_device', 1)[1]
+assert 'a52_device_links_force_probe(dev' not in rscc_block.split('static bool a52_legacy_fw_devlink_consumer', 1)[0]
+for marker in (
+    'RSCC main-register enter',
+    'RSCC probe enter dev=%s node=%s counter=%d rpmh=%u',
+    'RSCC component-add exit rc=%d',
+):
+    assert marker in rsc, marker
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase193-rscc-drivercore-gate-trace.patch"
+test -s "$OUT/stage/phase193-rscc-drivercore-gate-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase193-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase193-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase193-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase193-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for object in 'drivers/base/core.o' 'drivers/base/dd.o'; do
+  grep -Fq "$object" "$OUT/logs/phase193-compile.log"
+done
+for marker in \
+  'RSCCCORE match path=driver-attach dev=%s drv=%s rc=%d' \
+  'RSCCCORE really-probe enter dev=%s drv=%s' \
+  'RSCCCORE suppliers dev=%s rc=%d reason=%s' \
+  'RSCCCORE link n=%u s=%s st=%u fl=0x%x' \
+  'RSCCCORE busprobe exit dev=%s rc=%d' \
+  'RSCC main-register enter' \
+  'DRMCOMP connectors prop=%u len=%d' \
+  'PINCTRL Lagoon reserved secure=13-16'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 193 RSCC driver-core gate trace candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 192 hardware result:
+  - RSCC-RPMh driver registered and its child probe returned 0
+  - qcom,sde-rsc DT node and platform device exist
+  - the main sde_rsc driver registered with rc=0
+  - the main sde_rsc probe callback was never entered
+  - BOOT_READY was reached and the kernel stayed alive through 58.396 seconds
+
+Phase 193 is instrumentation-only. It records:
+  - platform/device-driver match return values for qcom,sde-rsc
+  - driver_probe_device and really_probe entry/exit
+  - every supplier device link, status, flags, supplier driver and OF node
+  - supplier-check return and deferred reason
+  - generic pinctrl, DMA, sysfs, PM and bus-probe gates
+
+The device-link trace is read-only. It does not drop, promote, bypass or create links.
+It does not force probe, alter an errno, remove RSCC from the DRM match list,
+or change display commands, timing, clocks, regulators, DTB, ramdisk or
+recovery DTBO. Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-rscc-drivercore-gate-trace')
+base = json.loads(Path('artifacts/a52xq-sde-rscc-probe-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+core = (root / 'stage/core-after-phase193.c').read_text()
+dd = (root / 'stage/dd-after-phase193.c').read_text()
+image = root / 'compile/Image'; boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-rscc-drivercore-gate-trace-audited',
+    'phase': 193,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase192': False,
+    'phase192_hardware_validated': True,
+    'phase192_kernel_alive_ms': 58396.048,
+    'phase192_result': 'main-rscc-driver-registered-probe-callback-not-entered',
+    'rscc_match_trace_added': 'RSCCCORE match path=driver-attach' in dd,
+    'rscc_supplier_trace_added': 'RSCCCORE suppliers dev=%s rc=%d reason=%s' in dd,
+    'rscc_link_enumeration_added': 'RSCCCORE link n=%u s=%s st=%u fl=0x%x' in core,
+    'device_link_state_changed': False,
+    'probe_control_flow_changed': False,
+    'probe_return_values_changed': False,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in ('phase192_hardware_validated','rscc_match_trace_added',
+            'rscc_supplier_trace_added','rscc_link_enumeration_added',
+            'dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True)+'\n')
+PY
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase 192 hardware evidence

The untouched 1 MiB RAMOOPS capture proves that the RSCC helper path is healthy but the main RSCC callback is never invoked:

- `qcom,sde-rsc-rpmh` driver registered and its child probe returned 0
- the main `qcom,sde-rsc` DT node exists
- the main platform device exists
- the main `sde_rsc` driver registered with rc=0
- no `sde_rsc_probe()` entry was recorded
- no internal RSCC probe stage, cleanup, component registration, or bind record appeared
- the kernel reached `BOOT_READY` and remained alive through 58.396 seconds behind the black screen

This moves the blocker into the generic driver-core path before the driver callback. The remaining possibilities are a failed platform match or a pre-probe supplier/device-link gate.

## Phase 193

Instrumentation-only tracing of the exact `qcom,sde-rsc` device:

- match return values in both device-attach and driver-attach paths
- `driver_probe_device()` entry and exit
- `really_probe()` entry and completion
- every supplier device link, including status, flags, supplier driver, and OF node
- supplier-check return value and deferred-probe reason
- pinctrl, DMA, sysfs, PM-domain, and platform-bus probe gates
- deferred-probe queue insertion

Supplier-link enumeration is strictly read-only under the existing device-link read lock.

## Safety and scope

- no forced probe or deferred-probe retry
- no supplier link created, removed, promoted, or bypassed
- no return value or matching decision changed
- no RSCC component-list bypass
- no panel, reset, backlight, clock, regulator, or display-mode change
- no DTB, ramdisk, or recovery-DTBO change
- phase 190 secure GPIO reservation preserved
- phase 191 component tracing preserved
- phase 192 RSCC tracing preserved

The patcher was applied locally to the exact inherited Android 5.10 `core.c` and `dd.c`, and Python and shell syntax validation passed. This PR is a draft and is not hardware validated.