### PR TITLE
Provide A52 MDSS core GDSC regulator

### DIFF
--- a/.github/workflows/194-a52-mdss-core-gdsc-provider.yml
+++ b/.github/workflows/194-a52-mdss-core-gdsc-provider.yml
@@ -1,0 +1,98 @@
+name: 194 - A52 GKI 5.10 MDSS core GDSC provider
+
+run-name: Build GKI 5.10 A52 MDSS core GDSC provider candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-mdss-core-gdsc-provider-v1
+    paths:
+      - .github/workflows/194-a52-mdss-core-gdsc-provider.yml
+      - scripts/194_apply.py
+      - scripts/194_ci.sh
+      - scripts/194_NOTES.txt
+      - RAMOOPS-PHASE193-HARDWARE-RESULT.md
+  pull_request:
+    branches:
+      - agent/a52-rscc-drivercore-gate-trace-v1
+    paths:
+      - .github/workflows/194-a52-mdss-core-gdsc-provider.yml
+      - scripts/194_apply.py
+      - scripts/194_ci.sh
+      - scripts/194_NOTES.txt
+      - RAMOOPS-PHASE193-HARDWARE-RESULT.md
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-mdss-core-gdsc-provider-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-194 MDSS core GDSC provider candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-194 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, provide, package and audit phase 194
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: bash scripts/194_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-mdss-core-gdsc-provider-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-mdss-core-gdsc-provider
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-194 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-mdss-core-gdsc-provider-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-mdss-core-gdsc-provider
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/194-a52-mdss-core-gdsc-provider.yml
+++ b/.github/workflows/194-a52-mdss-core-gdsc-provider.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - .github/workflows/194-a52-mdss-core-gdsc-provider.yml
       - scripts/194_apply.py
+      - scripts/194_fix_inherited_guard.py
       - scripts/194_ci.sh
       - scripts/194_NOTES.txt
       - RAMOOPS-PHASE193-HARDWARE-RESULT.md
@@ -19,6 +20,7 @@ on:
     paths:
       - .github/workflows/194-a52-mdss-core-gdsc-provider.yml
       - scripts/194_apply.py
+      - scripts/194_fix_inherited_guard.py
       - scripts/194_ci.sh
       - scripts/194_NOTES.txt
       - RAMOOPS-PHASE193-HARDWARE-RESULT.md
@@ -77,7 +79,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
-        run: bash scripts/194_ci.sh
+        run: |
+          python3 scripts/194_fix_inherited_guard.py
+          bash scripts/194_ci.sh
 
       - name: Upload failed diagnostics
         if: ${{ failure() }}

--- a/RAMOOPS-PHASE193-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE193-HARDWARE-RESULT.md
@@ -1,0 +1,24 @@
+# Phase 193 A52 hardware result
+
+The untouched 1 MiB RAMOOPS capture proves the RSCC driver and platform device
+match, but driver core defers the probe before the callback because one supplier
+is not ready.
+
+```text
+RSCCCORE match path=device-attach dev=af20000.qcom,sde_rscc drv=sde_rsc rc=1
+RSCCCORE driver-probe enter dev=af20000.qcom,sde_rscc drv=sde_rsc
+RSCCCORE really-probe enter dev=af20000.qcom,sde_rscc drv=sde_rsc
+RSCCCORE link n=0 s=af00000.qcom,dispcc st=1 fl=0x160
+RSCCCORE link n=0 of=qcom,dispcc@af00000 drv=disp_cc-lagoon
+RSCCCORE link n=1 s=af01004.qcom,gdsc st=0 fl=0x160
+RSCCCORE link n=1 of=qcom,gdsc@af01004 drv=none
+RSCCCORE suppliers dev=af20000.qcom,sde_rscc rc=-517 reason=-
+RSCCCORE deferred-add dev=af20000.qcom,sde_rscc reason=-
+```
+
+The blocking supplier is `/soc/qcom,gdsc@af01004`, compatible `qcom,gdsc`,
+regulator name `mdss_core_gdsc`. The existing A52 legacy GDSC bridge binds the
+working UFS node but rejects this display regulator by name.
+
+The kernel reached BOOT_READY and remained alive through 46.140115 seconds with
+all eight CPUs online. No panic, watchdog reset, or lockup was recorded.

