### PR TITLE
Trace A52 KMS hardware-block initialization

### DIFF
--- a/.github/workflows/196-a52-kms-block-init-trace.yml
+++ b/.github/workflows/196-a52-kms-block-init-trace.yml
@@ -1,0 +1,102 @@
+name: 196 - A52 GKI 5.10 KMS block initialization trace
+
+run-name: Build GKI 5.10 A52 KMS block initialization trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-kms-block-init-trace-v1
+    paths:
+      - .github/workflows/196-a52-kms-block-init-trace.yml
+      - scripts/196_apply.py
+      - scripts/196_ci.sh
+      - scripts/196_NOTES.txt
+      - scripts/196_EXPECTED_MARKERS.txt
+      - RAMOOPS-PHASE195-HARDWARE-RESULT.md
+  pull_request:
+    branches:
+      - agent/a52-drm-post-kms-trace-v1
+    paths:
+      - .github/workflows/196-a52-kms-block-init-trace.yml
+      - scripts/196_apply.py
+      - scripts/196_ci.sh
+      - scripts/196_NOTES.txt
+      - scripts/196_EXPECTED_MARKERS.txt
+      - RAMOOPS-PHASE195-HARDWARE-RESULT.md
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-kms-block-init-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+
+jobs:
+  build-package:
+    name: Build phase-196 KMS block initialization trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out phase-196 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, trace, package and audit phase 196
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: |
+          python3 scripts/194_fix_inherited_guard.py
+          bash scripts/196_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-kms-block-init-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-kms-block-init-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload phase-196 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-kms-block-init-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-kms-block-init-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/RAMOOPS-PHASE195-HARDWARE-RESULT.md
+++ b/RAMOOPS-PHASE195-HARDWARE-RESULT.md
@@ -1,0 +1,26 @@
+# Phase 195 hardware result
+
+The raw 1 MiB RAMOOPS snapshot and early frozen copy are identical. SHA-256:
+
+`cbadd5317354536d98ae63c332a3f50707b74861060a320b5273a99e8a2cadee`
+
+The exact phase 195 decoder recovered 702 records, sequences 65 through 766.
+
+Key result:
+
+```text
+KMSPOST splash rc=0 regions=1 displays=1
+KMSPOST pm-get exit rc=0
+KMSPOST blocks exit rc=-19 crtc=0 enc=0 conn=0 plane=0
+KMSPOST fail stage=blocks rc=-19
+```
+
+DSI controller, PHY, clock manager, MIPI host, panel driver and Samsung
+`ss_panel_init()` completed before this point. RSCC also bound successfully.
+
+`-19` is `-ENODEV`. The failure is inside `_sde_kms_hw_init_blocks()` before
+any DRM CRTC, encoder, connector or plane is created. The subsequent
+`mdss_core_gdsc` collapse is error cleanup, not the root cause.
+
+Phase 196 adds observation-only checkpoints around every hardware-block and
+SMMU/splash-map substep to identify the exact source of `-ENODEV`.

--- a/scripts/196_EXPECTED_MARKERS.txt
+++ b/scripts/196_EXPECTED_MARKERS.txt
@@ -1,0 +1,22 @@
+KMSBLK core-rev exit rev=0x%x
+KMSBLK catalog exit rc=%ld null=%d
+KMSBLK power-helper exit rc=%d genpd=%d
+KMSBLK mmu exit rc=%d base-null=%d
+KMSMMU new exit domain=%d rc=%ld
+KMSMMU aspace exit domain=%d rc=%ld
+KMSMMU splash-map exit domain=%d rc=%d
+KMSMMU early-map exit domain=%d rc=%d
+KMSBLK reg-dma exit rc=%d
+KMSBLK rm exit rc=%d
+KMSBLK intr exit rc=%ld null=%d
+KMSBLK splash-res exit rc=%d
+KMSBLK mdp exit rc=%ld null=%d
+KMSBLK vbif exit i=%d id=%u rc=%ld null=%d
+KMSBLK sid exit rc=%ld null=%d
+KMSBLK perf exit rc=%d
+KMSBLK drm-obj exit rc=%d crtc=%d enc=%d conn=%d plane=%d
+KMSOBJ irq-domain exit rc=%d
+KMSOBJ get-displays rc=%d
+KMSOBJ setup-displays rc=%d enc=%d conn=%d
+KMSOBJ plane exit i=%d rc=%ld
+KMSOBJ crtc exit i=%d rc=%ld

