### PR TITLE
Phase 198: trace SDE hardware catalog initialization

### DIFF
--- a/.github/workflows/198-a52-catalog-init-trace.yml
+++ b/.github/workflows/198-a52-catalog-init-trace.yml
@@ -1,0 +1,96 @@
+name: 198 - A52 SDE hardware catalog initialization trace
+
+run-name: Build Phase 198 catalog initialization trace candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-catalog-init-trace-v1
+    paths:
+      - .github/workflows/198-a52-catalog-init-trace.yml
+      - scripts/198_apply_catalog_trace.py
+      - scripts/198_ci.sh
+  pull_request:
+    branches:
+      - agent/a52-kms-block-init-triple-rs-v1
+    paths:
+      - .github/workflows/198-a52-catalog-init-trace.yml
+      - scripts/198_apply_catalog_trace.py
+      - scripts/198_ci.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-catalog-init-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 198 catalog trace candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 198 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 198
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: |
+          python3 scripts/194_fix_inherited_guard.py
+          bash scripts/198_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-catalog-init-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-catalog-init-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 198 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-catalog-init-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-catalog-init-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/198_apply_catalog_trace.py
+++ b/scripts/198_apply_catalog_trace.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected exactly one anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+OLD_FUNCTION = r'''struct sde_mdss_cfg *sde_hw_catalog_init(struct drm_device *dev, u32 hw_rev)
+{
+	int rc;
+	struct sde_mdss_cfg *sde_cfg;
+	struct device_node *np = dev->dev->of_node;
+
+	sde_cfg = kzalloc(sizeof(*sde_cfg), GFP_KERNEL);
+	if (!sde_cfg)
+		return ERR_PTR(-ENOMEM);
+
+	sde_cfg->hwversion = hw_rev;
+
+	rc = _sde_hardware_pre_caps(sde_cfg, hw_rev);
+	if (rc)
+		goto end;
+
+	rc = sde_top_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+#if defined(CONFIG_DISPLAY_SAMSUNG)
+	{
+		/* sde_hw_catalog_init() be called once for dual dsi,
+		 * and two vdds share same sde_kms pointer.
+		 * get sde_kms from primary vdd, then call ss_callback
+		 * for primary and secondary vdd, respectively.
+		 */
+		struct samsung_display_driver_data *vdd = ss_get_vdd(PRIMARY_DISPLAY_NDX);
+		int i;
+
+		if (IS_ERR_OR_NULL(vdd))
+			goto done;
+
+		for (i = PRIMARY_DISPLAY_NDX; i <= SECONDARY_DISPLAY_NDX; i++) {
+			vdd = ss_get_vdd(i);
+			ss_pba_config(vdd, (void *)sde_cfg);
+		}
+	}
+done:
+#endif
+
+	rc = sde_perf_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_qos_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_rot_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	/* uidle must be done before sspp and ctl,
+	 * so if something goes wrong, we won't
+	 * enable it in ctl and sspp.
+	 */
+	rc = sde_uidle_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_ctl_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_sspp_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_dspp_top_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_dspp_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_ds_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_dsc_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_pp_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	/* mixer parsing should be done after dspp,
+	 * ds and pp for mapping setup
+	 */
+	rc = sde_mixer_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_intf_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_wb_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	/* cdm parsing should be done after intf and wb for mapping setup */
+	rc = sde_cdm_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_vbif_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_parse_reg_dma_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_parse_merge_3d_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = sde_qdss_parse_dt(np, sde_cfg);
+	if (rc)
+		goto end;
+
+	rc = _sde_hardware_post_caps(sde_cfg, hw_rev);
+	if (rc)
+		goto end;
+
+	return sde_cfg;
+
+end:
+	sde_hw_catalog_deinit(sde_cfg);
+	return NULL;
+}'''
+
+
+NEW_FUNCTION = r'''struct sde_mdss_cfg *sde_hw_catalog_init(struct drm_device *dev, u32 hw_rev)
+{
+	int rc;
+	struct sde_mdss_cfg *sde_cfg;
+	struct device_node *np = dev->dev->of_node;
+
+	a52_ackfr_record("CAT enter rev=0x%x np-null=%d", hw_rev, !np);
+	a52_ackfr_record("CAT alloc enter bytes=%zu", sizeof(*sde_cfg));
+	sde_cfg = kzalloc(sizeof(*sde_cfg), GFP_KERNEL);
+	a52_ackfr_record("CAT alloc exit null=%d", !sde_cfg);
+	if (!sde_cfg)
+		return ERR_PTR(-ENOMEM);
+
+	sde_cfg->hwversion = hw_rev;
+
+	a52_ackfr_record("CAT pre-caps enter");
+	rc = _sde_hardware_pre_caps(sde_cfg, hw_rev);
+	a52_ackfr_record("CAT pre-caps exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT top enter");
+	rc = sde_top_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT top exit rc=%d mdp=%u", rc, sde_cfg->mdp_count);
+	if (rc)
+		goto end;
+
+#if defined(CONFIG_DISPLAY_SAMSUNG)
+	{
+		/* sde_hw_catalog_init() be called once for dual dsi,
+		 * and two vdds share same sde_kms pointer.
+		 * get sde_kms from primary vdd, then call ss_callback
+		 * for primary and secondary vdd, respectively.
+		 */
+		struct samsung_display_driver_data *vdd;
+		int i;
+
+		a52_ackfr_record("CAT samsung primary enter");
+		vdd = ss_get_vdd(PRIMARY_DISPLAY_NDX);
+		a52_ackfr_record("CAT samsung primary exit null=%d err=%ld",
+			!vdd, IS_ERR(vdd) ? PTR_ERR(vdd) : 0L);
+		if (IS_ERR_OR_NULL(vdd))
+			goto done;
+
+		for (i = PRIMARY_DISPLAY_NDX; i <= SECONDARY_DISPLAY_NDX; i++) {
+			a52_ackfr_record("CAT samsung pba enter i=%d", i);
+			vdd = ss_get_vdd(i);
+			a52_ackfr_record("CAT samsung vdd i=%d null=%d err=%ld", i,
+				!vdd, IS_ERR(vdd) ? PTR_ERR(vdd) : 0L);
+			ss_pba_config(vdd, (void *)sde_cfg);
+			a52_ackfr_record("CAT samsung pba exit i=%d", i);
+		}
+	}
+done:
+	a52_ackfr_record("CAT samsung done");
+#endif
+
+	a52_ackfr_record("CAT perf enter");
+	rc = sde_perf_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT perf exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT qos enter");
+	rc = sde_qos_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT qos exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT rot enter");
+	rc = sde_rot_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT rot exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	/* uidle must be done before sspp and ctl,
+	 * so if something goes wrong, we won't
+	 * enable it in ctl and sspp.
+	 */
+	a52_ackfr_record("CAT uidle enter");
+	rc = sde_uidle_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT uidle exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT ctl enter");
+	rc = sde_ctl_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT ctl exit rc=%d count=%u", rc, sde_cfg->ctl_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT sspp enter");
+	rc = sde_sspp_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT sspp exit rc=%d count=%u", rc, sde_cfg->sspp_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT dspp-top enter");
+	rc = sde_dspp_top_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT dspp-top exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT dspp enter");
+	rc = sde_dspp_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT dspp exit rc=%d count=%u", rc, sde_cfg->dspp_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT ds enter");
+	rc = sde_ds_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT ds exit rc=%d count=%u", rc, sde_cfg->ds_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT dsc enter");
+	rc = sde_dsc_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT dsc exit rc=%d count=%u", rc, sde_cfg->dsc_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT pp enter");
+	rc = sde_pp_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT pp exit rc=%d count=%u", rc, sde_cfg->pingpong_count);
+	if (rc)
+		goto end;
+
+	/* mixer parsing should be done after dspp,
+	 * ds and pp for mapping setup
+	 */
+	a52_ackfr_record("CAT mixer enter");
+	rc = sde_mixer_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT mixer exit rc=%d count=%u", rc, sde_cfg->mixer_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT intf enter");
+	rc = sde_intf_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT intf exit rc=%d count=%u", rc, sde_cfg->intf_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT wb enter");
+	rc = sde_wb_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT wb exit rc=%d count=%u", rc, sde_cfg->wb_count);
+	if (rc)
+		goto end;
+
+	/* cdm parsing should be done after intf and wb for mapping setup */
+	a52_ackfr_record("CAT cdm enter");
+	rc = sde_cdm_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT cdm exit rc=%d count=%u", rc, sde_cfg->cdm_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT vbif enter");
+	rc = sde_vbif_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT vbif exit rc=%d count=%u", rc, sde_cfg->vbif_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT reg-dma enter");
+	rc = sde_parse_reg_dma_dt(np, sde_cfg);
+	a52_ackfr_record("CAT reg-dma exit rc=%d count=%u", rc,
+		sde_cfg->reg_dma_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT merge3d enter");
+	rc = sde_parse_merge_3d_dt(np, sde_cfg);
+	a52_ackfr_record("CAT merge3d exit rc=%d count=%u", rc,
+		sde_cfg->merge_3d_count);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT qdss enter");
+	rc = sde_qdss_parse_dt(np, sde_cfg);
+	a52_ackfr_record("CAT qdss exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT post-caps enter");
+	rc = _sde_hardware_post_caps(sde_cfg, hw_rev);
+	a52_ackfr_record("CAT post-caps exit rc=%d", rc);
+	if (rc)
+		goto end;
+
+	a52_ackfr_record("CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u",
+		sde_cfg->ctl_count, sde_cfg->sspp_count, sde_cfg->mixer_count,
+		sde_cfg->intf_count, sde_cfg->wb_count);
+	return sde_cfg;
+
+end:
+	a52_ackfr_record("CAT fail rc=%d", rc);
+	sde_hw_catalog_deinit(sde_cfg);
+	return NULL;
+}'''
+
+
+def patch_file(path: Path) -> None:
+    text = path.read_text()
+    text = replace_once(
+        text,
+        '#include <linux/pm_qos.h>\n',
+        '#include <linux/pm_qos.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'recorder include',
+    )
+    text = replace_once(text, OLD_FUNCTION, NEW_FUNCTION, 'catalog init function')
+    path.write_text(text)
+
+
+def self_test() -> None:
+    sample = '#include <linux/pm_qos.h>\n\n' + OLD_FUNCTION + '\n'
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / 'sde_hw_catalog.c'
+        path.write_text(sample)
+        patch_file(path)
+        out = path.read_text()
+        assert '#include <linux/a52_ack_secure_flight_recorder.h>' in out
+        assert 'CAT enter rev=0x%x np-null=%d' in out
+        assert 'CAT samsung pba exit i=%d' in out
+        assert 'CAT post-caps exit rc=%d' in out
+        assert 'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u' in out
+        assert 'CAT fail rc=%d' in out
+        assert OLD_FUNCTION not in out
+    print('phase198 catalog trace patcher self-test: PASS')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path)
+    parser.add_argument('--self-test', action='store_true')
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        return
+    if args.root is None:
+        parser.error('--root is required unless --self-test is used')
+
+    target = args.root / 'drivers/a52_display/msm/sde/sde_hw_catalog.c'
+    patch_file(target)
+    print(f'phase198 catalog trace applied: {target}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/198_ci.sh
+++ b/scripts/198_ci.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-kms-block-init-triple-rs"
+OUT="$PWD/artifacts/a52xq-catalog-init-trace"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/197_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase198.config"
+cp "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
+  "$OUT/stage/sde-hw-catalog-before-phase198.c"
+sha256sum \
+  "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$ROOT/fs/pstore/ram.c" \
+  "$ROOT/init/main.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  > "$OUT/stage/phase197-invariants-before-phase198.sha256"
+
+python3 scripts/198_apply_catalog_trace.py --self-test | \
+  tee "$OUT/logs/phase198-patcher-self-test.log"
+python3 scripts/198_apply_catalog_trace.py --root "$ROOT" | \
+  tee "$OUT/logs/phase198-apply.log"
+
+cp "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
+  "$OUT/stage/sde-hw-catalog-after-phase198.c"
+cp scripts/198_apply_catalog_trace.py "$OUT/stage/"
+
+git -C "$ROOT" diff --check
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase198.config" "$OUT/config/final.config"
+sha256sum -c "$OUT/stage/phase197-invariants-before-phase198.sha256"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+cat = (root / 'drivers/a52_display/msm/sde/sde_hw_catalog.c').read_text()
+rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+ram = (root / 'fs/pstore/ram.c').read_text()
+main = (root / 'init/main.c').read_text()
+kms = (root / 'drivers/a52_display/msm/sde/sde_kms.c').read_text()
+
+for marker in (
+    '#include <linux/a52_ack_secure_flight_recorder.h>',
+    'CAT enter rev=0x%x np-null=%d',
+    'CAT alloc exit null=%d',
+    'CAT pre-caps exit rc=%d',
+    'CAT top exit rc=%d mdp=%u',
+    'CAT samsung primary exit null=%d err=%ld',
+    'CAT samsung pba exit i=%d',
+    'CAT perf exit rc=%d',
+    'CAT qos exit rc=%d',
+    'CAT rot exit rc=%d',
+    'CAT uidle exit rc=%d',
+    'CAT ctl exit rc=%d count=%u',
+    'CAT sspp exit rc=%d count=%u',
+    'CAT dspp-top exit rc=%d',
+    'CAT dspp exit rc=%d count=%u',
+    'CAT ds exit rc=%d count=%u',
+    'CAT dsc exit rc=%d count=%u',
+    'CAT pp exit rc=%d count=%u',
+    'CAT mixer exit rc=%d count=%u',
+    'CAT intf exit rc=%d count=%u',
+    'CAT wb exit rc=%d count=%u',
+    'CAT cdm exit rc=%d count=%u',
+    'CAT vbif exit rc=%d count=%u',
+    'CAT reg-dma exit rc=%d count=%u',
+    'CAT merge3d exit rc=%d count=%u',
+    'CAT qdss exit rc=%d',
+    'CAT post-caps exit rc=%d',
+    'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u',
+    'CAT fail rc=%d',
+):
+    assert marker in cat, marker
+
+assert cat.count('a52_ackfr_record("CAT ') >= 50
+for marker in (
+    '#define A52_R179_BANK_RECORD BIT(2)',
+    'copies=3 crc=0',
+    'BOOT rs=ready phase=197 roots=%u copies=3 crc=0',
+):
+    assert marker in rec, marker
+for marker in (
+    '#define A52_DIAG_RECORD_PHYS 0xB1B00000ULL',
+    'a52_persistent_diag_mark_record("%.*s", (int)len, buf);',
+):
+    assert marker in ram, marker
+assert main.count('A52USR2 BOOT_EARLY stage=mm_init') == 3
+for marker in (
+    'KMSBLK catalog enter rev=0x%x',
+    'KMSBLK catalog exit rc=%ld null=%d',
+    'KMSBLK drm-obj exit rc=%d crtc=%d enc=%d conn=%d plane=%d',
+):
+    assert marker in kms, marker
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase198-catalog-init-trace.patch"
+test -s "$OUT/stage/phase198-catalog-init-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase198-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase198-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase198-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase198-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/a52_display/msm/sde/sde_hw_catalog.o' \
+  "$OUT/logs/phase198-compile.log"
+for marker in \
+  'CAT enter rev=0x%x np-null=%d' \
+  'CAT samsung pba exit i=%d' \
+  'CAT sspp exit rc=%d count=%u' \
+  'CAT post-caps exit rc=%d' \
+  'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u' \
+  'CAT fail rc=%d' \
+  'BOOT rs=ready phase=197 roots=%u copies=3 crc=0' \
+  'KMSBLK catalog enter rev=0x%x' \
+  'A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r179-rs-recorder.py" --self-test
+python3 "$OUT/tools/decode-a52-r197-triple-rs.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 phase 198 SDE hardware-catalog initialization trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+This candidate is Phase 197 plus observation-only checkpoints inside:
+  sde_hw_catalog_init()
+
+The checkpoints bracket allocation, hardware pre-caps, top parsing, Samsung PBA
+callbacks, and every major catalog parser through post-caps. The final Phase 197
+capture ended at "KMSBLK catalog enter", so this build identifies the exact
+catalog substage that fails, hangs, or returns an error.
+
+Recorder behavior is unchanged from Phase 197:
+  - 157 data bytes plus 32 Reed-Solomon parity symbols per copy
+  - 255-byte R79 transport
+  - three independent banks at +0x00000, +0x40000 and +0x80000
+  - no CRC and no recorder-v3 format
+
+The Phase 194 mdss_core_gdsc fix and all Phase 196 KMS block tracing remain
+preserved. Return values, DTB, DTBO, ramdisk, panel commands, timing, IOMMU
+behavior, splash policy and GDSC policy are unchanged.
+
+Decode an untouched 1 MiB RAMOOPS capture with:
+  python3 tools/decode-a52-r197-triple-rs.py RAW_OR_ZIP --output decoded-r198
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+root = Path('artifacts/a52xq-catalog-init-trace')
+base = json.loads(Path('artifacts/a52xq-kms-block-init-triple-rs/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+cat = (root / 'stage/sde-hw-catalog-after-phase198.c').read_text()
+
+audit = dict(base)
+audit.update({
+    'status': 'a52-catalog-init-trace-audited',
+    'phase': 198,
+    'base_phase': 197,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase197': 'observation-only-catalog-trace',
+    'phase197_triple_rs_preserved': True,
+    'phase196_kms_trace_preserved': True,
+    'phase194_mdss_core_gdsc_fix_preserved': True,
+    'catalog_function_instrumented': True,
+    'catalog_checkpoint_count': cat.count('a52_ackfr_record("CAT '),
+    'recorder_copy_count': 3,
+    'recorder_parity_symbols_per_copy': 32,
+    'recorder_crc': False,
+    'return_codes_changed': False,
+    'iommu_bypass_added': False,
+    'continuous_splash_forced': False,
+    'gdsc_keep_on_forced': False,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase197_triple_rs_preserved',
+    'phase196_kms_trace_preserved',
+    'phase194_mdss_core_gdsc_fix_preserved',
+    'catalog_function_instrumented',
+    'dtb_preserved',
+    'ramdisk_preserved',
+    'recovery_dtbo_preserved',
+):
+    assert audit[key] is True, key
+assert audit['catalog_checkpoint_count'] >= 50
+assert audit['recorder_copy_count'] == 3
+assert audit['recorder_parity_symbols_per_copy'] == 32
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
Observation-only checkpoints inside `sde_hw_catalog_init()` on top of Phase 197. Preserves the Phase 194 display fix, Phase 196 KMS tracing, and Phase 197 three-copy RS recorder. Hardware validation pending.