--- a/scripts/194_NOTES.txt
+++ b/scripts/194_NOTES.txt
@@ -1,0 +1,20 @@
+Phase 194 - A52 MDSS core GDSC provider
+
+Hardware evidence from phase 193:
+- qcom,sde-rsc matches sde_rsc
+- driver-core probe begins
+- dispcc supplier is ready
+- qcom,gdsc@af01004 is not bound
+- supplier check returns -EPROBE_DEFER
+- qcom,gdsc@af01004 is mdss_core_gdsc
+- the existing A52 bridge accepts gcc_ufs_phy_gdsc only
+
+Functional change:
+- preserve the UFS profile and keep-on disable policy
+- add an explicit mdss_core_gdsc profile
+- use normal software enable and collapse for MDSS
+- support normal/fast hardware-trigger modes declared by DT
+- bind the existing supplier rather than bypassing fw_devlink
+
+No DTB, panel command, display timing, clock rate, regulator voltage, supplier
+link, matching decision, or probe retry is changed.

--- a/scripts/194_apply.py
+++ b/scripts/194_apply.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+DRIVER_SOURCE = r'''// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Qualcomm legacy standalone GDSC regulator bridge for Samsung A52 Lagoon DT.
+ *
+ * The vendor DT exposes two standalone "qcom,gdsc" regulators that Android
+ * common 5.10 does not otherwise bind:
+ *
+ *   - gcc_ufs_phy_gdsc: boot-critical UFS profile, kept on after enable
+ *   - mdss_core_gdsc: display profile, normal software collapse supported
+ *
+ * Keep the profiles explicit. Do not claim unrelated qcom,gdsc nodes.
+ */
+
+#include <linux/a52_ack_secure_flight_recorder.h>
+#include <linux/bitops.h>
+#include <linux/delay.h>
+#include <linux/io.h>
+#include <linux/ioport.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+#include <linux/regulator/driver.h>
+#include <linux/regulator/machine.h>
+#include <linux/regulator/of_regulator.h>
+#include <linux/string.h>
+
+#define A52_GDSC_PWR_ON          BIT(31)
+#define A52_GDSC_SW_OVERRIDE     BIT(2)
+#define A52_GDSC_HW_CONTROL      BIT(1)
+#define A52_GDSC_SW_COLLAPSE     BIT(0)
+#define A52_GDSC_TIMEOUT_US      100
+
+enum a52_legacy_gdsc_profile {
+    A52_GDSC_PROFILE_UFS,
+    A52_GDSC_PROFILE_MDSS,
+};
+
+struct a52_legacy_gdsc {
+    struct device *dev;
+    void __iomem *gdscr;
+    struct regulator_desc desc;
+    enum a52_legacy_gdsc_profile profile;
+    bool support_hw_trigger;
+};
+
+extern void a52_persistent_diag_mark(const char *fmt, ...);
+
+static const char *a52_legacy_gdsc_profile_name(
+        const struct a52_legacy_gdsc *gdsc)
+{
+    return gdsc->profile == A52_GDSC_PROFILE_MDSS ? "mdss" : "ufs";
+}
+
+static int a52_legacy_gdsc_poll(struct a52_legacy_gdsc *gdsc, bool on,
+                               u32 *last)
+{
+    u32 val;
+    int ret;
+
+    if (on)
+        ret = readl_poll_timeout(gdsc->gdscr, val,
+                                 val & A52_GDSC_PWR_ON,
+                                 1, A52_GDSC_TIMEOUT_US);
+    else
+        ret = readl_poll_timeout(gdsc->gdscr, val,
+                                 !(val & A52_GDSC_PWR_ON),
+                                 1, A52_GDSC_TIMEOUT_US);
+    if (last)
+        *last = val;
+    return ret;
+}
+
+static int a52_legacy_gdsc_is_enabled(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    return !!((val & A52_GDSC_PWR_ON) &&
+              !(val & A52_GDSC_SW_COLLAPSE));
+}
+
+static int a52_legacy_gdsc_enable(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    val &= ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE |
+             A52_GDSC_SW_COLLAPSE);
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+    a52_ackfr_record(
+        "A52GDSC enable profile=%s name=%s rc=%d before=0x%x after=0x%x",
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->desc.name,
+        ret, before, val);
+    a52_persistent_diag_mark(
+        "A52GDSC ENABLE dev=%s name=%s ret=%d reg=0x%08x\n",
+        dev_name(gdsc->dev), gdsc->desc.name, ret, val);
+
+    if (ret)
+        dev_err(gdsc->dev, "enable timed out, GDSCR=0x%08x\n", val);
+    return ret;
+}
+
+static int a52_legacy_gdsc_disable_ufs(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    a52_ackfr_record(
+        "A52GDSC disable-keep-on profile=ufs name=%s reg=0x%x",
+        gdsc->desc.name, val);
+    a52_persistent_diag_mark(
+        "A52GDSC DISABLE_KEEP_ON dev=%s name=%s reg=0x%08x\n",
+        dev_name(gdsc->dev), gdsc->desc.name, val);
+    return 0;
+}
+
+static int a52_legacy_gdsc_disable_mdss(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    if (val & A52_GDSC_HW_CONTROL) {
+        val &= ~A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+    }
+
+    val |= A52_GDSC_SW_COLLAPSE;
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, false, &val);
+    a52_ackfr_record(
+        "A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x",
+        gdsc->desc.name, ret, before, val);
+    if (ret)
+        dev_err(gdsc->dev, "disable timed out, GDSCR=0x%08x\n", val);
+    return ret;
+}
+
+static unsigned int a52_legacy_gdsc_get_mode(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    return val & A52_GDSC_HW_CONTROL ?
+           REGULATOR_MODE_FAST : REGULATOR_MODE_NORMAL;
+}
+
+static int a52_legacy_gdsc_set_mode(struct regulator_dev *rdev,
+                                    unsigned int mode)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret = 0;
+
+    if (!gdsc->support_hw_trigger)
+        return -EINVAL;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    switch (mode) {
+    case REGULATOR_MODE_FAST:
+        val |= A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+        break;
+    case REGULATOR_MODE_NORMAL:
+        val &= ~A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+        if ((val & A52_GDSC_PWR_ON) &&
+            !(val & A52_GDSC_SW_COLLAPSE))
+            ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    a52_ackfr_record(
+        "A52GDSC mode profile=%s name=%s mode=%u rc=%d before=0x%x after=0x%x",
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->desc.name,
+        mode, ret, before, val);
+    return ret;
+}
+
+static const struct regulator_ops a52_legacy_gdsc_ufs_ops = {
+    .enable = a52_legacy_gdsc_enable,
+    .disable = a52_legacy_gdsc_disable_ufs,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+};
+
+static const struct regulator_ops a52_legacy_gdsc_mdss_ops = {
+    .enable = a52_legacy_gdsc_enable,
+    .disable = a52_legacy_gdsc_disable_mdss,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+    .set_mode = a52_legacy_gdsc_set_mode,
+    .get_mode = a52_legacy_gdsc_get_mode,
+};
+
+static int a52_legacy_gdsc_probe(struct platform_device *pdev)
+{
+    struct regulator_config config = { };
+    struct regulator_init_data *init_data = NULL;
+    struct a52_legacy_gdsc *gdsc;
+    struct regulator_dev *rdev;
+    struct resource *res;
+    const char *name;
+    u32 before, val;
+
+    if (of_property_read_string(pdev->dev.of_node, "regulator-name", &name))
+        return -EINVAL;
+
+    if (!strcmp(name, "gcc_ufs_phy_gdsc")) {
+    } else if (!strcmp(name, "mdss_core_gdsc")) {
+    } else {
+        return -ENODEV;
+    }
+
+    gdsc = devm_kzalloc(&pdev->dev, sizeof(*gdsc), GFP_KERNEL);
+    if (!gdsc)
+        return -ENOMEM;
+
+    gdsc->dev = &pdev->dev;
+    gdsc->profile = !strcmp(name, "mdss_core_gdsc") ?
+                    A52_GDSC_PROFILE_MDSS : A52_GDSC_PROFILE_UFS;
+    gdsc->support_hw_trigger =
+        of_property_read_bool(pdev->dev.of_node,
+                              "qcom,support-hw-trigger");
+
+    res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+    if (!res)
+        return -EINVAL;
+    gdsc->gdscr = devm_ioremap(&pdev->dev, res->start, resource_size(res));
+    if (!gdsc->gdscr)
+        return -ENOMEM;
+
+    gdsc->desc.name = name;
+    gdsc->desc.of_match = name;
+    gdsc->desc.type = REGULATOR_VOLTAGE;
+    gdsc->desc.owner = THIS_MODULE;
+    gdsc->desc.ops = gdsc->profile == A52_GDSC_PROFILE_MDSS ?
+                     &a52_legacy_gdsc_mdss_ops :
+                     &a52_legacy_gdsc_ufs_ops;
+
+    if (gdsc->profile == A52_GDSC_PROFILE_MDSS) {
+        init_data = of_get_regulator_init_data(&pdev->dev,
+                                               pdev->dev.of_node,
+                                               &gdsc->desc);
+        if (init_data && gdsc->support_hw_trigger) {
+            init_data->constraints.valid_ops_mask |= REGULATOR_CHANGE_MODE;
+            init_data->constraints.valid_modes_mask |=
+                REGULATOR_MODE_NORMAL | REGULATOR_MODE_FAST;
+        }
+
+        before = readl_relaxed(gdsc->gdscr);
+        val = before & ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE);
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        a52_ackfr_record(
+            "A52GDSC mdss-init name=%s before=0x%x after=0x%x hw=%u",
+            name, before, val, gdsc->support_hw_trigger);
+    }
+
+    config.dev = &pdev->dev;
+    config.of_node = pdev->dev.of_node;
+    config.init_data = init_data;
+    config.driver_data = gdsc;
+
+    a52_ackfr_record(
+        "A52GDSC register enter dev=%s name=%s profile=%s hw=%u",
+        dev_name(&pdev->dev), name,
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->support_hw_trigger);
+    rdev = devm_regulator_register(&pdev->dev, &gdsc->desc, &config);
+    if (IS_ERR(rdev)) {
+        int ret = PTR_ERR(rdev);
+
+        a52_ackfr_record(
+            "A52GDSC register exit dev=%s name=%s rc=%d",
+            dev_name(&pdev->dev), name, ret);
+        if (ret != -EPROBE_DEFER)
+            dev_err(&pdev->dev, "failed to register %s: %d\n", name, ret);
+        return ret;
+    }
+
+    platform_set_drvdata(pdev, gdsc);
+    val = readl_relaxed(gdsc->gdscr);
+    a52_ackfr_record(
+        "A52GDSC register exit dev=%s name=%s rc=0 reg=0x%x profile=%s",
+        dev_name(&pdev->dev), name, val,
+        a52_legacy_gdsc_profile_name(gdsc));
+    a52_persistent_diag_mark(
+        "A52GDSC PROBE dev=%s name=%s reg=0x%08x pwr=%u collapse=%u\n",
+        dev_name(&pdev->dev), name, val,
+        !!(val & A52_GDSC_PWR_ON), !!(val & A52_GDSC_SW_COLLAPSE));
+    dev_info(&pdev->dev, "registered A52 legacy GDSC regulator %s (%s)\n",
+             name, a52_legacy_gdsc_profile_name(gdsc));
+    return 0;
+}
+
+static const struct of_device_id a52_legacy_gdsc_match[] = {
+    { .compatible = "qcom,gdsc" },
+    { }
+};
+MODULE_DEVICE_TABLE(of, a52_legacy_gdsc_match);
+
+static struct platform_driver a52_legacy_gdsc_driver = {
+    .probe = a52_legacy_gdsc_probe,
+    .driver = {
+        .name = "a52-legacy-gdsc-regulator",
+        .of_match_table = a52_legacy_gdsc_match,
+    },
+};
+
+static int __init a52_legacy_gdsc_init(void)
+{
+    int ret;
+
+    a52_ackfr_record("A52GDSC driver-register enter");
+    ret = platform_driver_register(&a52_legacy_gdsc_driver);
+    a52_ackfr_record("A52GDSC driver-register exit rc=%d", ret);
+    return ret;
+}
+subsys_initcall(a52_legacy_gdsc_init);
+
+static void __exit a52_legacy_gdsc_exit(void)
+{
+    platform_driver_unregister(&a52_legacy_gdsc_driver);
+}
+module_exit(a52_legacy_gdsc_exit);
+
+MODULE_DESCRIPTION("Samsung A52 legacy Qualcomm UFS and MDSS GDSC regulator bridge");
+MODULE_LICENSE("GPL");
+'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    args = parser.parse_args()
+
+    path = args.root / "drivers/regulator/a52-legacy-gdsc-regulator.c"
+    if not path.is_file():
+        raise SystemExit(f"legacy GDSC bridge missing: {path}")
+
+    old = path.read_text(encoding="utf-8")
+    for marker in (
+        'strcmp(name, "gcc_ufs_phy_gdsc")',
+        "A52GDSC DISABLE_KEEP_ON",
+        "a52-legacy-gdsc-regulator",
+    ):
+        if marker not in old:
+            raise SystemExit(f"unexpected inherited GDSC bridge, missing: {marker}")
+    if '"mdss_core_gdsc"' in old:
+        raise SystemExit("mdss_core_gdsc support already present")
+
+    for marker in (
+        '"gcc_ufs_phy_gdsc"',
+        '"mdss_core_gdsc"',
+        "A52GDSC disable-keep-on profile=ufs",
+        "A52GDSC disable profile=mdss",
+        "A52GDSC mdss-init",
+        "REGULATOR_CHANGE_MODE",
+        "A52_GDSC_HW_CONTROL",
+        "A52_GDSC_SW_COLLAPSE",
+    ):
+        if marker not in DRIVER_SOURCE:
+            raise SystemExit(f"new GDSC source missing: {marker}")
+
+    path.write_text(DRIVER_SOURCE, encoding="utf-8")
+    print("phase194 MDSS core GDSC provider applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/194_ci.sh
+++ b/scripts/194_ci.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-rscc-drivercore-gate-trace"
+OUT="$PWD/artifacts/a52xq-mdss-core-gdsc-provider"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/193_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase194.config"
+cp "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  "$OUT/stage/a52-legacy-gdsc-before-phase194.c"
+
+python3 scripts/194_apply.py --root "$ROOT" | tee "$OUT/logs/phase194-apply.log"
+
+cp "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  "$OUT/stage/a52-legacy-gdsc-after-phase194.c"
+cp scripts/194_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase194.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+gdsc = (root / 'drivers/regulator/a52-legacy-gdsc-regulator.c').read_text()
+dd = (root / 'drivers/base/dd.c').read_text()
+rsc = (root / 'drivers/a52_display/msm/sde_rsc.c').read_text()
+for marker in (
+    '"gcc_ufs_phy_gdsc"', '"mdss_core_gdsc"',
+    'A52GDSC disable-keep-on profile=ufs',
+    'A52GDSC disable profile=mdss',
+    'A52GDSC mdss-init name=%s before=0x%x after=0x%x hw=%u',
+    'A52GDSC register exit dev=%s name=%s rc=0 reg=0x%x profile=%s',
+    'REGULATOR_CHANGE_MODE',
+    'REGULATOR_MODE_NORMAL | REGULATOR_MODE_FAST',
+    'val |= A52_GDSC_SW_COLLAPSE;',
+    'val &= ~A52_GDSC_HW_CONTROL;',
+):
+    assert marker in gdsc, marker
+assert 'A52GDSC DISABLE_KEEP_ON' in gdsc
+assert 'return -ENODEV;' in gdsc
+assert '.compatible = "qcom,gdsc"' in gdsc
+assert 'devm_ioremap(&pdev->dev, res->start, resource_size(res))' in gdsc
+assert 'RSCCCORE suppliers dev=%s rc=%d reason=%s' in dd
+assert dd.count('ret = device_links_check_suppliers(dev);') == 1
+assert 'RSCC probe enter dev=%s node=%s counter=%d rpmh=%u' in rsc
+assert 'RSCC component-add exit rc=%d' in rsc
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase194-mdss-core-gdsc-provider.patch"
+test -s "$OUT/stage/phase194-mdss-core-gdsc-provider.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase194-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase194-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase194-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase194-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/regulator/a52-legacy-gdsc-regulator.o' \
+  "$OUT/logs/phase194-compile.log"
+for marker in \
+  'A52GDSC driver-register enter' \
+  'A52GDSC mdss-init name=%s before=0x%x after=0x%x hw=%u' \
+  'A52GDSC register enter dev=%s name=%s profile=%s hw=%u' \
+  'A52GDSC enable profile=%s name=%s rc=%d before=0x%x after=0x%x' \
+  'A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x' \
+  'A52GDSC disable-keep-on profile=ufs name=%s reg=0x%x' \
+  'RSCCCORE suppliers dev=%s rc=%d reason=%s' \
+  'RSCC probe stage=vdd-enable rc=%d' \
+  'RSCC component-add exit rc=%d' \
+  'DRMCOMP connectors prop=%u len=%d' \
+  'PINCTRL Lagoon reserved secure=13-16'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 194 MDSS core GDSC provider candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 193 hardware result:
+  - qcom,sde-rsc matches sde_rsc
+  - driver-core probing begins normally
+  - the display clock-controller supplier is ready
+  - the mdss_core_gdsc supplier has no driver
+  - supplier check returns -EPROBE_DEFER before sde_rsc_probe()
+  - BOOT_READY was reached and the kernel stayed alive through 46.140115 seconds
+
+Phase 194 is a narrow functional provider correction:
+  - the existing hardware-validated UFS GDSC profile remains keep-on
+  - mdss_core_gdsc is accepted as a second explicit profile
+  - MDSS uses normal software enable and power collapse
+  - the DT-declared hardware-trigger normal/fast modes are supported
+  - the existing supplier link and deferred-probe ordering are preserved
+
+It does not force probe, bypass a supplier, change the DTB, panel commands,
+display timing, clock rates, regulator voltages, ramdisk, or recovery DTBO.
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-mdss-core-gdsc-provider')
+base = json.loads(Path('artifacts/a52xq-rscc-drivercore-gate-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+gdsc = (root / 'stage/a52-legacy-gdsc-after-phase194.c').read_text()
+image = root / 'compile/Image'; boot = root / 'package/boot.img'
+audit = dict(base)
+audit.update({
+    'status': 'a52-mdss-core-gdsc-provider-audited',
+    'phase': 194,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase193': True,
+    'phase193_hardware_validated': True,
+    'phase193_kernel_alive_ms': 46140.115,
+    'phase193_blocking_supplier': 'qcom,gdsc@af01004 / mdss_core_gdsc',
+    'phase193_supplier_errno': -517,
+    'ufs_profile_preserved': 'A52GDSC DISABLE_KEEP_ON' in gdsc,
+    'mdss_profile_added': '"mdss_core_gdsc"' in gdsc,
+    'mdss_normal_collapse_added': 'A52GDSC disable profile=mdss' in gdsc,
+    'mdss_hw_trigger_mode_added': 'REGULATOR_CHANGE_MODE' in gdsc,
+    'supplier_link_bypassed': False,
+    'probe_forced': False,
+    'dtb_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'display_modes_changed': False,
+    'clock_rates_changed': False,
+    'regulator_voltage_changed': False,
+    'storage_write_added': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in ('phase193_hardware_validated','ufs_profile_preserved',
+            'mdss_profile_added','mdss_normal_collapse_added',
+            'mdss_hw_trigger_mode_added','dtb_preserved','ramdisk_preserved',
+            'recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True)+'\n')
+PY
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/194_fix_inherited_guard.py
+++ b/scripts/194_fix_inherited_guard.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+path = Path("scripts/194_apply.py")
+text = path.read_text(encoding="utf-8")
+
+stale = '        "A52GDSC DISABLE_KEEP_ON",\n'
+replacement = (
+    '        "static int a52_legacy_gdsc_disable(struct regulator_dev *rdev)",\n'
+    '        "boot-critical UFS GDSC",\n'
+)
+
+count = text.count(stale)
+if count == 1:
+    text = text.replace(stale, replacement, 1)
+elif count == 0 and all(
+    marker in text
+    for marker in (
+        "static int a52_legacy_gdsc_disable(struct regulator_dev *rdev)",
+        "boot-critical UFS GDSC",
+    )
+):
+    pass
+else:
+    raise SystemExit(
+        f"phase194 inherited-source guard layout changed unexpectedly: stale_count={count}"
+    )
+
+path.write_text(text, encoding="utf-8")
+print("phase194 inherited UFS guard normalized")


### PR DESCRIPTION
## Phase 193 hardware evidence

The untouched 1 MiB RAMOOPS capture identified the exact pre-probe blocker:

- `qcom,sde-rsc` matches `sde_rsc`
- driver-core probing begins normally
- the `dispcc` supplier is ready and bound
- the `qcom,gdsc@af01004` supplier is not bound
- supplier checking returns `-EPROBE_DEFER`
- the RSCC callback is never entered
- the kernel remains alive behind the black screen

The blocking node is the enabled standalone `qcom,gdsc` regulator named `mdss_core_gdsc`. The existing A52 compatibility bridge only accepts `gcc_ufs_phy_gdsc`, so the display supplier never becomes available.

## Phase 194 functional correction

Extend the existing compatibility provider with two explicit profiles:

- preserve `gcc_ufs_phy_gdsc` and its hardware-validated keep-on disable policy
- add `mdss_core_gdsc` with normal software enable and power collapse
- expose normal/fast mode switching for the DT-declared hardware-trigger feature
- initialize the display GDSCR in software state-machine mode, matching the original Qualcomm driver
- keep all register polling and recorder checkpoints local to the provider

The provider still rejects every other `qcom,gdsc` regulator name.

## Why this is safer than a bypass

This change does not force the RSCC probe, alter `fw_devlink`, drop the supplier link, remove `vdd-supply`, convert an errno, or remove RSCC from the DRM component list. The existing dependency becomes satisfiable through its intended regulator provider.

## Preserved behavior

- UFS profile and keep-on policy
- secure GPIO 13-16 reservation
- phase 191 DRM component trace
- phase 192 RSCC trace
- phase 193 driver-core supplier trace
- original DTB, ramdisk and recovery DTBO
- panel commands, display timing, modes, clock rates and regulator voltages

The patcher and shell workflow passed local syntax and source-shape validation. This PR is a draft and is not hardware validated.