### PR TITLE
Trace A52 DRM post-KMS initialization

### DIFF
--- a/.github/workflows/195-a52-drm-post-kms-trace.yml
+++ b/.github/workflows/195-a52-drm-post-kms-trace.yml
@@ -1,0 +1,102 @@
+name: 195 - A52 GKI 5.10 DRM post-KMS trace
+
+run-name: Build GKI 5.10 A52 DRM post-KMS trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-drm-post-kms-trace-v1
+    paths:
+      - .github/workflows/195-a52-drm-post-kms-trace.yml
+      - scripts/195_apply.py
+      - scripts/195_ci.sh
+      - scripts/195_NOTES.txt
+      - scripts/195_EXPECTED_MARKERS.txt
+      - RAMOOPS-PHASE194-HARDWARE-RESULT.md
+  pull_request:
+    branches:
+      - agent/a52-mdss-core-gdsc-provider-v1
+    paths:
+      - .github/workflows/195-a52-drm-post-kms-trace.yml
+      - scripts/195_apply.py
+      - scripts/195_ci.sh
+      - scripts/195_NOTES.txt
+      - scripts/195_EXPECTED_MARKERS.txt
+      - RAMOOPS-PHASE194-HARDWARE-RESULT.md
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-drm-post-kms-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-195 DRM post-KMS trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-195 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 195
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: |
+          python3 scripts/194_fix_inherited_guard.py
+          bash scripts/195_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-drm-post-kms-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-drm-post-kms-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-195 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-drm-post-kms-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-drm-post-kms-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/RAMOOPS-PHASE194-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE194-HARDWARE-RESULT.md
@@ -1,0 +1,45 @@
+# Phase 194 hardware result
+
+## Visible behavior
+
+The Samsung boot logo remained visible and frozen. The display no longer became black after roughly 20 seconds.
+
+## Capture integrity
+
+- Raw RAMOOPS size: 1,048,576 bytes.
+- Early and exported snapshots were identical.
+- SHA-256: `58f999824ff8442e726aa86e98bd57905c4230a4a4f7c68876dcb36beb7d68b0`.
+- Decoder recovered 706 records, sequence 17 through 755.
+- Last recovered timestamp: 1113.392 ms.
+
+## Confirmed progress
+
+Phase 194 resolved the RSCC supplier gate:
+
+- `mdss_core_gdsc` bound to `a52-legacy-gdsc-regulator`.
+- RSCC supplier check returned zero.
+- `sde_rsc_probe()` completed.
+- RSCC `component_add()` returned zero.
+- DRM component assembly reached `msm_drm_bind()`.
+- DSI controller, PHY, clock manager and host bind succeeded.
+- `dsi_panel_drv_init()` and Samsung `ss_panel_init()` succeeded.
+- RSCC bind succeeded.
+- `sde_kms_init()` and `_sde_kms_hw_init_blocks()` returned.
+
+## Final recovered events
+
+```text
+749 1108.662 ms DISP enter fn=a52.life.sde_kms_hw_init
+750 1109.051 ms DISP enter fn=a52.life._sde_kms_hw_init_blocks
+751 1112.610 ms DISP exit fn=a52.life._sde_kms_hw_init_blocks
+752 1112.741 ms A52GDSC mode profile=mdss name=mdss_core_gdsc mode=1 rc=0
+753 1113.006 ms A52GDSC disable profile=mdss name=mdss_core_gdsc rc=0
+754 1113.271 ms DISP exit fn=a52.life.sde_kms_hw_init
+755 1113.392 ms DISP exit fn=a52.life._msm_drm_init_helper
+```
+
+## Current interpretation
+
+The successful path in TouchGrass collapses MDP resources at this point only when the continuous-splash display count is zero. The physical logo can remain in the AMOLED panel frame memory even after MDP resources are dropped, explaining the new stuck-logo behavior.
+
+This is not yet sufficient justification to force continuous splash or keep the GDSC enabled. The exact post-KMS boundary must be traced first.

