### PR TITLE
Add triple-copy Reed-Solomon recorder to Phase 196

### DIFF
--- a/.github/workflows/197-a52-kms-block-init-triple-rs.yml
+++ b/.github/workflows/197-a52-kms-block-init-triple-rs.yml
@@ -31,6 +31,8 @@ concurrency:
 
 env:
   GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
   TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
   TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
 

--- a/.github/workflows/197-a52-kms-block-init-triple-rs.yml
+++ b/.github/workflows/197-a52-kms-block-init-triple-rs.yml
@@ -1,0 +1,96 @@
+name: 197 - A52 KMS block trace triple-copy RS recorder
+
+run-name: Build Phase 197 triple-copy Reed-Solomon KMS trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-kms-block-init-triple-rs-v1
+    paths:
+      - .github/workflows/197-a52-kms-block-init-triple-rs.yml
+      - scripts/197_apply_triple_rs.py
+      - scripts/197_ci.sh
+      - tools/decode-a52-r197-triple-rs.py
+  pull_request:
+    branches:
+      - agent/a52-kms-block-init-trace-v1
+    paths:
+      - .github/workflows/197-a52-kms-block-init-triple-rs.yml
+      - scripts/197_apply_triple_rs.py
+      - scripts/197_ci.sh
+      - tools/decode-a52-r197-triple-rs.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-kms-block-init-triple-rs-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 197 triple-copy RS candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 197 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 197
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: |
+          python3 scripts/194_fix_inherited_guard.py
+          bash scripts/197_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-kms-block-init-triple-rs-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-kms-block-init-triple-rs
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 197 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-kms-block-init-triple-rs-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-kms-block-init-triple-rs
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/197_apply_triple_rs.py
+++ b/scripts/197_apply_triple_rs.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+RECORDER = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+RAMOOPS = Path('fs/pstore/ram.c')
+MAIN = Path('init/main.c')
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'{label}: expected exactly one match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def insert_before_once(text: str, marker: str, insertion: str, label: str) -> str:
+    count = text.count(marker)
+    if count != 1:
+        raise SystemExit(f'{label}: expected exactly one marker, found {count}')
+    return text.replace(marker, insertion + marker, 1)
+
+
+def patch_recorder(text: str) -> str:
+    text = replace_once(
+        text,
+        ' * to the console and ftrace RAMOOPS banks. CRC is intentionally not used in\n',
+        ' * to the record, console and ftrace RAMOOPS banks. CRC is intentionally not used in\n',
+        'recorder bank comment',
+    )
+    text = replace_once(
+        text,
+        '#define A52_R179_BANK_CONSOLE BIT(0)\n'
+        '#define A52_R179_BANK_FTRACE BIT(1)\n'
+        '#define A52_R179_BANK_BOTH (A52_R179_BANK_CONSOLE | A52_R179_BANK_FTRACE)\n',
+        '#define A52_R179_BANK_CONSOLE BIT(0)\n'
+        '#define A52_R179_BANK_FTRACE BIT(1)\n'
+        '#define A52_R179_BANK_RECORD BIT(2)\n'
+        '#define A52_R179_BANK_ALL (A52_R179_BANK_CONSOLE | \\\n'
+        '\t\t\t   A52_R179_BANK_FTRACE | A52_R179_BANK_RECORD)\n',
+        'recorder bank masks',
+    )
+    count = text.count('A52_R179_BANK_BOTH')
+    if count != 2:
+        raise SystemExit(f'recorder all-bank uses: expected 2, found {count}')
+    text = text.replace('A52_R179_BANK_BOTH', 'A52_R179_BANK_ALL')
+    text = replace_once(
+        text,
+        'a52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=2 crc=0",',
+        'a52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=3 crc=0",',
+        'recorder control copy count',
+    )
+    text = replace_once(
+        text,
+        'a52_ackfr_record("BOOT rs=ready phase=179 roots=%u copies=2 crc=0",',
+        'a52_ackfr_record("BOOT rs=ready phase=197 roots=%u copies=3 crc=0",',
+        'recorder ready marker',
+    )
+    text = replace_once(
+        text,
+        'pr_info("phase179 recorder enabled stored=%llu dropped=%llu\\n",',
+        'pr_info("phase197 triple-copy recorder enabled stored=%llu dropped=%llu\\n",',
+        'recorder printk profile',
+    )
+    return text
+
+
+def patch_ramoops(text: str) -> str:
+    text = replace_once(
+        text,
+        '#define A52_ACKFR_BANK_CONSOLE BIT(0)\n'
+        '#define A52_ACKFR_BANK_FTRACE BIT(1)\n',
+        '#define A52_ACKFR_BANK_CONSOLE BIT(0)\n'
+        '#define A52_ACKFR_BANK_FTRACE BIT(1)\n'
+        '#define A52_ACKFR_BANK_RECORD BIT(2)\n',
+        'ramoops writer bank masks',
+    )
+    text = replace_once(
+        text,
+        'void a52_persistent_diag_mark(const char *fmt, ...);\n'
+        'void a52_persistent_diag_mark_ftrace(const char *fmt, ...);\n',
+        'void a52_persistent_diag_mark(const char *fmt, ...);\n'
+        'void a52_persistent_diag_mark_ftrace(const char *fmt, ...);\n'
+        'void a52_persistent_diag_mark_record(const char *fmt, ...);\n',
+        'ramoops mark declarations',
+    )
+    text = replace_once(
+        text,
+        '\tif (targets & A52_ACKFR_BANK_FTRACE) {\n'
+        '\t\ta52_persistent_diag_mark_ftrace("%.*s", (int)len, buf);\n'
+        '\t\twritten |= A52_ACKFR_BANK_FTRACE;\n'
+        '\t}\n'
+        '\twmb();\n',
+        '\tif (targets & A52_ACKFR_BANK_FTRACE) {\n'
+        '\t\ta52_persistent_diag_mark_ftrace("%.*s", (int)len, buf);\n'
+        '\t\twritten |= A52_ACKFR_BANK_FTRACE;\n'
+        '\t}\n'
+        '\tif (targets & A52_ACKFR_BANK_RECORD) {\n'
+        '\t\ta52_persistent_diag_mark_record("%.*s", (int)len, buf);\n'
+        '\t\twritten |= A52_ACKFR_BANK_RECORD;\n'
+        '\t}\n'
+        '\twmb();\n',
+        'ramoops third writer branch',
+    )
+    text = replace_once(
+        text,
+        '#define A52_DIAG_CONSOLE_PHYS 0xB1B40000ULL\n'
+        '#define A52_DIAG_CONSOLE_SIZE 0x00040000UL\n',
+        '#define A52_DIAG_RECORD_PHYS 0xB1B00000ULL\n'
+        '#define A52_DIAG_RECORD_SIZE 0x00040000UL\n'
+        '#define A52_DIAG_CONSOLE_PHYS 0xB1B40000ULL\n'
+        '#define A52_DIAG_CONSOLE_SIZE 0x00040000UL\n',
+        'record bank physical range',
+    )
+    text = replace_once(
+        text,
+        'static u32 a52_diag_ftrace_raw_start;\n'
+        'static u32 a52_diag_ftrace_raw_size;\n',
+        'static u32 a52_diag_ftrace_raw_start;\n'
+        'static u32 a52_diag_ftrace_raw_size;\n'
+        'static struct persistent_ram_zone *a52_diag_record_prz;\n'
+        'static u8 __iomem *a52_diag_record_raw;\n'
+        'static u32 a52_diag_record_raw_start;\n'
+        'static u32 a52_diag_record_raw_size;\n',
+        'record bank globals',
+    )
+
+    record_raw = r'''/* A52_DIAG_RECORD_MIRROR */
+static void a52_diag_record_raw_write(const char *s, unsigned int count)
+{
+	unsigned int first;
+
+	if (!a52_diag_record_raw || !count)
+		return;
+	if (count > A52_DIAG_DATA_SIZE) {
+		s += count - A52_DIAG_DATA_SIZE;
+		count = A52_DIAG_DATA_SIZE;
+	}
+	first = min_t(unsigned int, count,
+		      A52_DIAG_DATA_SIZE - a52_diag_record_raw_start);
+	memcpy_toio(a52_diag_record_raw + A52_DIAG_HEADER_SIZE +
+		    a52_diag_record_raw_start, s, first);
+	if (count > first)
+		memcpy_toio(a52_diag_record_raw + A52_DIAG_HEADER_SIZE,
+			    s + first, count - first);
+	a52_diag_record_raw_start += count;
+	while (a52_diag_record_raw_start >= A52_DIAG_DATA_SIZE)
+		a52_diag_record_raw_start -= A52_DIAG_DATA_SIZE;
+	a52_diag_record_raw_size = min_t(u32, A52_DIAG_DATA_SIZE,
+				      a52_diag_record_raw_size + count);
+	wmb();
+	writel_relaxed(a52_diag_record_raw_start, a52_diag_record_raw + 4);
+	writel_relaxed(a52_diag_record_raw_size, a52_diag_record_raw + 8);
+	wmb();
+}
+
+'''
+    text = insert_before_once(
+        text,
+        '/* A52_DIAG_FTRACE_MIRROR */\n',
+        record_raw,
+        'record raw writer insertion',
+    )
+
+    record_mark = r'''void a52_persistent_diag_mark_record(const char *fmt, ...)
+{
+	char line[A52_DIAG_LINE_SIZE];
+	va_list args;
+	int len;
+
+	if (IS_ERR_OR_NULL(a52_diag_record_prz) && !a52_diag_record_raw)
+		return;
+	va_start(args, fmt);
+	len = vscnprintf(line, sizeof(line), fmt, args);
+	va_end(args);
+	if (len <= 0)
+		return;
+	if (a52_diag_record_prz)
+		persistent_ram_write(a52_diag_record_prz, line, len);
+	else
+		a52_diag_record_raw_write(line, len);
+	wmb();
+}
+
+'''
+    text = insert_before_once(
+        text,
+        'void a52_persistent_diag_mark_ftrace(const char *fmt, ...)\n',
+        record_mark,
+        'record mark function insertion',
+    )
+
+    record_init = r'''static int __init a52_persistent_diag_record_init(void)
+{
+	struct persistent_ram_ecc_info ecc = { };
+	int prz_ret;
+
+	if (a52_diag_record_prz || a52_diag_record_raw)
+		return 0;
+	a52_diag_record_prz = persistent_ram_new(A52_DIAG_RECORD_PHYS,
+					 A52_DIAG_RECORD_SIZE, 0, &ecc,
+					 1, PRZ_FLAG_ZAP_OLD,
+					 "a52-early-record");
+	if (!IS_ERR(a52_diag_record_prz)) {
+		a52_diag_record_prz->type = PSTORE_TYPE_DMESG;
+		return 0;
+	}
+	prz_ret = PTR_ERR(a52_diag_record_prz);
+	a52_diag_record_prz = NULL;
+	a52_diag_record_raw = ioremap_wc(A52_DIAG_RECORD_PHYS,
+					 A52_DIAG_RECORD_SIZE);
+	if (!a52_diag_record_raw)
+		a52_diag_record_raw = ioremap(A52_DIAG_RECORD_PHYS,
+					      A52_DIAG_RECORD_SIZE);
+	if (!a52_diag_record_raw)
+		return prz_ret ? prz_ret : -ENOMEM;
+	memset_io(a52_diag_record_raw, 0, A52_DIAG_RECORD_SIZE);
+	writel_relaxed(A52_DIAG_PERSISTENT_RAM_SIG, a52_diag_record_raw);
+	writel_relaxed(0, a52_diag_record_raw + 4);
+	writel_relaxed(0, a52_diag_record_raw + 8);
+	a52_diag_record_raw_start = 0;
+	a52_diag_record_raw_size = 0;
+	wmb();
+	return 0;
+}
+
+'''
+    text = insert_before_once(
+        text,
+        'static int __init a52_persistent_diag_ftrace_init(void)\n',
+        record_init,
+        'record bank init insertion',
+    )
+
+    return_count = text.count('return a52_persistent_diag_ftrace_init();')
+    if return_count != 3:
+        raise SystemExit(
+            f'ramoops mirror-init returns: expected 3, found {return_count}'
+        )
+    text = text.replace(
+        'return a52_persistent_diag_ftrace_init();',
+        'return a52_persistent_diag_all_mirrors_init();',
+    )
+
+    all_init = r'''static int __init a52_persistent_diag_all_mirrors_init(void)
+{
+	int ret;
+
+	ret = a52_persistent_diag_ftrace_init();
+	if (ret)
+		return ret;
+	return a52_persistent_diag_record_init();
+}
+
+'''
+    text = insert_before_once(
+        text,
+        'int __init a52_persistent_diag_init(void)\n',
+        all_init,
+        'all-mirror init insertion',
+    )
+    return text
+
+
+def patch_main(text: str) -> str:
+    text = replace_once(
+        text,
+        'extern void a52_persistent_diag_mark(const char *fmt, ...);\n'
+        'extern void a52_persistent_diag_mark_ftrace(const char *fmt, ...);\n',
+        'extern void a52_persistent_diag_mark(const char *fmt, ...);\n'
+        'extern void a52_persistent_diag_mark_ftrace(const char *fmt, ...);\n'
+        'extern void a52_persistent_diag_mark_record(const char *fmt, ...);\n',
+        'main record declaration',
+    )
+    text = replace_once(
+        text,
+        'static inline void a52_persistent_diag_mark(const char *fmt, ...) { }\n'
+        'static inline void a52_persistent_diag_mark_ftrace(const char *fmt, ...) { }\n',
+        'static inline void a52_persistent_diag_mark(const char *fmt, ...) { }\n'
+        'static inline void a52_persistent_diag_mark_ftrace(const char *fmt, ...) { }\n'
+        'static inline void a52_persistent_diag_mark_record(const char *fmt, ...) { }\n',
+        'main record stub',
+    )
+    text = replace_once(
+        text,
+        '\t\ta52_persistent_diag_mark_ftrace(\n'
+        '\t\t\t"A52USR2 BOOT_EARLY stage=mm_init backend=early-mirrored "\n'
+        '\t\t\t"metadata_only=1 commit=5a52c0de\\n");\n',
+        '\t\ta52_persistent_diag_mark_ftrace(\n'
+        '\t\t\t"A52USR2 BOOT_EARLY stage=mm_init backend=early-mirrored "\n'
+        '\t\t\t"metadata_only=1 commit=5a52c0de\\n");\n'
+        '\t\ta52_persistent_diag_mark_record(\n'
+        '\t\t\t"A52USR2 BOOT_EARLY stage=mm_init backend=early-mirrored "\n'
+        '\t\t\t"metadata_only=1 commit=5a52c0de\\n");\n',
+        'main third early marker',
+    )
+    return text
+
+
+def patch_tree(root: Path) -> None:
+    recorder = root / RECORDER
+    ramoops = root / RAMOOPS
+    main = root / MAIN
+    recorder.write_text(patch_recorder(recorder.read_text()), encoding='utf-8')
+    ramoops.write_text(patch_ramoops(ramoops.read_text()), encoding='utf-8')
+    main.write_text(patch_main(main.read_text()), encoding='utf-8')
+
+
+def self_test() -> None:
+    recorder = ''' * to the console and ftrace RAMOOPS banks. CRC is intentionally not used in\n#define A52_R179_BANK_CONSOLE BIT(0)\n#define A52_R179_BANK_FTRACE BIT(1)\n#define A52_R179_BANK_BOTH (A52_R179_BANK_CONSOLE | A52_R179_BANK_FTRACE)\nmissing = A52_R179_BANK_BOTH & ~event.persisted_mask;\nwritten = a52_r179_persist_event(&event, A52_R179_BANK_BOTH);\na52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=2 crc=0",\na52_ackfr_record("BOOT rs=ready phase=179 roots=%u copies=2 crc=0",\npr_info("phase179 recorder enabled stored=%llu dropped=%llu\\n",\n'''
+    patched_recorder = patch_recorder(recorder)
+    assert 'A52_R179_BANK_RECORD BIT(2)' in patched_recorder
+    assert patched_recorder.count('copies=3') == 2
+    assert 'phase=197' in patched_recorder
+
+    ramoops = '''#define A52_ACKFR_BANK_CONSOLE BIT(0)\n#define A52_ACKFR_BANK_FTRACE BIT(1)\nvoid a52_persistent_diag_mark(const char *fmt, ...);\nvoid a52_persistent_diag_mark_ftrace(const char *fmt, ...);\n\tif (targets & A52_ACKFR_BANK_FTRACE) {\n\t\ta52_persistent_diag_mark_ftrace("%.*s", (int)len, buf);\n\t\twritten |= A52_ACKFR_BANK_FTRACE;\n\t}\n\twmb();\n#define A52_DIAG_CONSOLE_PHYS 0xB1B40000ULL\n#define A52_DIAG_CONSOLE_SIZE 0x00040000UL\nstatic u32 a52_diag_ftrace_raw_start;\nstatic u32 a52_diag_ftrace_raw_size;\n/* A52_DIAG_FTRACE_MIRROR */\nvoid a52_persistent_diag_mark_ftrace(const char *fmt, ...)\nstatic int __init a52_persistent_diag_ftrace_init(void)\nreturn a52_persistent_diag_ftrace_init();\nreturn a52_persistent_diag_ftrace_init();\nreturn a52_persistent_diag_ftrace_init();\nint __init a52_persistent_diag_init(void)\n'''
+    patched_ramoops = patch_ramoops(ramoops)
+    assert 'A52_DIAG_RECORD_PHYS 0xB1B00000ULL' in patched_ramoops
+    assert 'a52-early-record' in patched_ramoops
+    assert 'A52_ACKFR_BANK_RECORD' in patched_ramoops
+    assert patched_ramoops.count('a52_persistent_diag_all_mirrors_init();') == 3
+
+    main = '''extern void a52_persistent_diag_mark(const char *fmt, ...);\nextern void a52_persistent_diag_mark_ftrace(const char *fmt, ...);\nstatic inline void a52_persistent_diag_mark(const char *fmt, ...) { }\nstatic inline void a52_persistent_diag_mark_ftrace(const char *fmt, ...) { }\n\t\ta52_persistent_diag_mark_ftrace(\n\t\t\t"A52USR2 BOOT_EARLY stage=mm_init backend=early-mirrored "\n\t\t\t"metadata_only=1 commit=5a52c0de\\n");\n'''
+    patched_main = patch_main(main)
+    assert 'a52_persistent_diag_mark_record' in patched_main
+    assert patched_main.count('BOOT_EARLY') == 2
+
+    with tempfile.TemporaryDirectory(prefix='a52-r197-selftest-') as td:
+        root = Path(td)
+        for rel, content in ((RECORDER, recorder), (RAMOOPS, ramoops), (MAIN, main)):
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        patch_tree(root)
+    print('phase197 triple-copy source patcher self-test: PASS')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path)
+    parser.add_argument('--self-test', action='store_true')
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.root is None:
+        parser.error('--root is required unless --self-test is used')
+    patch_tree(args.root)
+    print('phase197 triple-copy recorder source patch applied')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/197_ci.sh
+++ b/scripts/197_ci.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-kms-block-init-trace"
+OUT="$PWD/artifacts/a52xq-kms-block-init-triple-rs"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/196_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase197.config"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-before-phase197.c"
+cp "$ROOT/fs/pstore/ram.c" "$OUT/stage/ram-before-phase197.c"
+cp "$ROOT/init/main.c" "$OUT/stage/main-before-phase197.c"
+sha256sum \
+  "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+  > "$OUT/stage/display-invariants-before-phase197.sha256"
+
+python3 scripts/197_apply_triple_rs.py --self-test | tee "$OUT/logs/phase197-patcher-self-test.log"
+python3 scripts/197_apply_triple_rs.py --root "$ROOT" | tee "$OUT/logs/phase197-apply.log"
+
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-after-phase197.c"
+cp "$ROOT/fs/pstore/ram.c" "$OUT/stage/ram-after-phase197.c"
+cp "$ROOT/init/main.c" "$OUT/stage/main-after-phase197.c"
+cp scripts/197_apply_triple_rs.py "$OUT/stage/"
+cp tools/decode-a52-r197-triple-rs.py "$OUT/tools/"
+chmod +x "$OUT/tools/decode-a52-r197-triple-rs.py"
+
+git -C "$ROOT" diff --check
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase197.config" "$OUT/config/final.config"
+sha256sum -c "$OUT/stage/display-invariants-before-phase197.sha256"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+ram = (root / 'fs/pstore/ram.c').read_text()
+main = (root / 'init/main.c').read_text()
+kms = (root / 'drivers/a52_display/msm/sde/sde_kms.c').read_text()
+gdsc = (root / 'drivers/regulator/a52-legacy-gdsc-regulator.c').read_text()
+
+for marker in (
+    '#define A52_R179_BANK_RECORD BIT(2)',
+    '#define A52_R179_BANK_ALL',
+    'A52_R179_BANK_FTRACE | A52_R179_BANK_RECORD',
+    'copies=3 crc=0',
+    'BOOT rs=ready phase=197 roots=%u copies=3 crc=0',
+    'phase197 triple-copy recorder enabled',
+    'encode_rs8(a52_r179_rs, codeword, A52_R179_DATA_BYTES,',
+    '#define A52_R179_RS_ROOTS 32U',
+    '#define A52_R179_DATA_BYTES 157U',
+    '#define A52_R179_CODE_BYTES (A52_R179_DATA_BYTES + A52_R179_RS_ROOTS)',
+    '#define A52_R179_PREFIX "R79"',
+):
+    assert marker in rec, marker
+assert rec.count('copies=3 crc=0') == 2
+assert 'A52_R179_BANK_BOTH' not in rec
+assert 'copies=2 crc=0' not in rec
+
+for marker in (
+    '#define A52_ACKFR_BANK_RECORD BIT(2)',
+    '#define A52_DIAG_RECORD_PHYS 0xB1B00000ULL',
+    '#define A52_DIAG_RECORD_SIZE 0x00040000UL',
+    'a52_persistent_diag_mark_record("%.*s", (int)len, buf);',
+    'static void a52_diag_record_raw_write',
+    'void a52_persistent_diag_mark_record',
+    'static int __init a52_persistent_diag_record_init',
+    '"a52-early-record"',
+    'a52_diag_record_prz->type = PSTORE_TYPE_DMESG;',
+    'static int __init a52_persistent_diag_all_mirrors_init',
+    'return a52_persistent_diag_record_init();',
+):
+    assert marker in ram, marker
+assert ram.count('return a52_persistent_diag_all_mirrors_init();') == 3
+
+assert 'extern void a52_persistent_diag_mark_record' in main
+assert 'static inline void a52_persistent_diag_mark_record' in main
+assert main.count('a52_persistent_diag_mark_record(') == 3
+assert main.count('A52USR2 BOOT_EARLY stage=mm_init') == 3
+
+for marker in (
+    'KMSBLK core-rev exit rev=0x%x',
+    'KMSMMU new exit domain=%d rc=%ld',
+    'KMSBLK drm-obj exit rc=%d crtc=%d enc=%d conn=%d plane=%d',
+    'KMSPOST blocks exit rc=%d crtc=%d enc=%d conn=%d plane=%d',
+):
+    assert marker in kms, marker
+for marker in ('"mdss_core_gdsc"', 'A52GDSC disable profile=mdss', 'REGULATOR_CHANGE_MODE'):
+    assert marker in gdsc, marker
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase197-kms-block-triple-rs.patch"
+test -s "$OUT/stage/phase197-kms-block-triple-rs.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase197-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase197-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase197-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase197-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for object in \
+  'drivers/a52_secure/a52_ack_secure_flight_recorder.o' \
+  'fs/pstore/ram.o' \
+  'init/main.o'; do
+  grep -Fq "$object" "$OUT/logs/phase197-compile.log"
+done
+for marker in \
+  'BOOT rs=ready phase=197 roots=%u copies=3 crc=0' \
+  'phase197 triple-copy recorder enabled' \
+  'a52-early-record' \
+  'KMSBLK core-rev exit rev=0x%x' \
+  'KMSMMU new exit domain=%d rc=%ld' \
+  'KMSBLK drm-obj exit rc=%d crtc=%d enc=%d conn=%d plane=%d' \
+  'A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r197-triple-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 197 KMS block trace with triple-copy Reed-Solomon recorder
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+This candidate is Phase 196 plus one recorder-only change:
+  - the existing RS(189,157) format is preserved
+  - every 157-byte event still receives 32 Reed-Solomon parity symbols
+  - the exact 255-byte R79 transport is written independently to three banks
+  - bank 1: record  at RAMOOPS +0x00000
+  - bank 2: console at RAMOOPS +0x40000
+  - bank 3: ftrace  at RAMOOPS +0x80000
+  - no CRC and no recorder-v3 binary format are introduced
+
+The Phase 194 mdss_core_gdsc fix and all Phase 196 KMS/SMMU block tracing are
+preserved. Display control flow, return values, IOMMU behavior, continuous
+splash policy, GDSC policy, DTB, DTBO, panel commands, timing, clocks,
+regulator voltages, ramdisk and recovery DTBO are unchanged.
+
+Decode an untouched 1 MiB RAMOOPS capture with:
+  python3 tools/decode-a52-r197-triple-rs.py RAW_OR_ZIP --output decoded-r197
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+root = Path('artifacts/a52xq-kms-block-init-triple-rs')
+base = json.loads(Path('artifacts/a52xq-kms-block-init-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+rec = (root / 'stage/recorder-after-phase197.c').read_text()
+ram = (root / 'stage/ram-after-phase197.c').read_text()
+main = (root / 'stage/main-after-phase197.c').read_text()
+
+audit = dict(base)
+audit.update({
+    'status': 'a52-kms-block-init-triple-rs-audited',
+    'phase': 197,
+    'base_phase': 196,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase196': 'recorder-third-copy-only',
+    'phase196_kms_trace_preserved': True,
+    'phase194_mdss_core_gdsc_fix_preserved': True,
+    'recorder_format': 'phase179-r79-rs-shortened',
+    'recorder_data_bytes': 157,
+    'recorder_parity_symbols_per_copy': 32,
+    'recorder_codeword_bytes': 189,
+    'recorder_transport_bytes': 255,
+    'recorder_crc': False,
+    'recorder_copy_count': 3,
+    'recorder_banks': [
+        {'name': 'record', 'offset': 0x00000, 'physical': '0xB1B00000', 'bytes': 0x40000},
+        {'name': 'console', 'offset': 0x40000, 'physical': '0xB1B40000', 'bytes': 0x40000},
+        {'name': 'ftrace', 'offset': 0x80000, 'physical': '0xB1B80000', 'bytes': 0x40000},
+    ],
+    'third_copy_source_present': '#define A52_R179_BANK_RECORD BIT(2)' in rec,
+    'third_copy_writer_present': 'a52_persistent_diag_mark_record("%.*s", (int)len, buf);' in ram,
+    'third_bank_mapping_present': '#define A52_DIAG_RECORD_PHYS 0xB1B00000ULL' in ram,
+    'early_marker_three_copies': main.count('A52USR2 BOOT_EARLY stage=mm_init') == 3,
+    'return_codes_changed': False,
+    'iommu_bypass_added': False,
+    'continuous_splash_forced': False,
+    'gdsc_keep_on_forced': False,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase196_kms_trace_preserved',
+    'phase194_mdss_core_gdsc_fix_preserved',
+    'third_copy_source_present',
+    'third_copy_writer_present',
+    'third_bank_mapping_present',
+    'early_marker_three_copies',
+    'dtb_preserved',
+    'ramdisk_preserved',
+    'recovery_dtbo_preserved',
+):
+    assert audit[key] is True, key
+assert audit['recorder_copy_count'] == 3
+assert audit['recorder_parity_symbols_per_copy'] == 32
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/tools/decode-a52-r197-triple-rs.py
+++ b/tools/decode-a52-r197-triple-rs.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Decode the A52 phase-197 triple-copy Reed-Solomon recorder.
+
+The record transport is unchanged from phase 179:
+    b"R79" + base64(RS(157 data bytes + 32 parity bytes))
+
+Phase 197 writes the same protected record independently to the record,
+console, and ftrace 0x40000-byte banks in the 1 MiB A52 RAMOOPS region.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import importlib.util
+import json
+import random
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+PHASE = 197
+BANK_BYTES = 0x40000
+RAMOOPS_TOTAL_BYTES = 0x100000
+BANK_OFFSETS = {
+    "record": 0x00000,
+    "console": 0x40000,
+    "ftrace": 0x80000,
+}
+BANK_ORDER = ("record", "console", "ftrace")
+
+
+def load_base():
+    path = Path(__file__).with_name("decode-a52-r179-rs-recorder.py")
+    if not path.is_file():
+        raise RuntimeError(f"missing phase-179 decoder beside this file: {path}")
+    spec = importlib.util.spec_from_file_location("a52_r179_decoder", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load phase-179 decoder: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = load_base()
+DecodeFailure = BASE.DecodeFailure
+
+
+def bank_name_for_file(path: Path) -> str:
+    lower = path.name.lower()
+    if "ftrace" in lower:
+        return "ftrace"
+    if "record" in lower or "dmesg" in lower:
+        return "record"
+    return "console"
+
+
+def extract_banks(snapshot: Path) -> dict[str, bytes]:
+    raw = snapshot.read_bytes()
+    if len(raw) == RAMOOPS_TOTAL_BYTES:
+        return {
+            name: raw[offset : offset + BANK_BYTES]
+            for name, offset in BANK_OFFSETS.items()
+        }
+    if len(raw) == BANK_BYTES:
+        return {bank_name_for_file(snapshot): raw}
+    raise DecodeFailure("unsupported snapshot size")
+
+
+def merge_records(
+    records_by_bank: dict[str, Sequence[object]],
+) -> tuple[list[object], dict[str, object]]:
+    by_seq: dict[int, list[object]] = defaultdict(list)
+    for records in records_by_bank.values():
+        for record in records:
+            by_seq[record.seq].append(record)
+
+    merged: list[object] = []
+    only_by_bank = Counter()
+    copy_count_histogram = Counter()
+    disagreements = 0
+    duplicates = 0
+    for seq in sorted(by_seq):
+        candidates = by_seq[seq]
+        banks = {item.bank for item in candidates}
+        copy_count_histogram[len(banks)] += 1
+        if len(banks) == 1:
+            only_by_bank[next(iter(banks))] += 1
+        payloads = {item.raw_data_hex for item in candidates}
+        if len(payloads) > 1:
+            disagreements += 1
+        if len(candidates) > len(banks):
+            duplicates += len(candidates) - len(banks)
+        merged.append(BASE.select_best(candidates))
+
+    stats: dict[str, object] = {
+        "merged_sequences": len(merged),
+        "recovered_only_from_record": only_by_bank["record"],
+        "recovered_only_from_console": only_by_bank["console"],
+        "recovered_only_from_ftrace": only_by_bank["ftrace"],
+        "recovered_from_one_bank": copy_count_histogram[1],
+        "recovered_from_two_banks": copy_count_histogram[2],
+        "recovered_from_all_three": copy_count_histogram[3],
+        "sequence_disagreements": disagreements,
+        "duplicate_records_within_banks": duplicates,
+        "first_sequence": merged[0].seq if merged else None,
+        "last_sequence": merged[-1].seq if merged else None,
+        "missing_sequences_between_first_and_last": (
+            merged[-1].seq - merged[0].seq + 1 - len(merged) if merged else 0
+        ),
+    }
+    return merged, stats
+
+
+def write_outputs(
+    output_dir: Path,
+    source: Path,
+    records_by_bank: dict[str, Sequence[object]],
+    merged: Sequence[object],
+    summary: dict[str, object],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    fieldnames = [
+        "seq",
+        "monotonic_ns",
+        "monotonic_ms",
+        "pid",
+        "tgid",
+        "cpu",
+        "kind",
+        "comm",
+        "message",
+        "selected_bank",
+        "corrected_symbols",
+        "erasures",
+        "prefix_distance",
+        "bank_offset",
+    ]
+    with (output_dir / "events.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for item in merged:
+            writer.writerow(
+                {
+                    "seq": item.seq,
+                    "monotonic_ns": item.monotonic_ns,
+                    "monotonic_ms": f"{item.monotonic_ns / 1_000_000:.3f}",
+                    "pid": item.pid,
+                    "tgid": item.tgid,
+                    "cpu": item.cpu,
+                    "kind": item.kind,
+                    "comm": item.comm,
+                    "message": item.message,
+                    "selected_bank": item.bank,
+                    "corrected_symbols": item.corrected_symbols,
+                    "erasures": item.erasures,
+                    "prefix_distance": item.prefix_distance,
+                    "bank_offset": item.offset,
+                }
+            )
+
+    with (output_dir / "timeline.txt").open("w", encoding="utf-8") as handle:
+        handle.write(f"source={source}\n")
+        handle.write(f"records={len(merged)}\n\n")
+        for item in merged:
+            handle.write(
+                f"{item.seq:08d} {item.monotonic_ns / 1_000_000:12.3f}ms "
+                f"cpu={item.cpu:02d} pid={item.pid:<6d} {item.comm:<16.16s} "
+                f"bank={item.bank:<7s} rs={item.corrected_symbols:<2d} "
+                f"eras={item.erasures:<2d} {item.message}\n"
+            )
+
+    for name in BANK_ORDER:
+        records = records_by_bank.get(name, ())
+        with (output_dir / f"{name}-records.jsonl").open("w", encoding="utf-8") as handle:
+            for item in records:
+                handle.write(json.dumps(asdict(item), sort_keys=True) + "\n")
+
+
+def decode_snapshot(snapshot: Path, output_dir: Path) -> dict[str, object]:
+    banks = extract_banks(snapshot)
+    records_by_bank: dict[str, list[object]] = {}
+    bank_stats: dict[str, object] = {}
+    for bank_name, bank_data in banks.items():
+        records, stats = BASE.decode_bank(bank_data, bank_name)
+        records_by_bank[bank_name] = records
+        bank_stats[bank_name] = stats
+
+    merged, merge_stats = merge_records(records_by_bank)
+    summary: dict[str, object] = {
+        "status": "a52-r197-rs-triple-decoded",
+        "phase": PHASE,
+        "source": str(snapshot),
+        "record_format": {
+            "transport_bytes": BASE.TEXT_BYTES,
+            "prefix": BASE.PREFIX.decode("ascii"),
+            "data_bytes": BASE.DATA_BYTES,
+            "parity_symbols": BASE.PARITY_BYTES,
+            "maximum_correctable_unknown_symbols_per_copy": BASE.PARITY_BYTES // 2,
+            "copies": list(BANK_ORDER),
+            "crc": False,
+        },
+        "banks": bank_stats,
+        "merge": merge_stats,
+    }
+    write_outputs(output_dir, snapshot, records_by_bank, merged, summary)
+    return summary
+
+
+def self_test() -> None:
+    BASE.self_test()
+    transport = BASE.encode_record_for_test(197, "KMSBLK triple-copy self-test")
+    copies: dict[str, object] = {}
+    corruption = {"record": 7, "console": 3, "ftrace": 1}
+    rng = random.Random(0xA52197)
+    for bank, errors in corruption.items():
+        codeword = bytearray(base64.b64decode(transport[3:]))
+        for position in rng.sample(range(BASE.CODE_BYTES), errors):
+            codeword[position] ^= rng.randrange(1, 256)
+        damaged = transport[:3] + base64.b64encode(codeword)
+        copies[bank] = BASE.try_decode_transport(damaged, bank=bank, offset=0)
+
+    merged, stats = merge_records({name: [record] for name, record in copies.items()})
+    if len(merged) != 1 or merged[0].bank != "ftrace":
+        raise AssertionError("triple-copy quality selection failed")
+    if stats["recovered_from_all_three"] != 1:
+        raise AssertionError("triple-copy merge accounting failed")
+
+    record_only, stats = merge_records({"record": [copies["record"]]})
+    if len(record_only) != 1 or stats["recovered_only_from_record"] != 1:
+        raise AssertionError("record-bank-only recovery failed")
+    print("phase197 triple-copy decoder self-test: PASS")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decode A52 phase-197 triple-copy RS-protected RAMOOPS records"
+    )
+    parser.add_argument("input", type=Path, nargs="?")
+    parser.add_argument("--output", type=Path, default=Path("decoded-a52-r197"))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        self_test()
+        return 0
+    if args.input is None:
+        parser.error("input is required unless --self-test is used")
+
+    snapshots = BASE.find_snapshots(args.input)
+    summaries = []
+    for index, snapshot in enumerate(snapshots):
+        destination = args.output if len(snapshots) == 1 else args.output / f"snapshot-{index:02d}"
+        summaries.append(decode_snapshot(snapshot, destination))
+    print(json.dumps(summaries[0] if len(summaries) == 1 else summaries, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DecodeFailure as exc:
+        print(f"decode error: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Scope

This creates Phase 197 directly on top of the hardware-relevant Phase 196 KMS block trace.

## Recorder change

- Preserve the proven phase-179 `R79` shortened RS(189,157) transport.
- Preserve 157 data bytes and 32 Reed-Solomon parity symbols per copy.
- Add the unused RAMOOPS record quarter as a third independent physical copy.
- Write every protected event to record, console, and ftrace banks.
- Keep CRC disabled and do not reuse recorder-v3.
- Include a matching three-bank decoder and corruption-selection self-test.

## Preserved kernel behavior

- Phase 194 `mdss_core_gdsc` fix.
- Phase 195 post-KMS evidence.
- All Phase 196 KMS, SMMU, splash-map, resource-manager, interrupt, MDP/VBIF/SID/performance and DRM-object checkpoints.
- Display control flow and return values.
- Continuous-splash and GDSC policy.
- DTB, DTBO, ramdisk, recovery DTBO, panel commands, timing, clocks and regulator voltages.

## Validation gate

The workflow must pass source-shape audits, display-source hash invariants, full Image compilation, final Image marker checks, both two-copy and three-copy decoder self-tests, boot-image repack invariants and checksum verification.

Draft and not hardware validated.