--- a/scripts/196_NOTES.txt
+++ b/scripts/196_NOTES.txt
@@ -1,0 +1,13 @@
+Phase 196 scope: KMS hardware-block initialization trace
+
+Hardware evidence from phase 195:
+- continuous splash is valid: one region and one display
+- DSI and Samsung panel initialization complete
+- runtime-PM acquisition succeeds
+- _sde_kms_hw_init_blocks returns -ENODEV
+- no DRM objects are created
+- GDSC collapse follows the failure and is cleanup
+
+This phase adds persistent observation checkpoints only. It does not change
+control flow, error handling, device-tree data, display commands, power policy,
+IOMMU behavior, clocks, regulator voltages, thread scheduling or partition data.

--- a/scripts/196_apply.py
+++ b/scripts/196_apply.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected exactly one anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch(path: Path) -> None:
+    text = path.read_text()
+
+    text = replace_once(text,
+'''\tfor (i = 0; i < MSM_SMMU_DOMAIN_MAX; i++) {
+\t\tstruct msm_gem_address_space *aspace;
+
+\t\tmmu = msm_smmu_new(sde_kms->dev->dev, i);
+\t\tif (IS_ERR(mmu)) {
+''',
+'''\ta52_ackfr_record("KMSMMU enter domains=%d regions=%u", MSM_SMMU_DOMAIN_MAX,
+\t\tsde_kms->splash_data.num_splash_regions);
+\tfor (i = 0; i < MSM_SMMU_DOMAIN_MAX; i++) {
+\t\tstruct msm_gem_address_space *aspace;
+
+\t\ta52_ackfr_record("KMSMMU new enter domain=%d", i);
+\t\tmmu = msm_smmu_new(sde_kms->dev->dev, i);
+\t\ta52_ackfr_record("KMSMMU new exit domain=%d rc=%ld", i,
+\t\t\tIS_ERR(mmu) ? PTR_ERR(mmu) : 0L);
+\t\tif (IS_ERR(mmu)) {
+''', 'mmu new')
+
+    text = replace_once(text,
+'''\t\taspace = msm_gem_smmu_address_space_create(sde_kms->dev,
+\t\t\tmmu, "sde");
+\t\tif (IS_ERR(aspace)) {
+''',
+'''\t\ta52_ackfr_record("KMSMMU aspace enter domain=%d", i);
+\t\taspace = msm_gem_smmu_address_space_create(sde_kms->dev,
+\t\t\tmmu, "sde");
+\t\ta52_ackfr_record("KMSMMU aspace exit domain=%d rc=%ld", i,
+\t\t\tIS_ERR(aspace) ? PTR_ERR(aspace) : 0L);
+\t\tif (IS_ERR(aspace)) {
+''', 'mmu aspace')
+
+    text = replace_once(text,
+'''\t\t\tret = _sde_kms_map_all_splash_regions(sde_kms);
+\t\t\tif (ret) {
+''',
+'''\t\t\ta52_ackfr_record("KMSMMU splash-map enter domain=%d", i);
+\t\t\tret = _sde_kms_map_all_splash_regions(sde_kms);
+\t\t\ta52_ackfr_record("KMSMMU splash-map exit domain=%d rc=%d", i, ret);
+\t\t\tif (ret) {
+''', 'mmu splash map')
+
+    text = replace_once(text,
+'''\t\tret = mmu->funcs->set_attribute(mmu, DOMAIN_ATTR_EARLY_MAP,
+\t\t\t\t &early_map);
+\t\tif (ret) {
+''',
+'''\t\ta52_ackfr_record("KMSMMU early-map enter domain=%d", i);
+\t\tret = mmu->funcs->set_attribute(mmu, DOMAIN_ATTR_EARLY_MAP,
+\t\t\t\t &early_map);
+\t\ta52_ackfr_record("KMSMMU early-map exit domain=%d rc=%d", i, ret);
+\t\tif (ret) {
+''', 'mmu early map')
+
+    text = replace_once(text,
+'''\tsde_kms->base.aspace = sde_kms->aspace[0];
+
+\treturn 0;
+
+early_map_fail:
+''',
+'''\tsde_kms->base.aspace = sde_kms->aspace[0];
+\ta52_ackfr_record("KMSMMU success base-null=%d", !sde_kms->base.aspace);
+
+\treturn 0;
+
+early_map_fail:
+\ta52_ackfr_record("KMSMMU fail stage=early-map rc=%d", ret);
+''', 'mmu result')
+
+    text = replace_once(text,
+'''fail:
+\t_sde_kms_mmu_destroy(sde_kms);
+
+\treturn ret;
+}
+''',
+'''fail:
+\ta52_ackfr_record("KMSMMU fail stage=destroy rc=%d", ret);
+\t_sde_kms_mmu_destroy(sde_kms);
+
+\treturn ret;
+}
+''', 'mmu fail')
+
+    text = replace_once(text,
+'''\t_sde_kms_core_hw_rev_init(sde_kms);
+
+\tpr_info("sde hardware revision:0x%x\\n", sde_kms->core_rev);
+
+\tsde_kms->catalog = sde_hw_catalog_init(dev, sde_kms->core_rev);
+''',
+'''\ta52_ackfr_record("KMSBLK core-rev enter");
+\t_sde_kms_core_hw_rev_init(sde_kms);
+\ta52_ackfr_record("KMSBLK core-rev exit rev=0x%x", sde_kms->core_rev);
+
+\tpr_info("sde hardware revision:0x%x\\n", sde_kms->core_rev);
+
+\ta52_ackfr_record("KMSBLK catalog enter rev=0x%x", sde_kms->core_rev);
+\tsde_kms->catalog = sde_hw_catalog_init(dev, sde_kms->core_rev);
+\ta52_ackfr_record("KMSBLK catalog exit rc=%ld null=%d",
+\t\tIS_ERR(sde_kms->catalog) ? PTR_ERR(sde_kms->catalog) : 0L,
+\t\t!sde_kms->catalog);
+''', 'catalog')
+
+    text = replace_once(text,
+'''\trc = _sde_kms_hw_init_power_helper(dev, sde_kms);
+\tif (rc) {
+''',
+'''\ta52_ackfr_record("KMSBLK power-helper enter");
+\trc = _sde_kms_hw_init_power_helper(dev, sde_kms);
+\ta52_ackfr_record("KMSBLK power-helper exit rc=%d genpd=%d", rc,
+\t\tsde_kms->genpd_init);
+\tif (rc) {
+''', 'power helper')
+
+    text = replace_once(text,
+'''\trc = _sde_kms_mmu_init(sde_kms);
+\tif (rc) {
+''',
+'''\ta52_ackfr_record("KMSBLK mmu enter");
+\trc = _sde_kms_mmu_init(sde_kms);
+\ta52_ackfr_record("KMSBLK mmu exit rc=%d base-null=%d", rc,
+\t\t!sde_kms->base.aspace);
+\tif (rc) {
+''', 'block mmu')
+
+    text = replace_once(text,
+'''\trc = sde_reg_dma_init(sde_kms->reg_dma, sde_kms->catalog,
+\t\t\tsde_kms->dev);
+\tif (rc) {
+''',
+'''\ta52_ackfr_record("KMSBLK reg-dma enter");
+\trc = sde_reg_dma_init(sde_kms->reg_dma, sde_kms->catalog,
+\t\t\tsde_kms->dev);
+\ta52_ackfr_record("KMSBLK reg-dma exit rc=%d", rc);
+\tif (rc) {
+''', 'reg dma')
+
+    text = replace_once(text,
+'''\trc = sde_rm_init(rm, sde_kms->catalog, sde_kms->mmio,
+\t\t\tsde_kms->dev);
+\tif (rc) {
+''',
+'''\ta52_ackfr_record("KMSBLK rm enter");
+\trc = sde_rm_init(rm, sde_kms->catalog, sde_kms->mmio,
+\t\t\tsde_kms->dev);
+\ta52_ackfr_record("KMSBLK rm exit rc=%d", rc);
+\tif (rc) {
+''', 'rm')
+
+    text = replace_once(text,
+'''\tsde_kms->hw_intr = sde_hw_intr_init(sde_kms->mmio, sde_kms->catalog);
+\tif (IS_ERR_OR_NULL(sde_kms->hw_intr)) {
+''',
+'''\ta52_ackfr_record("KMSBLK intr enter");
+\tsde_kms->hw_intr = sde_hw_intr_init(sde_kms->mmio, sde_kms->catalog);
+\ta52_ackfr_record("KMSBLK intr exit rc=%ld null=%d",
+\t\tIS_ERR(sde_kms->hw_intr) ? PTR_ERR(sde_kms->hw_intr) : 0L,
+\t\t!sde_kms->hw_intr);
+\tif (IS_ERR_OR_NULL(sde_kms->hw_intr)) {
+''', 'intr')
+
+    text = replace_once(text,
+'''\t\tret = sde_rm_cont_splash_res_init(priv, &sde_kms->rm,
+\t\t\t\t&sde_kms->splash_data, sde_kms->catalog);
+
+\t\tfor (i = 0; i < display_count; i++) {
+''',
+'''\t\ta52_ackfr_record("KMSBLK splash-res enter displays=%d", display_count);
+\t\tret = sde_rm_cont_splash_res_init(priv, &sde_kms->rm,
+\t\t\t\t&sde_kms->splash_data, sde_kms->catalog);
+\t\ta52_ackfr_record("KMSBLK splash-res exit rc=%d", ret);
+
+\t\tfor (i = 0; i < display_count; i++) {
+''', 'splash resource')
+
+    text = replace_once(text,
+'''\t\t\tdisplay = &sde_kms->splash_data.splash_display[i];
+\t\t\t/*
+''',
+'''\t\t\tdisplay = &sde_kms->splash_data.splash_display[i];
+\t\t\ta52_ackfr_record("KMSBLK splash-display i=%d enabled=%d ret=%d",
+\t\t\t\ti, display->cont_splash_enabled, ret);
+\t\t\t/*
+''', 'splash display')
+
+    text = replace_once(text,
+'''\tsde_kms->hw_mdp = sde_rm_get_mdp(&sde_kms->rm);
+\tif (IS_ERR_OR_NULL(sde_kms->hw_mdp)) {
+''',
+'''\ta52_ackfr_record("KMSBLK mdp enter");
+\tsde_kms->hw_mdp = sde_rm_get_mdp(&sde_kms->rm);
+\ta52_ackfr_record("KMSBLK mdp exit rc=%ld null=%d",
+\t\tIS_ERR(sde_kms->hw_mdp) ? PTR_ERR(sde_kms->hw_mdp) : 0L,
+\t\t!sde_kms->hw_mdp);
+\tif (IS_ERR_OR_NULL(sde_kms->hw_mdp)) {
+''', 'mdp')
+
+    text = replace_once(text,
+'''\t\tsde_kms->hw_vbif[i] = sde_hw_vbif_init(vbif_idx,
+\t\t\t\tsde_kms->vbif[vbif_idx], sde_kms->catalog);
+\t\tif (IS_ERR_OR_NULL(sde_kms->hw_vbif[vbif_idx])) {
+''',
+'''\t\ta52_ackfr_record("KMSBLK vbif enter i=%d id=%u", i, vbif_idx);
+\t\tsde_kms->hw_vbif[i] = sde_hw_vbif_init(vbif_idx,
+\t\t\t\tsde_kms->vbif[vbif_idx], sde_kms->catalog);
+\t\ta52_ackfr_record("KMSBLK vbif exit i=%d id=%u rc=%ld null=%d", i,
+\t\t\tvbif_idx, IS_ERR(sde_kms->hw_vbif[vbif_idx]) ?
+\t\t\tPTR_ERR(sde_kms->hw_vbif[vbif_idx]) : 0L,
+\t\t\t!sde_kms->hw_vbif[vbif_idx]);
+\t\tif (IS_ERR_OR_NULL(sde_kms->hw_vbif[vbif_idx])) {
+''', 'vbif')
+
+    text = replace_once(text,
+'''\tsde_kms->hw_sid = sde_hw_sid_init(sde_kms->sid,
+\t\t\t\tsde_kms->sid_len, sde_kms->catalog);
+\tif (IS_ERR(sde_kms->hw_sid)) {
+''',
+'''\ta52_ackfr_record("KMSBLK sid enter");
+\tsde_kms->hw_sid = sde_hw_sid_init(sde_kms->sid,
+\t\t\t\tsde_kms->sid_len, sde_kms->catalog);
+\ta52_ackfr_record("KMSBLK sid exit rc=%ld null=%d",
+\t\tIS_ERR(sde_kms->hw_sid) ? PTR_ERR(sde_kms->hw_sid) : 0L,
+\t\t!sde_kms->hw_sid);
+\tif (IS_ERR(sde_kms->hw_sid)) {
+''', 'sid')
+
+    text = replace_once(text,
+'''\trc = sde_core_perf_init(&sde_kms->perf, dev, sde_kms->catalog,
+\t\t\t&priv->phandle, "core_clk");
+\tif (rc) {
+''',
+'''\ta52_ackfr_record("KMSBLK perf enter");
+\trc = sde_core_perf_init(&sde_kms->perf, dev, sde_kms->catalog,
+\t\t\t&priv->phandle, "core_clk");
+\ta52_ackfr_record("KMSBLK perf exit rc=%d", rc);
+\tif (rc) {
+''', 'perf')
+
+    text = replace_once(text,
+'''\trc = _sde_kms_drm_obj_init(sde_kms);
+\tif (rc) {
+''',
+'''\ta52_ackfr_record("KMSBLK drm-obj enter");
+\trc = _sde_kms_drm_obj_init(sde_kms);
+\ta52_ackfr_record("KMSBLK drm-obj exit rc=%d crtc=%d enc=%d conn=%d plane=%d",
+\t\trc, priv->num_crtcs, priv->num_encoders,
+\t\tpriv->num_connectors, priv->num_planes);
+\tif (rc) {
+''', 'drm object')
+
+    text = replace_once(text,
+'''\tret = sde_core_irq_domain_add(sde_kms);
+\tif (ret)
+''',
+'''\ta52_ackfr_record("KMSOBJ irq-domain enter");
+\tret = sde_core_irq_domain_add(sde_kms);
+\ta52_ackfr_record("KMSOBJ irq-domain exit rc=%d", ret);
+\tif (ret)
+''', 'object irq')
+
+    text = replace_once(text,
+'''\tif (!_sde_kms_get_displays(sde_kms))
+\t\t(void)_sde_kms_setup_displays(dev, priv, sde_kms);
+
+\tmax_crtc_count = min(catalog->mixer_count, priv->num_encoders);
+''',
+'''\t{
+\t\tint display_rc = _sde_kms_get_displays(sde_kms);
+
+\t\ta52_ackfr_record("KMSOBJ get-displays rc=%d", display_rc);
+\t\tif (!display_rc) {
+\t\t\tint setup_rc = _sde_kms_setup_displays(dev, priv, sde_kms);
+
+\t\t\ta52_ackfr_record("KMSOBJ setup-displays rc=%d enc=%d conn=%d",
+\t\t\t\tsetup_rc, priv->num_encoders, priv->num_connectors);
+\t\t}
+\t}
+
+\tmax_crtc_count = min(catalog->mixer_count, priv->num_encoders);
+\ta52_ackfr_record("KMSOBJ counts mixers=%u sspp=%u max-crtc=%d enc=%d conn=%d",
+\t\tcatalog->mixer_count, catalog->sspp_count, max_crtc_count,
+\t\tpriv->num_encoders, priv->num_connectors);
+''', 'object displays')
+
+    text = replace_once(text,
+'''\t\tplane = sde_plane_init(dev, catalog->sspp[i].id, primary,
+\t\t\t\t(1UL << max_crtc_count) - 1, 0);
+\t\tif (IS_ERR(plane)) {
+''',
+'''\t\ta52_ackfr_record("KMSOBJ plane enter i=%d id=%u primary=%d", i,
+\t\t\tcatalog->sspp[i].id, primary);
+\t\tplane = sde_plane_init(dev, catalog->sspp[i].id, primary,
+\t\t\t\t(1UL << max_crtc_count) - 1, 0);
+\t\ta52_ackfr_record("KMSOBJ plane exit i=%d rc=%ld", i,
+\t\t\tIS_ERR(plane) ? PTR_ERR(plane) : 0L);
+\t\tif (IS_ERR(plane)) {
+''', 'object plane')
+
+    text = replace_once(text,
+'''\t\tcrtc = sde_crtc_init(dev, primary_planes[i]);
+\t\tif (IS_ERR(crtc)) {
+''',
+'''\t\ta52_ackfr_record("KMSOBJ crtc enter i=%d", i);
+\t\tcrtc = sde_crtc_init(dev, primary_planes[i]);
+\t\ta52_ackfr_record("KMSOBJ crtc exit i=%d rc=%ld", i,
+\t\t\tIS_ERR(crtc) ? PTR_ERR(crtc) : 0L);
+\t\tif (IS_ERR(crtc)) {
+''', 'object crtc')
+
+    path.write_text(text)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', required=True)
+    args = ap.parse_args()
+    path = Path(args.root) / 'drivers/a52_display/msm/sde/sde_kms.c'
+    patch(path)
+    print('phase196 KMS hardware-block trace applied')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/196_ci.sh
+++ b/scripts/196_ci.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-drm-post-kms-trace"
+OUT="$PWD/artifacts/a52xq-kms-block-init-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/195_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase196.config"
+cp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" "$OUT/stage/sde-kms-before-phase196.c"
+
+python3 scripts/196_apply.py --root "$ROOT" | tee "$OUT/logs/phase196-apply.log"
+
+cp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" "$OUT/stage/sde-kms-after-phase196.c"
+cp scripts/196_apply.py "$OUT/stage/"
+git -C "$ROOT" diff --check
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase196.config" "$OUT/config/final.config"
+
+python3 - <<'PY'
+from pathlib import Path
+p = Path('gki/common/drivers/a52_display/msm/sde/sde_kms.c')
+s = p.read_text()
+markers = (
+    'KMSBLK core-rev exit rev=0x%x',
+    'KMSBLK catalog exit rc=%ld null=%d',
+    'KMSBLK power-helper exit rc=%d genpd=%d',
+    'KMSBLK mmu exit rc=%d base-null=%d',
+    'KMSMMU new exit domain=%d rc=%ld',
+    'KMSMMU aspace exit domain=%d rc=%ld',
+    'KMSMMU splash-map exit domain=%d rc=%d',
+    'KMSMMU early-map exit domain=%d rc=%d',
+    'KMSBLK reg-dma exit rc=%d',
+    'KMSBLK rm exit rc=%d',
+    'KMSBLK intr exit rc=%ld null=%d',
+    'KMSBLK splash-res exit rc=%d',
+    'KMSBLK mdp exit rc=%ld null=%d',
+    'KMSBLK vbif exit i=%d id=%u rc=%ld null=%d',
+    'KMSBLK sid exit rc=%ld null=%d',
+    'KMSBLK perf exit rc=%d',
+    'KMSBLK drm-obj exit rc=%d crtc=%d enc=%d conn=%d plane=%d',
+    'KMSOBJ irq-domain exit rc=%d',
+    'KMSOBJ get-displays rc=%d',
+    'KMSOBJ setup-displays rc=%d enc=%d conn=%d',
+    'KMSOBJ plane exit i=%d rc=%ld',
+    'KMSOBJ crtc exit i=%d rc=%ld',
+)
+for marker in markers:
+    assert s.count(marker) == 1, (marker, s.count(marker))
+for marker in (
+    'sde_kms->catalog = sde_hw_catalog_init(dev, sde_kms->core_rev);',
+    'rc = _sde_kms_hw_init_power_helper(dev, sde_kms);',
+    'rc = _sde_kms_mmu_init(sde_kms);',
+    'rc = sde_reg_dma_init(sde_kms->reg_dma, sde_kms->catalog,',
+    'rc = sde_rm_init(rm, sde_kms->catalog, sde_kms->mmio,',
+    'sde_kms->hw_intr = sde_hw_intr_init(sde_kms->mmio, sde_kms->catalog);',
+    'ret = sde_rm_cont_splash_res_init(priv, &sde_kms->rm,',
+    'sde_kms->hw_mdp = sde_rm_get_mdp(&sde_kms->rm);',
+    'sde_kms->hw_sid = sde_hw_sid_init(sde_kms->sid,',
+    'rc = sde_core_perf_init(&sde_kms->perf, dev, sde_kms->catalog,',
+    'rc = _sde_kms_drm_obj_init(sde_kms);',
+    'mmu = msm_smmu_new(sde_kms->dev->dev, i);',
+    'aspace = msm_gem_smmu_address_space_create(sde_kms->dev,',
+    'ret = _sde_kms_map_all_splash_regions(sde_kms);',
+    'ret = mmu->funcs->set_attribute(mmu, DOMAIN_ATTR_EARLY_MAP,',
+):
+    assert marker in s, marker
+assert 'KMSPOST blocks exit rc=%d crtc=%d enc=%d conn=%d plane=%d' in s
+assert 'A52GDSC disable profile=mdss' in Path('gki/common/drivers/regulator/a52-legacy-gdsc-regulator.c').read_text()
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase196-kms-block-init-trace.patch"
+test -s "$OUT/stage/phase196-kms-block-init-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 KCFLAGS=-Wno-error=frame-larger-than Image > "$OUT/logs/phase196-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' "$OUT/logs/phase196-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase196-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' "$OUT/logs/phase196-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/a52_display/msm/sde/sde_kms.o' "$OUT/logs/phase196-compile.log"
+while IFS= read -r marker; do
+  [ -z "$marker" ] && continue
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done < scripts/196_EXPECTED_MARKERS.txt
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py --source source/extracted/package/boot.img --kernel "$OUT/package/Image.gz" --output "$OUT/package/boot.img" --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r180-soft-rs.py" --self-test
+python3 "$OUT/tools/decode-a52-r188-near-header.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 196 KMS hardware-block initialization trace candidate
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 195 hardware result:
+  - continuous splash was found: one region and one display
+  - runtime-PM get succeeded
+  - DSI and Samsung panel initialization succeeded
+  - _sde_kms_hw_init_blocks returned -ENODEV
+  - no CRTC, encoder, connector or plane was created
+  - the GDSC collapse was failure cleanup, not the root cause
+
+Phase 196 is observation only. It records every major KMS hardware-block step,
+per-SMMU-domain creation, display address-space creation, splash mapping,
+early-map release, resource-manager setup, MDP/VBIF/SID/perf setup and DRM
+object construction.
+
+It does not bypass -ENODEV, force an IOMMU domain, alter splash behavior,
+keep the GDSC on, change return values, modify DTB/DTBO, panel commands,
+display timing, clocks, regulator voltages, ramdisk or recovery DTBO.
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-kms-block-init-trace')
+base = json.loads(Path('artifacts/a52xq-drm-post-kms-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'; boot = root / 'package/boot.img'
+s = (root / 'stage/sde-kms-after-phase196.c').read_text()
+audit = dict(base)
+audit.update({
+    'status': 'a52-kms-block-init-trace-audited',
+    'phase': 196,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase195': False,
+    'phase195_hardware_validated': True,
+    'phase195_kms_blocks_errno': -19,
+    'phase195_splash_regions': 1,
+    'phase195_splash_displays': 1,
+    'phase195_drm_object_counts': {'crtc': 0, 'encoder': 0, 'connector': 0, 'plane': 0},
+    'smmu_trace_present': 'KMSMMU new exit domain=%d rc=%ld' in s,
+    'block_trace_present': 'KMSBLK catalog exit rc=%ld null=%d' in s,
+    'drm_object_trace_present': 'KMSOBJ irq-domain exit rc=%d' in s,
+    'return_codes_changed': False,
+    'iommu_bypass_added': False,
+    'continuous_splash_forced': False,
+    'gdsc_keep_on_forced': False,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in ('phase195_hardware_validated','smmu_trace_present','block_trace_present','drm_object_trace_present','dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    assert audit[key] is True, key
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True)+'\n')
+PY
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Hardware finding

Phase 195 confirms that continuous splash is valid and recognized with one reserved region and one display. DSI controller, PHY, clock manager, MIPI host, panel driver and Samsung panel initialization all complete.

The failure is inside `_sde_kms_hw_init_blocks()`, which returns `-ENODEV` before any DRM CRTC, encoder, connector or plane is created. The subsequent MDSS GDSC collapse is failure cleanup, not the root cause.

## Phase 196

This change adds persistent observation checkpoints around:

- SDE core revision and hardware catalog
- generic power-domain setup
- each SMMU domain lookup
- display address-space creation
- continuous-splash memory mapping
- early-map attribute release
- register-DMA setup
- SDE resource-manager initialization
- interrupt-block initialization
- continuous-splash resource reconstruction
- MDP, VBIF, SID and performance initialization
- DRM display discovery, encoder/connector setup, plane and CRTC creation

## Safety

Phase 196 does not bypass `-ENODEV`, force an IOMMU domain, change a return value, alter continuous splash or GDSC policy, modify DTB/DTBO, change panel commands or timing, change clocks or regulator voltages, or modify the ramdisk.

The workflow rebuilds the inherited phases, compiles the exact modified KMS object, verifies trace strings in the final Image, repacks only BOOT, checks partition invariants, runs recorder decoder self-tests, and emits checksums.

Draft and not hardware validated.