--- a/scripts/195_EXPECTED_MARKERS.txt
+++ b/scripts/195_EXPECTED_MARKERS.txt
@@ -1,0 +1,21 @@
+KMSPOST splash rc=<n> regions=<n> displays=<n>
+KMSPOST pm-get exit rc=<n>
+KMSPOST blocks exit rc=<n> crtc=<n> enc=<n> conn=<n> plane=<n>
+KMSPOST power-decision displays=<n> regions=<n>
+KMSPOST pm-put enter reason=no-splash
+KMSPOST affinity enter irq=<n>
+KMSPOST hw-init success crtc=<n> enc=<n> conn=<n> plane=<n>
+DRMPOST helper exit err=<0|1> null=<0|1> crtc=<n> enc=<n> conn=<n> plane=<n>
+DRMPOST commit-thread enter i=<n> crtc=<n>
+DRMPOST commit-sched exit i=<n> rc=<n>
+DRMPOST event-thread enter i=<n> crtc=<n>
+DRMPOST event-sched exit i=<n> rc=<n>
+DRMPOST pp-thread enter
+DRMPOST thread-create exit rc=<n>
+DRMPOST vblank exit rc=<n>
+DRMPOST irq-install exit rc=<n>
+DRMPOST dev-register exit rc=<n>
+DRMPOST mode-reset exit
+DRMPOST splash-config exit rc=<n>
+DRMPOST postinit exit rc=<n>
+DRMPOST init success

--- a/scripts/195_NOTES.txt
+++ b/scripts/195_NOTES.txt
@@ -1,0 +1,14 @@
+Phase 195 scope
+
+Hardware evidence from phase 194:
+- mdss_core_gdsc now binds.
+- RSCC probes and joins the DRM component framework.
+- msm_drm_bind, dsi_display_bind, dsi_panel_drv_init and ss_panel_init execute.
+- sde_kms_hw_init_blocks returns.
+- GDSC switches to hardware-trigger mode and is collapsed.
+- the Samsung boot logo remains visible instead of turning black.
+- the last recovered recorder event is the exit of _msm_drm_init_helper at 1113.392 ms.
+
+Phase 195 adds read-only flight-recorder checkpoints after that boundary.
+No return value, branch decision, scheduling policy, dependency, power vote,
+panel command, timing, clock rate, regulator voltage, DTB, DTBO or ramdisk is changed.

--- a/scripts/195_apply.py
+++ b/scripts/195_apply.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected exactly one anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_sde_kms(path: Path) -> None:
+    text = path.read_text()
+
+    text = replace_once(
+        text,
+        '''\trc = _sde_kms_get_splash_data(&sde_kms->splash_data);\n\tif (rc)\n\t\tSDE_DEBUG("sde splash data fetch failed: %d\\n", rc);\n\n\trc = pm_runtime_get_sync(sde_kms->dev->dev);\n''',
+        '''\trc = _sde_kms_get_splash_data(&sde_kms->splash_data);\n\ta52_ackfr_record("KMSPOST splash rc=%d regions=%u displays=%u",\n\t\trc, sde_kms->splash_data.num_splash_regions,\n\t\tsde_kms->splash_data.num_splash_displays);\n\tif (rc)\n\t\tSDE_DEBUG("sde splash data fetch failed: %d\\n", rc);\n\n\ta52_ackfr_record("KMSPOST pm-get enter");\n\trc = pm_runtime_get_sync(sde_kms->dev->dev);\n\ta52_ackfr_record("KMSPOST pm-get exit rc=%d", rc);\n''',
+        "sde splash and pm get",
+    )
+
+    text = replace_once(
+        text,
+        '''\trc = _sde_kms_hw_init_blocks(sde_kms, dev, priv);\n\tif (rc)\n\t\tgoto hw_init_err;\n\n\tdev->mode_config.min_width = sde_kms->catalog->min_display_width;\n''',
+        '''\ta52_ackfr_record("KMSPOST blocks enter");\n\trc = _sde_kms_hw_init_blocks(sde_kms, dev, priv);\n\ta52_ackfr_record("KMSPOST blocks exit rc=%d crtc=%d enc=%d conn=%d plane=%d",\n\t\trc, priv->num_crtcs, priv->num_encoders,\n\t\tpriv->num_connectors, priv->num_planes);\n\tif (rc)\n\t\tgoto hw_init_err;\n\n\tdev->mode_config.min_width = sde_kms->catalog->min_display_width;\n''',
+        "sde blocks",
+    )
+
+    text = replace_once(
+        text,
+        '''\tif (sde_kms->splash_data.num_splash_displays) {\n\t\tSDE_DEBUG("Skipping MDP Resources disable\\n");\n\t} else {\n\t\tfor (i = 0; i < SDE_POWER_HANDLE_DBUS_ID_MAX; i++)\n\t\t\tsde_power_data_bus_set_quota(&priv->phandle, i,\n\t\t\t\tSDE_POWER_HANDLE_ENABLE_BUS_AB_QUOTA,\n\t\t\t\tSDE_POWER_HANDLE_ENABLE_BUS_IB_QUOTA);\n\n\t\tpm_runtime_put_sync(sde_kms->dev->dev);\n\t}\n''',
+        '''\ta52_ackfr_record("KMSPOST power-decision displays=%u regions=%u",\n\t\tsde_kms->splash_data.num_splash_displays,\n\t\tsde_kms->splash_data.num_splash_regions);\n\tif (sde_kms->splash_data.num_splash_displays) {\n\t\ta52_ackfr_record("KMSPOST power keep reason=continuous-splash");\n\t\tSDE_DEBUG("Skipping MDP Resources disable\\n");\n\t} else {\n\t\tfor (i = 0; i < SDE_POWER_HANDLE_DBUS_ID_MAX; i++)\n\t\t\tsde_power_data_bus_set_quota(&priv->phandle, i,\n\t\t\t\tSDE_POWER_HANDLE_ENABLE_BUS_AB_QUOTA,\n\t\t\t\tSDE_POWER_HANDLE_ENABLE_BUS_IB_QUOTA);\n\n\t\ta52_ackfr_record("KMSPOST pm-put enter reason=no-splash");\n\t\tpm_runtime_put_sync(sde_kms->dev->dev);\n\t\ta52_ackfr_record("KMSPOST pm-put exit");\n\t}\n''',
+        "sde power decision",
+    )
+
+    text = replace_once(
+        text,
+        '''\tirq_num = platform_get_irq(to_platform_device(sde_kms->dev->dev), 0);\n\tSDE_DEBUG("Registering for notification of irq_num: %d\\n", irq_num);\n\tirq_set_affinity_notifier(irq_num, &sde_kms->affinity_notify);\n\n\treturn 0;\n\nhw_init_err:\n''',
+        '''\tirq_num = platform_get_irq(to_platform_device(sde_kms->dev->dev), 0);\n\ta52_ackfr_record("KMSPOST affinity enter irq=%d", irq_num);\n\tSDE_DEBUG("Registering for notification of irq_num: %d\\n", irq_num);\n\tirq_set_affinity_notifier(irq_num, &sde_kms->affinity_notify);\n\ta52_ackfr_record("KMSPOST affinity exit");\n\n\ta52_ackfr_record("KMSPOST hw-init success crtc=%d enc=%d conn=%d plane=%d",\n\t\tpriv->num_crtcs, priv->num_encoders,\n\t\tpriv->num_connectors, priv->num_planes);\n\treturn 0;\n\nhw_init_err:\n''',
+        "sde affinity and return",
+    )
+
+    text = replace_once(
+        text,
+        '''hw_init_err:\n\tpm_runtime_put_sync(sde_kms->dev->dev);\nerror:\n\t_sde_kms_hw_destroy(sde_kms, platformdev);\nend:\n\treturn rc;\n''',
+        '''hw_init_err:\n\ta52_ackfr_record("KMSPOST fail stage=blocks rc=%d", rc);\n\tpm_runtime_put_sync(sde_kms->dev->dev);\nerror:\n\ta52_ackfr_record("KMSPOST fail stage=destroy rc=%d", rc);\n\t_sde_kms_hw_destroy(sde_kms, platformdev);\nend:\n\ta52_ackfr_record("KMSPOST hw-init exit rc=%d", rc);\n\treturn rc;\n''',
+        "sde error path",
+    )
+
+    path.write_text(text)
+
+
+def patch_msm_drv(path: Path) -> None:
+    text = path.read_text()
+
+    text = replace_once(
+        text,
+        '''static int msm_drm_display_thread_create(struct sched_param param,\n\tstruct msm_drm_private *priv, struct drm_device *ddev,\n\tstruct device *dev)\n{\n\tint i, ret = 0;\n''',
+        '''static int msm_drm_display_thread_create(struct sched_param param,\n\tstruct msm_drm_private *priv, struct drm_device *ddev,\n\tstruct device *dev)\n{\n\tint i, ret = 0;\n\n\ta52_ackfr_record("DRMPOST threads enter crtc=%d", priv->num_crtcs);\n''',
+        "thread create enter",
+    )
+
+    text = replace_once(
+        text,
+        '''\t\tpriv->disp_thread[i].thread =\n\t\t\tkthread_run(kthread_worker_fn,\n\t\t\t\t&priv->disp_thread[i].worker,\n\t\t\t\t"crtc_commit:%d", priv->disp_thread[i].crtc_id);\n\t\tret = sched_setscheduler(priv->disp_thread[i].thread,\n''',
+        '''\t\ta52_ackfr_record("DRMPOST commit-thread enter i=%d crtc=%u",\n\t\t\ti, priv->disp_thread[i].crtc_id);\n\t\tpriv->disp_thread[i].thread =\n\t\t\tkthread_run(kthread_worker_fn,\n\t\t\t\t&priv->disp_thread[i].worker,\n\t\t\t\t"crtc_commit:%d", priv->disp_thread[i].crtc_id);\n\t\ta52_ackfr_record("DRMPOST commit-thread exit i=%d err=%d",\n\t\t\ti, IS_ERR(priv->disp_thread[i].thread));\n\t\ta52_ackfr_record("DRMPOST commit-sched enter i=%d", i);\n\t\tret = sched_setscheduler(priv->disp_thread[i].thread,\n''',
+        "commit thread",
+    )
+
+    text = replace_once(
+        text,
+        '''\t\tret = sched_setscheduler(priv->disp_thread[i].thread,\n\t\t\t\t\t\t\tSCHED_FIFO, &param);\n\t\tif (ret)\n''',
+        '''\t\tret = sched_setscheduler(priv->disp_thread[i].thread,\n\t\t\t\t\t\t\tSCHED_FIFO, &param);\n\t\ta52_ackfr_record("DRMPOST commit-sched exit i=%d rc=%d", i, ret);\n\t\tif (ret)\n''',
+        "commit scheduler exit",
+    )
+
+    text = replace_once(
+        text,
+        '''\t\tpriv->event_thread[i].thread =\n\t\t\tkthread_run(kthread_worker_fn,\n\t\t\t\t&priv->event_thread[i].worker,\n\t\t\t\t"crtc_event:%d", priv->event_thread[i].crtc_id);\n''',
+        '''\t\ta52_ackfr_record("DRMPOST event-thread enter i=%d crtc=%u",\n\t\t\ti, priv->event_thread[i].crtc_id);\n\t\tpriv->event_thread[i].thread =\n\t\t\tkthread_run(kthread_worker_fn,\n\t\t\t\t&priv->event_thread[i].worker,\n\t\t\t\t"crtc_event:%d", priv->event_thread[i].crtc_id);\n\t\ta52_ackfr_record("DRMPOST event-thread exit i=%d err=%d",\n\t\t\ti, IS_ERR(priv->event_thread[i].thread));\n''',
+        "event thread",
+    )
+
+    text = replace_once(
+        text,
+        '''\t\tret = sched_setscheduler(priv->event_thread[i].thread,\n\t\t\t\t\t\t\tSCHED_FIFO, &param);\n''',
+        '''\t\ta52_ackfr_record("DRMPOST event-sched enter i=%d", i);\n\t\tret = sched_setscheduler(priv->event_thread[i].thread,\n\t\t\t\t\t\t\tSCHED_FIFO, &param);\n\t\ta52_ackfr_record("DRMPOST event-sched exit i=%d rc=%d", i, ret);\n''',
+        "event scheduler",
+    )
+
+    text = replace_once(
+        text,
+        '''\tpriv->pp_event_thread = kthread_run(kthread_worker_fn,\n\t\t\t&priv->pp_event_worker, "pp_event");\n\n\tret = sched_setscheduler(priv->pp_event_thread,\n''',
+        '''\ta52_ackfr_record("DRMPOST pp-thread enter");\n\tpriv->pp_event_thread = kthread_run(kthread_worker_fn,\n\t\t\t&priv->pp_event_worker, "pp_event");\n\ta52_ackfr_record("DRMPOST pp-thread exit err=%d",\n\t\tIS_ERR(priv->pp_event_thread));\n\ta52_ackfr_record("DRMPOST pp-sched enter");\n\n\tret = sched_setscheduler(priv->pp_event_thread,\n''',
+        "pp thread",
+    )
+
+    text = replace_once(
+        text,
+        '''\tret = sched_setscheduler(priv->pp_event_thread,\n\t\t\t\t\t\tSCHED_FIFO, &param);\n\tif (ret)\n''',
+        '''\tret = sched_setscheduler(priv->pp_event_thread,\n\t\t\t\t\t\tSCHED_FIFO, &param);\n\ta52_ackfr_record("DRMPOST pp-sched exit rc=%d", ret);\n\tif (ret)\n''',
+        "pp scheduler exit",
+    )
+
+    text = replace_once(
+        text,
+        '''\treturn 0;\n\n}\nstatic struct msm_kms *_msm_drm_init_helper''',
+        '''\ta52_ackfr_record("DRMPOST threads exit rc=0");\n\treturn 0;\n\n}\nstatic struct msm_kms *_msm_drm_init_helper''',
+        "thread function success",
+    )
+
+    text = replace_once(
+        text,
+        '''\tkms = _msm_drm_init_helper(priv, ddev, dev, pdev);\n\tif (IS_ERR_OR_NULL(kms)) {\n''',
+        '''\ta52_ackfr_record("DRMPOST helper enter");\n\tkms = _msm_drm_init_helper(priv, ddev, dev, pdev);\n\ta52_ackfr_record("DRMPOST helper exit err=%d null=%d crtc=%d enc=%d conn=%d plane=%d",\n\t\tIS_ERR(kms), !kms, priv->num_crtcs, priv->num_encoders,\n\t\tpriv->num_connectors, priv->num_planes);\n\tif (IS_ERR_OR_NULL(kms)) {\n''',
+        "helper result",
+    )
+
+    text = replace_once(
+        text,
+        '''\tret = msm_drm_display_thread_create(param, priv, ddev, dev);\n\tif (ret) {\n''',
+        '''\ta52_ackfr_record("DRMPOST thread-create enter");\n\tret = msm_drm_display_thread_create(param, priv, ddev, dev);\n\ta52_ackfr_record("DRMPOST thread-create exit rc=%d", ret);\n\tif (ret) {\n''',
+        "thread result",
+    )
+
+    text = replace_once(
+        text,
+        '''\tret = drm_vblank_init(ddev, priv->num_crtcs);\n\tif (ret < 0) {\n''',
+        '''\ta52_ackfr_record("DRMPOST vblank enter crtc=%d", priv->num_crtcs);\n\tret = drm_vblank_init(ddev, priv->num_crtcs);\n\ta52_ackfr_record("DRMPOST vblank exit rc=%d", ret);\n\tif (ret < 0) {\n''',
+        "vblank",
+    )
+
+    text = replace_once(
+        text,
+        '''\tif (kms) {\n\t\tpm_runtime_get_sync(dev);\n\t\tret = drm_irq_install(ddev, platform_get_irq(pdev, 0));\n\t\tpm_runtime_put_sync(dev);\n''',
+        '''\tif (kms) {\n\t\ta52_ackfr_record("DRMPOST irq-pm-get enter");\n\t\tpm_runtime_get_sync(dev);\n\t\ta52_ackfr_record("DRMPOST irq-pm-get exit");\n\t\ta52_ackfr_record("DRMPOST irq-install enter irq=%d",\n\t\t\tplatform_get_irq(pdev, 0));\n\t\tret = drm_irq_install(ddev, platform_get_irq(pdev, 0));\n\t\ta52_ackfr_record("DRMPOST irq-install exit rc=%d", ret);\n\t\ta52_ackfr_record("DRMPOST irq-pm-put enter");\n\t\tpm_runtime_put_sync(dev);\n\t\ta52_ackfr_record("DRMPOST irq-pm-put exit");\n''',
+        "irq stage",
+    )
+
+    text = replace_once(
+        text,
+        '''\tret = drm_dev_register(ddev, 0);\n\tif (ret)\n\t\tgoto fail;\n\tpriv->registered = true;\n\n\tdrm_mode_config_reset(ddev);\n''',
+        '''\ta52_ackfr_record("DRMPOST dev-register enter");\n\tret = drm_dev_register(ddev, 0);\n\ta52_ackfr_record("DRMPOST dev-register exit rc=%d", ret);\n\tif (ret)\n\t\tgoto fail;\n\tpriv->registered = true;\n\n\ta52_ackfr_record("DRMPOST mode-reset enter");\n\tdrm_mode_config_reset(ddev);\n\ta52_ackfr_record("DRMPOST mode-reset exit");\n''',
+        "device register and reset",
+    )
+
+    text = replace_once(
+        text,
+        '''\tif (kms && kms->funcs && kms->funcs->cont_splash_config) {\n\t\tret = kms->funcs->cont_splash_config(kms);\n''',
+        '''\tif (kms && kms->funcs && kms->funcs->cont_splash_config) {\n\t\ta52_ackfr_record("DRMPOST splash-config enter");\n\t\tret = kms->funcs->cont_splash_config(kms);\n\t\ta52_ackfr_record("DRMPOST splash-config exit rc=%d", ret);\n''',
+        "splash config",
+    )
+
+    text = replace_once(
+        text,
+        '''\tret = sde_dbg_debugfs_register(dev);\n''',
+        '''\ta52_ackfr_record("DRMPOST debugfs enter");\n\tret = sde_dbg_debugfs_register(dev);\n\ta52_ackfr_record("DRMPOST debugfs exit rc=%d", ret);\n''',
+        "debugfs",
+    )
+
+    text = replace_once(
+        text,
+        '''\tif (kms && kms->funcs && kms->funcs->postinit) {\n\t\tret = kms->funcs->postinit(kms);\n''',
+        '''\tif (kms && kms->funcs && kms->funcs->postinit) {\n\t\ta52_ackfr_record("DRMPOST postinit enter");\n\t\tret = kms->funcs->postinit(kms);\n\t\ta52_ackfr_record("DRMPOST postinit exit rc=%d", ret);\n''',
+        "postinit",
+    )
+
+    text = replace_once(
+        text,
+        '''\tdrm_kms_helper_poll_init(ddev);\n\n\treturn 0;\n\nfail:\n''',
+        '''\ta52_ackfr_record("DRMPOST poll-init enter");\n\tdrm_kms_helper_poll_init(ddev);\n\ta52_ackfr_record("DRMPOST poll-init exit");\n\n\ta52_ackfr_record("DRMPOST init success");\n\treturn 0;\n\nfail:\n\ta52_ackfr_record("DRMPOST init fail rc=%d", ret);\n''',
+        "poll and final result",
+    )
+
+    path.write_text(text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', required=True)
+    args = parser.parse_args()
+    root = Path(args.root)
+    patch_sde_kms(root / 'drivers/a52_display/msm/sde/sde_kms.c')
+    patch_msm_drv(root / 'drivers/a52_display/msm/msm_drv.c')
+    print('phase195 DRM post-KMS and splash trace applied')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/195_ci.sh
+++ b/scripts/195_ci.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-mdss-core-gdsc-provider"
+OUT="$PWD/artifacts/a52xq-drm-post-kms-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/194_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase195.config"
+cp "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+  "$OUT/stage/msm-drv-before-phase195.c"
+cp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$OUT/stage/sde-kms-before-phase195.c"
+
+python3 scripts/195_apply.py --root "$ROOT" | tee "$OUT/logs/phase195-apply.log"
+
+cp "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+  "$OUT/stage/msm-drv-after-phase195.c"
+cp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$OUT/stage/sde-kms-after-phase195.c"
+cp scripts/195_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase195.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+msm = (root / 'drivers/a52_display/msm/msm_drv.c').read_text()
+kms = (root / 'drivers/a52_display/msm/sde/sde_kms.c').read_text()
+
+msm_markers = (
+    'DRMPOST helper enter',
+    'DRMPOST helper exit err=%d null=%d crtc=%d enc=%d conn=%d plane=%d',
+    'DRMPOST threads enter crtc=%d',
+    'DRMPOST commit-thread enter i=%d crtc=%u',
+    'DRMPOST commit-sched exit i=%d rc=%d',
+    'DRMPOST event-thread enter i=%d crtc=%u',
+    'DRMPOST event-sched exit i=%d rc=%d',
+    'DRMPOST pp-thread enter',
+    'DRMPOST thread-create exit rc=%d',
+    'DRMPOST vblank exit rc=%d',
+    'DRMPOST irq-install exit rc=%d',
+    'DRMPOST dev-register exit rc=%d',
+    'DRMPOST mode-reset exit',
+    'DRMPOST splash-config exit rc=%d',
+    'DRMPOST postinit exit rc=%d',
+    'DRMPOST init success',
+    'DRMPOST init fail rc=%d',
+)
+for marker in msm_markers:
+    assert msm.count(marker) == 1, (marker, msm.count(marker))
+
+kms_markers = (
+    'KMSPOST splash rc=%d regions=%u displays=%u',
+    'KMSPOST pm-get exit rc=%d',
+    'KMSPOST blocks exit rc=%d crtc=%d enc=%d conn=%d plane=%d',
+    'KMSPOST power-decision displays=%u regions=%u',
+    'KMSPOST power keep reason=continuous-splash',
+    'KMSPOST pm-put enter reason=no-splash',
+    'KMSPOST affinity enter irq=%d',
+    'KMSPOST hw-init success crtc=%d enc=%d conn=%d plane=%d',
+    'KMSPOST hw-init exit rc=%d',
+)
+for marker in kms_markers:
+    assert kms.count(marker) == 1, (marker, kms.count(marker))
+
+# Observation-only safety invariants. The original calls and control decisions remain.
+for marker in (
+    'kms = _msm_drm_init_helper(priv, ddev, dev, pdev);',
+    'ret = msm_drm_display_thread_create(param, priv, ddev, dev);',
+    'ret = drm_vblank_init(ddev, priv->num_crtcs);',
+    'ret = drm_irq_install(ddev, platform_get_irq(pdev, 0));',
+    'ret = drm_dev_register(ddev, 0);',
+    'drm_mode_config_reset(ddev);',
+    'ret = kms->funcs->cont_splash_config(kms);',
+    'drm_kms_helper_poll_init(ddev);',
+):
+    assert marker in msm, marker
+
+for marker in (
+    'rc = _sde_kms_get_splash_data(&sde_kms->splash_data);',
+    'rc = pm_runtime_get_sync(sde_kms->dev->dev);',
+    'rc = _sde_kms_hw_init_blocks(sde_kms, dev, priv);',
+    'if (sde_kms->splash_data.num_splash_displays)',
+    'pm_runtime_put_sync(sde_kms->dev->dev);',
+    'irq_set_affinity_notifier(irq_num, &sde_kms->affinity_notify);',
+):
+    assert marker in kms, marker
+
+# The phase-194 functional provider and earlier evidence remain present.
+gdsc = (root / 'drivers/regulator/a52-legacy-gdsc-regulator.c').read_text()
+for marker in (
+    '"mdss_core_gdsc"',
+    'A52GDSC disable profile=mdss',
+    'REGULATOR_CHANGE_MODE',
+):
+    assert marker in gdsc, marker
+assert 'RSCCCORE suppliers dev=%s rc=%d reason=%s' in \
+    (root / 'drivers/base/dd.c').read_text()
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase195-drm-post-kms-trace.patch"
+test -s "$OUT/stage/phase195-drm-post-kms-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase195-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase195-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase195-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase195-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/a52_display/msm/msm_drv.o' \
+  "$OUT/logs/phase195-compile.log"
+grep -Fq 'drivers/a52_display/msm/sde/sde_kms.o' \
+  "$OUT/logs/phase195-compile.log"
+for marker in \
+  'KMSPOST splash rc=%d regions=%u displays=%u' \
+  'KMSPOST blocks exit rc=%d crtc=%d enc=%d conn=%d plane=%d' \
+  'KMSPOST power-decision displays=%u regions=%u' \
+  'KMSPOST pm-put enter reason=no-splash' \
+  'KMSPOST hw-init success crtc=%d enc=%d conn=%d plane=%d' \
+  'DRMPOST helper exit err=%d null=%d crtc=%d enc=%d conn=%d plane=%d' \
+  'DRMPOST commit-thread enter i=%d crtc=%u' \
+  'DRMPOST thread-create exit rc=%d' \
+  'DRMPOST vblank exit rc=%d' \
+  'DRMPOST irq-install exit rc=%d' \
+  'DRMPOST dev-register exit rc=%d' \
+  'DRMPOST splash-config exit rc=%d' \
+  'DRMPOST init success' \
+  'A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x' \
+  'RSCC component-add exit rc=%d'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 195 DRM post-KMS and continuous-splash trace candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 194 hardware result:
+  - mdss_core_gdsc bound successfully
+  - RSCC passed its supplier gate, probed and joined the DRM component master
+  - msm_drm_bind, DSI bind, panel driver init and Samsung panel init executed
+  - sde_kms_hw_init_blocks returned
+  - the Samsung logo remained visible instead of turning black
+  - the last recovered event was immediately after _msm_drm_init_helper
+
+Phase 195 is observation only. It records:
+  - continuous-splash region and display counts
+  - KMS object counts
+  - display commit/event and pp thread creation
+  - vblank initialization
+  - IRQ runtime-PM and installation
+  - DRM device registration and mode reset
+  - continuous-splash configuration
+  - KMS post-init and poll initialization
+  - exact success or failure boundary
+
+It does not force continuous splash, keep the GDSC on, alter return codes,
+change scheduling, bypass a dependency, modify DTB/DTBO, change panel commands,
+display timing, clock rates, regulator voltages, ramdisk, or recovery DTBO.
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-drm-post-kms-trace')
+base = json.loads(Path('artifacts/a52xq-mdss-core-gdsc-provider/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+msm = (root / 'stage/msm-drv-after-phase195.c').read_text()
+kms = (root / 'stage/sde-kms-after-phase195.c').read_text()
+audit = dict(base)
+audit.update({
+    'status': 'a52-drm-post-kms-trace-audited',
+    'phase': 195,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase194': False,
+    'phase194_hardware_validated': True,
+    'phase194_last_recorder_sequence': 755,
+    'phase194_last_recorder_timestamp_ms': 1113.392,
+    'phase194_last_scope': 'a52.life._msm_drm_init_helper',
+    'phase194_visible_result': 'Samsung logo remained visible and frozen',
+    'continuous_splash_forced': False,
+    'gdsc_keep_on_forced': False,
+    'return_codes_changed': False,
+    'thread_scheduling_changed': False,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'clock_rates_changed': False,
+    'regulator_voltage_changed': False,
+    'post_kms_trace_present': 'DRMPOST init success' in msm,
+    'splash_count_trace_present': 'KMSPOST splash rc=%d regions=%u displays=%u' in kms,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase194_hardware_validated', 'post_kms_trace_present',
+    'splash_count_trace_present', 'dtb_preserved', 'ramdisk_preserved',
+    'recovery_dtbo_preserved',
+):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Hardware finding

Phase 194 resolved the missing `mdss_core_gdsc` supplier and allowed RSCC, DRM component assembly, DSI bind, Samsung panel initialization, and SDE KMS hardware initialization to execute.

The visible behavior changed from a black screen after about 20 seconds to a Samsung logo that remained visible and frozen.

The persistent recorder stopped at sequence 755, timestamp 1113.392 ms, immediately after `_msm_drm_init_helper()` returned. The final preceding events show the MDSS GDSC entering hardware-trigger mode and being collapsed.

## Phase 195

This change adds read-only persistent checkpoints around:

- continuous-splash region and display counts
- KMS object counts after hardware-block initialization
- the MDP power-retention decision
- commit, event and post-processing thread creation
- vblank initialization
- IRQ runtime-PM and installation
- DRM device registration and mode reset
- continuous-splash configuration
- KMS post-initialization and poll initialization
- exact success and failure boundaries

## Safety

Phase 195 does not force continuous splash, keep the GDSC enabled, change a return value, alter thread scheduling, bypass a dependency, modify DTB or DTBO, change panel commands or timing, change clock rates or regulator voltages, or modify the ramdisk.

The workflow rebuilds the full inherited chain, compiles the exact modified DRM and KMS objects, audits marker presence in the final Image, repacks only BOOT, verifies partition invariants, runs recorder decoder self-tests, and emits checksums.

Draft and not hardware validated.