### PR TITLE
Build Phase 199 post-KMS CRC32C recorder

### DIFF
--- a/.github/workflows/199-a52-post-kms-crc32c.yml
+++ b/.github/workflows/199-a52-post-kms-crc32c.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/199-a52-post-kms-crc32c.yml
       - scripts/199_apply_recorder_crc32c.py
       - scripts/199_ci.sh
+      - stage/recorder-after-phase197.c
       - tools/decode-a52-r199-crc32c-base.py
       - tools/decode-a52-r199-crc32c-triple.py
   pull_request:
@@ -20,6 +21,7 @@ on:
       - .github/workflows/199-a52-post-kms-crc32c.yml
       - scripts/199_apply_recorder_crc32c.py
       - scripts/199_ci.sh
+      - stage/recorder-after-phase197.c
       - tools/decode-a52-r199-crc32c-base.py
       - tools/decode-a52-r199-crc32c-triple.py
 

--- a/.github/workflows/199-a52-post-kms-crc32c.yml
+++ b/.github/workflows/199-a52-post-kms-crc32c.yml
@@ -33,8 +33,12 @@ concurrency:
 
 env:
   GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
   PHASE198_ARTIFACT_ID: '8819127383'
   PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
 
 jobs:
   build-package:
@@ -68,12 +72,32 @@ jobs:
           path: gki
           key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
 
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
       - name: Build, package and audit Phase 199
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -Eeuo pipefail
           test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
           bash scripts/199_ci.sh
 
       - name: Upload failed diagnostics

--- a/.github/workflows/199-a52-post-kms-crc32c.yml
+++ b/.github/workflows/199-a52-post-kms-crc32c.yml
@@ -1,0 +1,100 @@
+name: 199 - A52 post-KMS trace with triple RS and CRC32C
+
+run-name: Build Phase 199 post-KMS CRC32C candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-post-kms-crc32c-rs3-v1
+    paths:
+      - .github/workflows/199-a52-post-kms-crc32c.yml
+      - scripts/199_apply_recorder_crc32c.py
+      - scripts/199_ci.sh
+      - tools/decode-a52-r199-crc32c-base.py
+      - tools/decode-a52-r199-crc32c-triple.py
+  pull_request:
+    branches:
+      - agent/a52-catalog-init-trace-v1
+    paths:
+      - .github/workflows/199-a52-post-kms-crc32c.yml
+      - scripts/199_apply_recorder_crc32c.py
+      - scripts/199_ci.sh
+      - tools/decode-a52-r199-crc32c-base.py
+      - tools/decode-a52-r199-crc32c-triple.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-post-kms-crc32c-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 199 post-KMS CRC32C candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 199 branch
+        uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 199
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
+        run: |
+          python3 scripts/194_fix_inherited_guard.py
+          bash scripts/199_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 199 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/199-a52-post-kms-crc32c.yml
+++ b/.github/workflows/199-a52-post-kms-crc32c.yml
@@ -33,20 +33,33 @@ concurrency:
 
 env:
   GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
-  SOURCE_ARTIFACT_ID: '8681171875'
-  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
-  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
-  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
 
 jobs:
   build-package:
     name: Build Phase 199 post-KMS CRC32C candidate
     runs-on: ubuntu-22.04
-    timeout-minutes: 360
+    timeout-minutes: 120
 
     steps:
       - name: Check out Phase 199 branch
         uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
 
       - name: Restore pinned GKI source
         id: gki-cache
@@ -55,30 +68,12 @@ jobs:
           path: gki
           key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
 
-      - name: Restore exact TouchGrass source
-        id: touchgrass-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: workspace/touchgrass-a52xq
-          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
-
-      - name: Clone exact TouchGrass source on cache miss
-        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
-        run: |
-          set -Eeuo pipefail
-          rm -rf workspace/touchgrass-a52xq
-          mkdir -p workspace/touchgrass-a52xq
-          git -C workspace/touchgrass-a52xq init
-          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
-          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
-          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
-
       - name: Build, package and audit Phase 199
         env:
           GH_TOKEN: ${{ github.token }}
-          GKI_CACHE_HIT: ${{ steps.gki-cache.outputs.cache-hit }}
         run: |
-          python3 scripts/194_fix_inherited_guard.py
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
           bash scripts/199_ci.sh
 
       - name: Upload failed diagnostics

--- a/.github/workflows/199b-a52-post-kms-crc32c-anchor-fix.yml
+++ b/.github/workflows/199b-a52-post-kms-crc32c-anchor-fix.yml
@@ -1,0 +1,116 @@
+name: 199b - A52 post-KMS CRC32C anchor-fixed build
+
+run-name: Build Phase 199 with robust CRC insertion anchor
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-post-kms-crc32c-rs3-v1
+    paths:
+      - .github/workflows/199b-a52-post-kms-crc32c-anchor-fix.yml
+      - scripts/199_runtime_fix_crc_anchor.py
+  pull_request:
+    branches:
+      - agent/a52-catalog-init-trace-v1
+    paths:
+      - .github/workflows/199b-a52-post-kms-crc32c-anchor-fix.yml
+      - scripts/199_runtime_fix_crc_anchor.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-post-kms-crc32c-anchor-fixed-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 199 post-KMS CRC32C candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out Phase 199 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 199
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor.py
+          python3 scripts/199_apply_recorder_crc32c.py --self-test
+          bash scripts/199_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-anchor-fixed-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 199 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-anchor-fixed-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/199c-a52-post-kms-crc32c-fixture-safe.yml
+++ b/.github/workflows/199c-a52-post-kms-crc32c-fixture-safe.yml
@@ -1,0 +1,116 @@
+name: 199c - A52 post-KMS CRC32C fixture-safe build
+
+run-name: Build Phase 199 with fixture-safe CRC insertion anchor
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-post-kms-crc32c-rs3-v1
+    paths:
+      - .github/workflows/199c-a52-post-kms-crc32c-fixture-safe.yml
+      - scripts/199_runtime_fix_crc_anchor_v2.py
+  pull_request:
+    branches:
+      - agent/a52-catalog-init-trace-v1
+    paths:
+      - .github/workflows/199c-a52-post-kms-crc32c-fixture-safe.yml
+      - scripts/199_runtime_fix_crc_anchor_v2.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-post-kms-crc32c-fixture-safe-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 199 post-KMS CRC32C candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out Phase 199 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 199
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_apply_recorder_crc32c.py --self-test
+          bash scripts/199_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-fixture-safe-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 199 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-fixture-safe-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/199d-a52-post-kms-crc32c-valid-audit.yml
+++ b/.github/workflows/199d-a52-post-kms-crc32c-valid-audit.yml
@@ -1,0 +1,118 @@
+name: 199d - A52 post-KMS CRC32C valid binary audit
+
+run-name: Build Phase 199 with valid source and Image audits
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-post-kms-crc32c-rs3-v1
+    paths:
+      - .github/workflows/199d-a52-post-kms-crc32c-valid-audit.yml
+      - scripts/199_runtime_fix_binary_audit.py
+  pull_request:
+    branches:
+      - agent/a52-catalog-init-trace-v1
+    paths:
+      - .github/workflows/199d-a52-post-kms-crc32c-valid-audit.yml
+      - scripts/199_runtime_fix_binary_audit.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-post-kms-crc32c-valid-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 199 post-KMS CRC32C candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out Phase 199 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_runtime_fix_binary_audit.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 199
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_runtime_fix_binary_audit.py
+          python3 scripts/199_apply_recorder_crc32c.py --self-test
+          bash scripts/199_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-valid-audit-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 199 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-post-kms-crc32c-valid-audit-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-post-kms-crc32c
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/199_apply_recorder_crc32c.py
+++ b/scripts/199_apply_recorder_crc32c.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+RECORDER = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected exactly one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_recorder(text: str) -> str:
+    if 'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c' in text:
+        return text
+
+    text = replace_once(
+        text,
+        " * A52 GKI 5.10 display takeover recorder, phase 179.\n",
+        " * A52 GKI 5.10 display takeover recorder, phase 199.\n",
+        "recorder phase comment",
+    )
+    text = replace_once(
+        text,
+        " * Records are fixed-size, Reed-Solomon protected, and written independently\n"
+        " * to the record, console and ftrace RAMOOPS banks. CRC is intentionally not used in\n"
+        " * this phase. Payloads remain metadata-only.\n",
+        " * Records are fixed-size, CRC32C validated, Reed-Solomon protected, and written\n"
+        " * independently to the record, console and ftrace RAMOOPS banks. Payloads\n"
+        " * remain metadata-only.\n",
+        "recorder protection comment",
+    )
+    text = replace_once(
+        text,
+        '#define pr_fmt(fmt) "A52R179: " fmt\n',
+        '#define pr_fmt(fmt) "A52R199: " fmt\n',
+        "recorder printk prefix",
+    )
+    text = replace_once(
+        text,
+        "#define A52_R179_CAPACITY 768U\n"
+        "#define A52_R179_MESSAGE_LEN 94U\n",
+        "#define A52_R179_CAPACITY 896U\n"
+        "#define A52_R179_MESSAGE_LEN 90U\n",
+        "capacity and message length",
+    )
+    text = replace_once(
+        text,
+        "#define A52_R179_COMMIT 0x5a52c179U\n"
+        "#define A52_R179_VERSION 1U\n",
+        "#define A52_R179_COMMIT 0x5a52c199U\n"
+        "#define A52_R179_VERSION 2U\n",
+        "format version and commit",
+    )
+    text = replace_once(
+        text,
+        '#define A52_R179_PREFIX "R79"\n',
+        '#define A52_R179_PREFIX "R99"\n',
+        "transport prefix",
+    )
+    text = replace_once(
+        text,
+        "\tchar message[A52_R179_MESSAGE_LEN - 1];\n"
+        "\t__le32 commit;\n",
+        "\tchar message[A52_R179_MESSAGE_LEN - 1];\n"
+        "\t__le32 crc32c;\n"
+        "\t__le32 commit;\n",
+        "record crc field",
+    )
+
+    crc_function = r'''
+static u32 a52_r199_crc32c(const void *buffer, size_t len)
+{
+	const u8 *bytes = buffer;
+	u32 crc = ~0U;
+	size_t index;
+	unsigned int bit;
+
+	for (index = 0; index < len; index++) {
+		crc ^= bytes[index];
+		for (bit = 0; bit < 8; bit++)
+			crc = (crc >> 1) ^
+				((crc & 1) ? 0x82f63b78U : 0U);
+	}
+	return ~crc;
+}
+
+'''
+    text = replace_once(
+        text,
+        "extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,\n"
+        "\t\t\t\t\t     unsigned int targets);\n\n",
+        "extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,\n"
+        "\t\t\t\t\t     unsigned int targets);\n\n"
+        + crc_function,
+        "crc32c function insertion",
+    )
+    text = replace_once(
+        text,
+        'memcpy(data->magic, "A52R0179", sizeof(data->magic));\n',
+        'memcpy(data->magic, "A52R0199", sizeof(data->magic));\n',
+        "record magic",
+    )
+    text = replace_once(
+        text,
+        "\tmemcpy(data->comm, event->comm, sizeof(data->comm));\n"
+        "\tmemcpy(data->message, event->message, message_len);\n"
+        "\tdata->commit = cpu_to_le32(A52_R179_COMMIT);\n",
+        "\tmemcpy(data->comm, event->comm, sizeof(data->comm));\n"
+        "\tmemcpy(data->message, event->message, message_len);\n"
+        "\tdata->crc32c = cpu_to_le32(a52_r199_crc32c(data,\n"
+        "\t\t\toffsetof(struct a52_r179_data, crc32c)));\n"
+        "\tdata->commit = cpu_to_le32(A52_R179_COMMIT);\n",
+        "record crc calculation",
+    )
+    text = replace_once(
+        text,
+        "\treturn !strncmp(message, \"BOOT \", 5) ||\n"
+        "\t       !strncmp(message, \"HB \", 3) ||\n"
+        "\t       !strncmp(message, \"REFGEN \", 7) ||\n"
+        "\t       !strncmp(message, \"DISP \", 5) ||\n"
+        "\t       !strncmp(message, \"WDT \", 4);\n",
+        "\treturn !strncmp(message, \"BOOT \", 5) ||\n"
+        "\t       !strncmp(message, \"HB \", 3) ||\n"
+        "\t       !strncmp(message, \"REFGEN \", 7) ||\n"
+        "\t       !strncmp(message, \"DISP \", 5) ||\n"
+        "\t       !strncmp(message, \"WDT \", 4) ||\n"
+        "\t       !strncmp(message, \"DRMPOST \", 8) ||\n"
+        "\t       !strncmp(message, \"KMSPOST \", 8) ||\n"
+        "\t       !strncmp(message, \"KMSBLK \", 7) ||\n"
+        "\t       !strncmp(message, \"CAT \", 4) ||\n"
+        "\t       !strncmp(message, \"A52GDSC \", 8);\n",
+        "critical retention prefixes",
+    )
+    text = replace_once(
+        text,
+        'a52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=3 crc=0",',
+        'a52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=3 crc=crc32c",',
+        "control crc marker",
+    )
+    text = replace_once(
+        text,
+        'a52_ackfr_record("BOOT rs=ready phase=197 roots=%u copies=3 crc=0",',
+        'a52_ackfr_record("BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c",',
+        "ready marker",
+    )
+    text = replace_once(
+        text,
+        'pr_info("phase197 triple-copy recorder enabled stored=%llu dropped=%llu\\n",',
+        'pr_info("phase199 triple-copy RS+CRC32C recorder enabled stored=%llu dropped=%llu\\n",',
+        "recorder printk profile",
+    )
+    return text
+
+
+def run(root: Path) -> None:
+    path = root / RECORDER
+    if not path.is_file():
+        raise SystemExit(f"missing recorder source: {path}")
+    original = path.read_text(encoding="utf-8")
+    patched = patch_recorder(original)
+    path.write_text(patched, encoding="utf-8")
+
+    required = (
+        "A52 GKI 5.10 display takeover recorder, phase 199",
+        '#define pr_fmt(fmt) "A52R199: " fmt',
+        "#define A52_R179_CAPACITY 896U",
+        "#define A52_R179_MESSAGE_LEN 90U",
+        "#define A52_R179_COMMIT 0x5a52c199U",
+        "#define A52_R179_VERSION 2U",
+        '#define A52_R179_PREFIX "R99"',
+        "__le32 crc32c;",
+        "a52_r199_crc32c",
+        'memcpy(data->magic, "A52R0199"',
+        "offsetof(struct a52_r179_data, crc32c)",
+        '!strncmp(message, "DRMPOST ", 8)',
+        '!strncmp(message, "KMSPOST ", 8)',
+        '!strncmp(message, "KMSBLK ", 7)',
+        '!strncmp(message, "CAT ", 4)',
+        '!strncmp(message, "A52GDSC ", 8)',
+        "copies=3 crc=crc32c",
+        "BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c",
+        "phase199 triple-copy RS+CRC32C recorder enabled",
+    )
+    for marker in required:
+        if marker not in patched:
+            raise SystemExit(f"missing Phase 199 marker: {marker}")
+    if "copies=3 crc=0" in patched:
+        raise SystemExit("legacy crc=0 marker remains")
+
+
+def self_test() -> None:
+    source = Path(__file__).resolve().parents[1] / "stage" / "recorder-after-phase197.c"
+    if not source.is_file():
+        fixture = '''// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * A52 GKI 5.10 display takeover recorder, phase 179.
+ *
+ * Records are fixed-size, Reed-Solomon protected, and written independently
+ * to the record, console and ftrace RAMOOPS banks. CRC is intentionally not used in
+ * this phase. Payloads remain metadata-only.
+ */
+#undef pr_fmt
+#define pr_fmt(fmt) "A52R179: " fmt
+#define A52_R179_CAPACITY 768U
+#define A52_R179_MESSAGE_LEN 94U
+#define A52_R179_COMMIT 0x5a52c179U
+#define A52_R179_VERSION 1U
+#define A52_R179_PREFIX "R79"
+struct a52_r179_data {
+	char message[A52_R179_MESSAGE_LEN - 1];
+	__le32 commit;
+} __packed;
+extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,
+					     unsigned int targets);
+static void p(void) {
+	memcpy(data->magic, "A52R0179", sizeof(data->magic));
+	memcpy(data->comm, event->comm, sizeof(data->comm));
+	memcpy(data->message, event->message, message_len);
+	data->commit = cpu_to_le32(A52_R179_COMMIT);
+}
+static bool a52_r179_is_critical_message(const char *message)
+{
+	return !strncmp(message, "BOOT ", 5) ||
+	       !strncmp(message, "HB ", 3) ||
+	       !strncmp(message, "REFGEN ", 7) ||
+	       !strncmp(message, "DISP ", 5) ||
+	       !strncmp(message, "WDT ", 4);
+}
+void c(void) {
+	a52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=3 crc=0",
+	a52_ackfr_record("BOOT rs=ready phase=197 roots=%u copies=3 crc=0",
+	pr_info("phase197 triple-copy recorder enabled stored=%llu dropped=%llu\\n",
+}
+'''
+    else:
+        fixture = source.read_text(encoding="utf-8")
+    patched = patch_recorder(fixture)
+    assert 'memcpy(data->magic, "A52R0199"' in patched
+    assert "__le32 crc32c;" in patched
+    assert "copies=3 crc=crc32c" in patched
+    assert '!strncmp(message, "DRMPOST ", 8)' in patched
+    assert "copies=3 crc=0" not in patched
+    print("phase199 recorder CRC32C patcher self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply Phase 199 recorder CRC32C and retention hardening")
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.root is None:
+        parser.error("--root is required unless --self-test is used")
+    run(args.root)
+    print("phase199 recorder CRC32C and post-KMS retention staged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/199_ci.sh
+++ b/scripts/199_ci.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-catalog-init-trace"
+OUT="$PWD/artifacts/a52xq-post-kms-crc32c"
+BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/198_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase199.config"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-before-phase199.c"
+sha256sum \
+  "$ROOT/fs/pstore/ram.c" \
+  "$ROOT/init/main.c" \
+  "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
+  "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  > "$OUT/stage/phase198-invariants-before-phase199.sha256"
+
+python3 scripts/199_apply_recorder_crc32c.py --self-test | \
+  tee "$OUT/logs/phase199-patcher-self-test.log"
+python3 scripts/199_apply_recorder_crc32c.py --root "$ROOT" | \
+  tee "$OUT/logs/phase199-apply.log"
+
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-after-phase199.c"
+cp scripts/199_apply_recorder_crc32c.py "$OUT/stage/"
+cp tools/decode-a52-r199-crc32c-base.py "$OUT/tools/"
+cp tools/decode-a52-r199-crc32c-triple.py "$OUT/tools/"
+
+git -C "$ROOT" diff --check
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase199.config" "$OUT/config/final.config"
+sha256sum -c "$OUT/stage/phase198-invariants-before-phase199.sha256"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+ram = (root / 'fs/pstore/ram.c').read_text()
+main = (root / 'init/main.c').read_text()
+msm = (root / 'drivers/a52_display/msm/msm_drv.c').read_text()
+kms = (root / 'drivers/a52_display/msm/sde/sde_kms.c').read_text()
+cat = (root / 'drivers/a52_display/msm/sde/sde_hw_catalog.c').read_text()
+
+for marker in (
+    'A52 GKI 5.10 display takeover recorder, phase 199',
+    '#define A52_R179_CAPACITY 896U',
+    '#define A52_R179_MESSAGE_LEN 90U',
+    '#define A52_R179_COMMIT 0x5a52c199U',
+    '#define A52_R179_VERSION 2U',
+    '#define A52_R179_PREFIX "R99"',
+    '__le32 crc32c;',
+    'a52_r199_crc32c',
+    '0x82f63b78U',
+    'memcpy(data->magic, "A52R0199"',
+    'offsetof(struct a52_r179_data, crc32c)',
+    '!strncmp(message, "DRMPOST ", 8)',
+    '!strncmp(message, "KMSPOST ", 8)',
+    '!strncmp(message, "KMSBLK ", 7)',
+    '!strncmp(message, "CAT ", 4)',
+    '!strncmp(message, "A52GDSC ", 8)',
+    'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c',
+    'phase199 triple-copy RS+CRC32C recorder enabled',
+):
+    assert marker in rec, marker
+assert 'copies=3 crc=0' not in rec
+assert '#define A52_R179_BANK_RECORD BIT(2)' in rec
+assert 'A52_R179_BANK_ALL' in rec
+assert '#define A52_DIAG_RECORD_PHYS 0xB1B00000ULL' in ram
+assert main.count('A52USR2 BOOT_EARLY stage=mm_init') == 3
+for marker in (
+    'DRMPOST thread-create enter',
+    'DRMPOST vblank enter crtc=%d',
+    'DRMPOST irq-install enter irq=%d',
+    'DRMPOST dev-register enter',
+    'DRMPOST mode-reset enter',
+    'DRMPOST splash-config enter',
+    'DRMPOST postinit enter',
+    'DRMPOST poll-init enter',
+    'DRMPOST init success',
+):
+    assert marker in msm, marker
+for marker in (
+    'KMSBLK catalog enter rev=0x%x',
+    'KMSBLK catalog exit rc=%ld null=%d',
+):
+    assert marker in kms, marker
+for marker in (
+    'CAT enter rev=0x%x np-null=%d',
+    'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u',
+):
+    assert marker in cat, marker
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase199-post-kms-crc32c.patch"
+test -s "$OUT/stage/phase199-post-kms-crc32c.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase199-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase199-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase199-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase199-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+grep -Fq 'drivers/a52_secure/a52_ack_secure_flight_recorder.o' \
+  "$OUT/logs/phase199-compile.log"
+for marker in \
+  'A52R0199' \
+  'phase199 triple-copy RS+CRC32C recorder enabled' \
+  'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c' \
+  'DRMPOST thread-create enter' \
+  'DRMPOST vblank enter crtc=%d' \
+  'DRMPOST irq-install enter irq=%d' \
+  'DRMPOST dev-register enter' \
+  'DRMPOST splash-config enter' \
+  'DRMPOST postinit enter' \
+  'DRMPOST poll-init enter' \
+  'KMSBLK catalog enter rev=0x%x' \
+  'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source source/extracted/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test
+python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 199 post-KMS trace with triple-copy RS + CRC32C
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+This candidate preserves the full Phase 198 catalog trace and the Phase 195
+post-KMS checkpoints. The functional display path is unchanged.
+
+Recorder format:
+  - three independent physical RAMOOPS banks at +0x00000, +0x40000, +0x80000
+  - 157 protected data bytes plus 32 Reed-Solomon parity symbols per copy
+  - CRC32C over record metadata and message
+  - fixed 255-byte R99 transport
+  - 896-record initial retention
+  - DRMPOST, KMSPOST, KMSBLK, CAT and A52GDSC remain retained after capacity
+
+The previous Phase 198 capture proved that the hardware catalog and SDE KMS
+hardware initialization complete. This image retains the already-present
+checkpoints for thread creation, vblank setup, IRQ installation, DRM device
+registration, mode reset, continuous splash, debugfs, KMS post-init and polling.
+
+Collect the untouched full 1 MiB RAMOOPS snapshot. The raw collector can remain
+unchanged. Decode on a computer with:
+  python3 tools/decode-a52-r199-crc32c-triple.py RAW_OR_ZIP --output decoded-r199
+
+Every accepted decoded record must pass CRC32C. The decoder also attempts
+same-offset majority and clear-bit OR fusion across the three physical copies.
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+root = Path('artifacts/a52xq-post-kms-crc32c')
+base = json.loads(Path('artifacts/a52xq-catalog-init-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+rec = (root / 'stage/recorder-after-phase199.c').read_text()
+
+audit = dict(base)
+audit.update({
+    'status': 'a52-post-kms-crc32c-audited',
+    'phase': 199,
+    'base_phase': 198,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'functional_change_from_phase198': 'recorder-integrity-and-retention-only',
+    'display_control_flow_changed': False,
+    'return_codes_changed': False,
+    'catalog_trace_preserved': True,
+    'post_kms_trace_preserved': True,
+    'phase194_mdss_core_gdsc_fix_preserved': True,
+    'recorder_format': 'R99-base64-RS-CRC32C',
+    'recorder_copy_count': 3,
+    'recorder_banks': ['record', 'console', 'ftrace'],
+    'recorder_data_bytes': 157,
+    'recorder_message_bytes': 89,
+    'recorder_parity_symbols_per_copy': 32,
+    'recorder_crc': 'CRC32C',
+    'recorder_crc_polynomial_reflected': '0x82f63b78',
+    'recorder_initial_capacity': 896,
+    'post_capacity_retention': ['BOOT', 'HB', 'REFGEN', 'DISP', 'WDT', 'DRMPOST', 'KMSPOST', 'KMSBLK', 'CAT', 'A52GDSC'],
+    'decoder_cross_copy_fusion': ['bit-majority', 'clear-bit-OR'],
+    'iommu_bypass_added': False,
+    'continuous_splash_forced': False,
+    'gdsc_keep_on_forced': False,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'catalog_trace_preserved',
+    'post_kms_trace_preserved',
+    'phase194_mdss_core_gdsc_fix_preserved',
+    'dtb_preserved',
+    'ramdisk_preserved',
+    'recovery_dtbo_preserved',
+):
+    assert audit[key] is True, key
+assert audit['recorder_copy_count'] == 3
+assert audit['recorder_parity_symbols_per_copy'] == 32
+assert audit['recorder_crc'] == 'CRC32C'
+assert 'copies=3 crc=0' not in rec
+(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/199_ci.sh
+++ b/scripts/199_ci.sh
@@ -1,19 +1,68 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BASE_OUT="$PWD/artifacts/a52xq-catalog-init-trace"
 OUT="$PWD/artifacts/a52xq-post-kms-crc32c"
-BUILD="$PWD/workspace/gki-display-init-recorder-plain-out"
+BUILD="$PWD/workspace/gki-phase199-out"
 ROOT="$PWD/gki/common"
-mkdir -p "$OUT/logs"
+PHASE198="$PWD/workspace/phase198-artifact"
+ARTIFACT_ZIP="$PWD/workspace/phase198-artifact.zip"
+mkdir -p "$OUT/logs" "$PWD/workspace"
 trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
 
-bash scripts/198_ci.sh
-rm -rf "$OUT"
-cp -a "$BASE_OUT" "$OUT"
-rm -f "$OUT/SHA256SUMS"
-mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+: "${PHASE198_ARTIFACT_ID:?PHASE198_ARTIFACT_ID is required}"
+: "${PHASE198_ARTIFACT_SHA256:?PHASE198_ARTIFACT_SHA256 is required}"
+: "${GKI_COMMON_SHA:?GKI_COMMON_SHA is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
 
+rm -rf "$OUT" "$PHASE198" "$BUILD"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools} "$PHASE198" "$BUILD"
+
+# Restore the exact audited Phase 198 artifact instead of rebuilding Phases 180-198.
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${PHASE198_ARTIFACT_ID}/zip" \
+  --output "$ARTIFACT_ZIP"
+printf '%s  %s\n' "$PHASE198_ARTIFACT_SHA256" "$ARTIFACT_ZIP" | sha256sum -c -
+unzip -q "$ARTIFACT_ZIP" -d "$PHASE198"
+(
+  cd "$PHASE198"
+  sha256sum -c SHA256SUMS
+) > "$OUT/logs/phase198-manifest-verification.log"
+
+for required in \
+  "$PHASE198/stage/phase198-catalog-init-trace.patch" \
+  "$PHASE198/config/final.config" \
+  "$PHASE198/package/boot.img" \
+  "$PHASE198/package/repack-report.json" \
+  "$PHASE198/final-audit.json" \
+  "$PHASE198/tools/decode-a52-r179-rs-recorder.py"; do
+  test -s "$required"
+done
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+root = Path('workspace/phase198-artifact')
+audit = json.loads((root / 'final-audit.json').read_text())
+assert audit['status'] == 'a52-catalog-init-trace-audited'
+assert audit['phase'] == 198
+assert audit['flashable_candidate'] is True
+assert audit['phase194_mdss_core_gdsc_fix_preserved'] is True
+assert audit['phase196_kms_trace_preserved'] is True
+assert audit['phase197_triple_rs_preserved'] is True
+PY
+
+# Recreate the exact Phase 198 source state from the pinned GKI commit.
+test -d "$ROOT/.git"
+test "$(git -C "$ROOT" rev-parse HEAD)" = "$GKI_COMMON_SHA"
+git -C "$ROOT" reset --hard "$GKI_COMMON_SHA"
+git -C "$ROOT" clean -fd
+git -C "$ROOT" apply --check "$PHASE198/stage/phase198-catalog-init-trace.patch"
+git -C "$ROOT" apply "$PHASE198/stage/phase198-catalog-init-trace.patch"
+git -C "$ROOT" diff --check
+
+cp "$PHASE198/config/final.config" "$BUILD/.config"
 cp "$BUILD/.config" "$OUT/config/before-phase199.config"
 cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
   "$OUT/stage/recorder-before-phase199.c"
@@ -34,12 +83,11 @@ python3 scripts/199_apply_recorder_crc32c.py --root "$ROOT" | \
 cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
   "$OUT/stage/recorder-after-phase199.c"
 cp scripts/199_apply_recorder_crc32c.py "$OUT/stage/"
+cp "$PHASE198/tools/decode-a52-r179-rs-recorder.py" "$OUT/tools/"
 cp tools/decode-a52-r199-crc32c-base.py "$OUT/tools/"
 cp tools/decode-a52-r199-crc32c-triple.py "$OUT/tools/"
 
 git -C "$ROOT" diff --check
-cp "$BUILD/.config" "$OUT/config/final.config"
-cmp "$OUT/config/before-phase199.config" "$OUT/config/final.config"
 sha256sum -c "$OUT/stage/phase198-invariants-before-phase199.sha256"
 
 python3 - <<'PY'
@@ -110,6 +158,11 @@ CLANG="$(readlink -f "$(command -v clang)")"
 export PATH="$(dirname "$CLANG"):$PATH"
 export CROSS_COMPILE=aarch64-linux-gnu-
 export CLANG_TRIPLE=aarch64-linux-gnu-
+make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+  2>&1 | tee "$OUT/logs/olddefconfig.log"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase199.config" "$OUT/config/final.config"
+
 set +e
 make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
   KCFLAGS=-Wno-error=frame-larger-than Image \
@@ -152,14 +205,16 @@ cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
 gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
 gzip -t "$OUT/package/Image.gz"
 python3 scripts/38_repack_a52_p1_boot.py \
-  --source source/extracted/package/boot.img \
+  --source "$PHASE198/package/boot.img" \
   --kernel "$OUT/package/Image.gz" \
   --output "$OUT/package/boot.img" \
   --report "$OUT/package/repack-report.json"
-python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test
-python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test
+python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test | \
+  tee "$OUT/logs/phase199-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test | \
+  tee "$OUT/logs/phase199-triple-decoder-self-test.log"
 
-cat > "$OUT/README-FIRST.txt" <<'EOF'
+cat > "$OUT/README-FIRST.txt" <<'README'
 A52 GKI 5.10 Phase 199 post-KMS trace with triple-copy RS + CRC32C
 
 FLASH ONLY:
@@ -189,7 +244,7 @@ Every accepted decoded record must pass CRC32C. The decoder also attempts
 same-offset majority and clear-bit OR fusion across the three physical copies.
 
 Compile-audited, not hardware validated.
-EOF
+README
 
 python3 - <<'PY'
 import hashlib
@@ -197,7 +252,8 @@ import json
 from pathlib import Path
 
 root = Path('artifacts/a52xq-post-kms-crc32c')
-base = json.loads(Path('artifacts/a52xq-catalog-init-trace/final-audit.json').read_text())
+base_root = Path('workspace/phase198-artifact')
+base = json.loads((base_root / 'final-audit.json').read_text())
 repack = json.loads((root / 'package/repack-report.json').read_text())
 image = root / 'compile/Image'
 boot = root / 'package/boot.img'
@@ -208,6 +264,7 @@ audit.update({
     'status': 'a52-post-kms-crc32c-audited',
     'phase': 199,
     'base_phase': 198,
+    'base_artifact_sha256': '99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6',
     'hardware_validated': False,
     'flashable_candidate': True,
     'functional_change_from_phase198': 'recorder-integrity-and-retention-only',

--- a/scripts/199_ci.sh
+++ b/scripts/199_ci.sh
@@ -5,318 +5,249 @@ OUT="$PWD/artifacts/a52xq-post-kms-crc32c"
 BUILD="$PWD/workspace/gki-phase199-out"
 ROOT="$PWD/gki/common"
 PHASE198="$PWD/workspace/phase198-artifact"
-ARTIFACT_ZIP="$PWD/workspace/phase198-artifact.zip"
-mkdir -p "$OUT/logs" "$PWD/workspace"
+SOURCE="$PWD/workspace/source-artifact"
+TOUCHGRASS="$PWD/workspace/touchgrass-a52xq"
+mkdir -p "$PWD/workspace"
 trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
 
-: "${PHASE198_ARTIFACT_ID:?PHASE198_ARTIFACT_ID is required}"
-: "${PHASE198_ARTIFACT_SHA256:?PHASE198_ARTIFACT_SHA256 is required}"
-: "${GKI_COMMON_SHA:?GKI_COMMON_SHA is required}"
-: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GKI_COMMON_SHA:?}"
+: "${GH_TOKEN:?}"
+: "${SOURCE_ARTIFACT_ID:?}"
+: "${SOURCE_ARTIFACT_SHA256:?}"
+: "${PHASE198_ARTIFACT_ID:?}"
+: "${PHASE198_ARTIFACT_SHA256:?}"
 
-rm -rf "$OUT" "$PHASE198" "$BUILD"
-mkdir -p "$OUT"/{config,logs,stage,compile,package,tools} "$PHASE198" "$BUILD"
+download_artifact() {
+  local id="$1" expected="$2" zip="$3" destination="$4"
+  rm -rf "$destination" "$zip"
+  mkdir -p "$destination"
+  curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+    -H "Authorization: Bearer ${GH_TOKEN}" \
+    -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" \
+    --output "$zip"
+  printf '%s  %s\n' "$expected" "$zip" | sha256sum -c -
+  unzip -q "$zip" -d "$destination"
+  (cd "$destination" && sha256sum -c SHA256SUMS)
+}
 
-# Restore the exact audited Phase 198 artifact instead of rebuilding Phases 180-198.
-curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
-  -H "Authorization: Bearer ${GH_TOKEN}" \
-  -H 'Accept: application/vnd.github+json' \
-  "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${PHASE198_ARTIFACT_ID}/zip" \
-  --output "$ARTIFACT_ZIP"
-printf '%s  %s\n' "$PHASE198_ARTIFACT_SHA256" "$ARTIFACT_ZIP" | sha256sum -c -
-unzip -q "$ARTIFACT_ZIP" -d "$PHASE198"
-(
-  cd "$PHASE198"
-  sha256sum -c SHA256SUMS
-) > "$OUT/logs/phase198-manifest-verification.log"
+rm -rf "$OUT" "$BUILD"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools} "$BUILD"
+
+download_artifact "$SOURCE_ARTIFACT_ID" "$SOURCE_ARTIFACT_SHA256" \
+  "$PWD/workspace/source-artifact.zip" "$SOURCE" \
+  > "$OUT/logs/source-artifact-verification.log"
+download_artifact "$PHASE198_ARTIFACT_ID" "$PHASE198_ARTIFACT_SHA256" \
+  "$PWD/workspace/phase198-artifact.zip" "$PHASE198" \
+  > "$OUT/logs/phase198-artifact-verification.log"
 
 for required in \
-  "$PHASE198/stage/phase198-catalog-init-trace.patch" \
+  "$SOURCE/stage/heap19-display-bindcore-source.patch" \
+  "$SOURCE/config/final.config" \
   "$PHASE198/config/final.config" \
   "$PHASE198/package/boot.img" \
-  "$PHASE198/package/repack-report.json" \
   "$PHASE198/final-audit.json" \
-  "$PHASE198/tools/decode-a52-r179-rs-recorder.py"; do
+  "$PHASE198/stage/180_apply.py" \
+  "$PHASE198/stage/198_apply_catalog_trace.py"; do
   test -s "$required"
 done
+test -d "$TOUCHGRASS/.git"
 
 python3 - <<'PY'
 import json
 from pathlib import Path
-root = Path('workspace/phase198-artifact')
-audit = json.loads((root / 'final-audit.json').read_text())
-assert audit['status'] == 'a52-catalog-init-trace-audited'
-assert audit['phase'] == 198
-assert audit['flashable_candidate'] is True
-assert audit['phase194_mdss_core_gdsc_fix_preserved'] is True
-assert audit['phase196_kms_trace_preserved'] is True
-assert audit['phase197_triple_rs_preserved'] is True
+p = Path('workspace/phase198-artifact/final-audit.json')
+a = json.loads(p.read_text())
+assert a['status'] == 'a52-catalog-init-trace-audited'
+assert a['phase'] == 198
+assert a['flashable_candidate'] is True
+assert a['phase194_mdss_core_gdsc_fix_preserved'] is True
+assert a['phase196_kms_trace_preserved'] is True
+assert a['phase197_triple_rs_preserved'] is True
 PY
 
-# Recreate the exact Phase 198 source state from the pinned GKI commit.
 test -d "$ROOT/.git"
 test "$(git -C "$ROOT" rev-parse HEAD)" = "$GKI_COMMON_SHA"
 git -C "$ROOT" reset --hard "$GKI_COMMON_SHA"
 git -C "$ROOT" clean -fd
-git -C "$ROOT" apply --check "$PHASE198/stage/phase198-catalog-init-trace.patch"
-git -C "$ROOT" apply "$PHASE198/stage/phase198-catalog-init-trace.patch"
+
+BASE_PATCH="$SOURCE/stage/heap19-display-bindcore-source.patch"
+git -C "$ROOT" apply --check "$BASE_PATCH"
+git -C "$ROOT" apply "$BASE_PATCH"
+
+P177="$PWD/workspace/phase177.patch"
+P177_TMP="$PWD/workspace/phase177-payload"
+rm -rf "$P177_TMP"; mkdir -p "$P177_TMP"
+for item in \
+  '00.txt 2e2e8773465271521302902aeedd3c0779c3eba750e191881eb0649654402a39' \
+  '01.txt 2cc8aa74d1080a38f3deabaa790ba6cec24accfe542d9747c3f4c6eda00699ba' \
+  '02.txt 640c2ce3842ecb8120e14494bb23b5d2e4a1c68700c2a67bab2ba55a04e36731' \
+  '03.txt 3799c05943d31375851b3e0680f61fcde892d96272edad98454b641589fd69e0' \
+  '04.txt 9e18d44f8df3abe72ac2c67a42919f8acbf90590acdb424ba609d0086c7cfc47' \
+  '05.txt 9f0a5026d1a78d096b73ff97f3c785a9fd807999a36decb7a89e7fa851477945' \
+  '06.txt b62056e0d393a7969bfac6c60295eb3fb6e78228f6955196e9326cdb90ea1f82' \
+  '07.txt da48f50560314b78ef184d7910d5b5a8026164cae8227997a3795e457c16180a'; do
+  set -- $item
+  tr -d '\r\n' < "scripts/177_patch_payload_chunks/$1" > "$P177_TMP/$1"
+  printf '%s  %s\n' "$2" "$P177_TMP/$1" | sha256sum -c -
+done
+cat "$P177_TMP"/*.txt | base64 --decode | gzip -dc > "$P177"
+printf '%s  %s\n' 9412b28da19c71e7bc97e767e83ce717e146313d32321c7429e6d4050a4f0d00 "$P177" | sha256sum -c -
+git -C "$ROOT" apply --check "$P177"
+git -C "$ROOT" apply "$P177"
+
+P179="$PWD/workspace/phase179.patch"
+tr -d '\r\n' < scripts/179_payloads/patch.gz.b64 | base64 --decode | gzip -dc > "$P179"
+printf '%s  %s\n' 81bc17510b643274dba9652baa5edf52e9c2127af02a77eb1597637be0c3c59f "$P179" | sha256sum -c -
+git -C "$ROOT" apply --check "$P179"
+git -C "$ROOT" apply "$P179"
+
+S="$PHASE198/stage"
+python3 "$S/180_apply.py" --root "$ROOT" --audit-source "$S/180_a52_display_bind_audit.c"
+for phase in 181 182 183 185; do python3 "$S/${phase}_apply.py" --root "$ROOT"; done
+python3 "$S/186_apply.py" --root "$ROOT" --touchgrass "$TOUCHGRASS"
+for phase in 187 188 189 190 191 192 193 194 195 196; do
+  python3 "$S/${phase}_apply.py" --root "$ROOT"
+done
+python3 "$S/197_apply_triple_rs.py" --self-test
+python3 "$S/197_apply_triple_rs.py" --root "$ROOT"
+python3 "$S/198_apply_catalog_trace.py" --self-test
+python3 "$S/198_apply_catalog_trace.py" --root "$ROOT"
 git -C "$ROOT" diff --check
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+stage = Path('workspace/phase198-artifact/stage')
+pairs = {
+ 'drivers/a52_secure/a52_ack_secure_flight_recorder.c': 'recorder-after-phase197.c',
+ 'fs/pstore/ram.c': 'ram-after-phase197.c',
+ 'init/main.c': 'main-after-phase197.c',
+ 'drivers/a52_display/msm/msm_drv.c': 'msm-drv-after-phase195.c',
+ 'drivers/a52_display/msm/sde/sde_kms.c': 'sde-kms-after-phase196.c',
+ 'drivers/a52_display/msm/sde/sde_hw_catalog.c': 'sde-hw-catalog-after-phase198.c',
+ 'drivers/a52_display/msm/dsi/dsi_ctrl.c': 'dsi-ctrl-after-phase182.c',
+ 'drivers/a52_display/msm/dsi/dsi_display.c': 'dsi-display-after-phase191.c',
+ 'drivers/a52_display/msm/sde_rsc.c': 'sde-rsc-after-phase192.c',
+ 'drivers/a52_secure/a52_display_bind_audit.c': 'display-bind-audit-after-phase187.c',
+ 'drivers/regulator/qpnp-amoled-regulator.c': 'qpnp-amoled-regulator-after-phase186.c',
+ 'drivers/regulator/a52-legacy-gdsc-regulator.c': 'a52-legacy-gdsc-after-phase194.c',
+ 'drivers/base/core.c': 'core-after-phase193.c',
+ 'drivers/base/dd.c': 'dd-after-phase193.c',
+ 'drivers/pinctrl/qcom/pinctrl-lagoon.c': 'pinctrl-lagoon-after-phase190.c',
+}
+for source, reference in pairs.items():
+    if (root/source).read_bytes() != (stage/reference).read_bytes():
+        raise SystemExit(f'Phase 198 reconstruction mismatch: {source}')
+print(f'Phase 198 exact-source comparisons: {len(pairs)} PASS')
+PY
 
 cp "$PHASE198/config/final.config" "$BUILD/.config"
 cp "$BUILD/.config" "$OUT/config/before-phase199.config"
-cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
-  "$OUT/stage/recorder-before-phase199.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" "$OUT/stage/recorder-before-phase199.c"
 sha256sum \
-  "$ROOT/fs/pstore/ram.c" \
-  "$ROOT/init/main.c" \
+  "$ROOT/fs/pstore/ram.c" "$ROOT/init/main.c" \
   "$ROOT/drivers/a52_display/msm/msm_drv.c" \
   "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
   "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
   "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
   > "$OUT/stage/phase198-invariants-before-phase199.sha256"
 
-python3 scripts/199_apply_recorder_crc32c.py --self-test | \
-  tee "$OUT/logs/phase199-patcher-self-test.log"
-python3 scripts/199_apply_recorder_crc32c.py --root "$ROOT" | \
-  tee "$OUT/logs/phase199-apply.log"
-
-cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
-  "$OUT/stage/recorder-after-phase199.c"
+python3 scripts/199_apply_recorder_crc32c.py --self-test | tee "$OUT/logs/phase199-patcher-self-test.log"
+python3 scripts/199_apply_recorder_crc32c.py --root "$ROOT" | tee "$OUT/logs/phase199-apply.log"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" "$OUT/stage/recorder-after-phase199.c"
 cp scripts/199_apply_recorder_crc32c.py "$OUT/stage/"
 cp "$PHASE198/tools/decode-a52-r179-rs-recorder.py" "$OUT/tools/"
-cp tools/decode-a52-r199-crc32c-base.py "$OUT/tools/"
-cp tools/decode-a52-r199-crc32c-triple.py "$OUT/tools/"
-
+cp tools/decode-a52-r199-crc32c-base.py tools/decode-a52-r199-crc32c-triple.py "$OUT/tools/"
 git -C "$ROOT" diff --check
 sha256sum -c "$OUT/stage/phase198-invariants-before-phase199.sha256"
 
 python3 - <<'PY'
 from pathlib import Path
-root = Path('gki/common')
-rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
-ram = (root / 'fs/pstore/ram.c').read_text()
-main = (root / 'init/main.c').read_text()
-msm = (root / 'drivers/a52_display/msm/msm_drv.c').read_text()
-kms = (root / 'drivers/a52_display/msm/sde/sde_kms.c').read_text()
-cat = (root / 'drivers/a52_display/msm/sde/sde_hw_catalog.c').read_text()
-
-for marker in (
-    'A52 GKI 5.10 display takeover recorder, phase 199',
-    '#define A52_R179_CAPACITY 896U',
-    '#define A52_R179_MESSAGE_LEN 90U',
-    '#define A52_R179_COMMIT 0x5a52c199U',
-    '#define A52_R179_VERSION 2U',
-    '#define A52_R179_PREFIX "R99"',
-    '__le32 crc32c;',
-    'a52_r199_crc32c',
-    '0x82f63b78U',
-    'memcpy(data->magic, "A52R0199"',
-    'offsetof(struct a52_r179_data, crc32c)',
-    '!strncmp(message, "DRMPOST ", 8)',
-    '!strncmp(message, "KMSPOST ", 8)',
-    '!strncmp(message, "KMSBLK ", 7)',
-    '!strncmp(message, "CAT ", 4)',
-    '!strncmp(message, "A52GDSC ", 8)',
-    'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c',
-    'phase199 triple-copy RS+CRC32C recorder enabled',
-):
-    assert marker in rec, marker
+root=Path('gki/common')
+rec=(root/'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+ram=(root/'fs/pstore/ram.c').read_text(); main=(root/'init/main.c').read_text()
+msm=(root/'drivers/a52_display/msm/msm_drv.c').read_text()
+kms=(root/'drivers/a52_display/msm/sde/sde_kms.c').read_text()
+cat=(root/'drivers/a52_display/msm/sde/sde_hw_catalog.c').read_text()
+required=(
+ 'A52 GKI 5.10 display takeover recorder, phase 199', '#define A52_R179_CAPACITY 896U',
+ '#define A52_R179_MESSAGE_LEN 90U', '#define A52_R179_COMMIT 0x5a52c199U',
+ '#define A52_R179_VERSION 2U', '#define A52_R179_PREFIX "R99"', '__le32 crc32c;',
+ 'a52_r199_crc32c', '0x82f63b78U', 'memcpy(data->magic, "A52R0199"',
+ 'offsetof(struct a52_r179_data, crc32c)', '!strncmp(message, "DRMPOST ", 8)',
+ '!strncmp(message, "KMSPOST ", 8)', '!strncmp(message, "KMSBLK ", 7)',
+ '!strncmp(message, "CAT ", 4)', '!strncmp(message, "A52GDSC ", 8)',
+ 'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c',
+ 'phase199 triple-copy RS+CRC32C recorder enabled')
+for m in required: assert m in rec, m
 assert 'copies=3 crc=0' not in rec
-assert '#define A52_R179_BANK_RECORD BIT(2)' in rec
-assert 'A52_R179_BANK_ALL' in rec
+assert '#define A52_R179_BANK_RECORD BIT(2)' in rec and 'A52_R179_BANK_ALL' in rec
 assert '#define A52_DIAG_RECORD_PHYS 0xB1B00000ULL' in ram
 assert main.count('A52USR2 BOOT_EARLY stage=mm_init') == 3
-for marker in (
-    'DRMPOST thread-create enter',
-    'DRMPOST vblank enter crtc=%d',
-    'DRMPOST irq-install enter irq=%d',
-    'DRMPOST dev-register enter',
-    'DRMPOST mode-reset enter',
-    'DRMPOST splash-config enter',
-    'DRMPOST postinit enter',
-    'DRMPOST poll-init enter',
-    'DRMPOST init success',
-):
-    assert marker in msm, marker
-for marker in (
-    'KMSBLK catalog enter rev=0x%x',
-    'KMSBLK catalog exit rc=%ld null=%d',
-):
-    assert marker in kms, marker
-for marker in (
-    'CAT enter rev=0x%x np-null=%d',
-    'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u',
-):
-    assert marker in cat, marker
+for m in ('DRMPOST thread-create enter','DRMPOST vblank enter crtc=%d','DRMPOST irq-install enter irq=%d','DRMPOST dev-register enter','DRMPOST mode-reset enter','DRMPOST splash-config enter','DRMPOST postinit enter','DRMPOST poll-init enter','DRMPOST init success'): assert m in msm,m
+for m in ('KMSBLK catalog enter rev=0x%x','KMSBLK catalog exit rc=%ld null=%d'): assert m in kms,m
+for m in ('CAT enter rev=0x%x np-null=%d','CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u'): assert m in cat,m
 PY
 
-git -C "$ROOT" diff --binary --no-ext-diff > \
-  "$OUT/stage/phase199-post-kms-crc32c.patch"
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase199-post-kms-crc32c.patch"
 test -s "$OUT/stage/phase199-post-kms-crc32c.patch"
 
 CLANG="$(readlink -f "$(command -v clang)")"
-export PATH="$(dirname "$CLANG"):$PATH"
-export CROSS_COMPILE=aarch64-linux-gnu-
-export CLANG_TRIPLE=aarch64-linux-gnu-
-make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
-  2>&1 | tee "$OUT/logs/olddefconfig.log"
+export PATH="$(dirname "$CLANG"):$PATH" CROSS_COMPILE=aarch64-linux-gnu- CLANG_TRIPLE=aarch64-linux-gnu-
+make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig 2>&1 | tee "$OUT/logs/olddefconfig.log"
 cp "$BUILD/.config" "$OUT/config/final.config"
 cmp "$OUT/config/before-phase199.config" "$OUT/config/final.config"
-
 set +e
-make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
-  KCFLAGS=-Wno-error=frame-larger-than Image \
-  > "$OUT/logs/phase199-compile.log" 2>&1
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 KCFLAGS=-Wno-error=frame-larger-than Image > "$OUT/logs/phase199-compile.log" 2>&1
 rc=$?
 set -e
 printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
 if [ "$rc" -ne 0 ]; then
-  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
-    "$OUT/logs/phase199-compile.log" | tail -n 300 || true
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' "$OUT/logs/phase199-compile.log" | tail -n 300 || true
   tail -n 500 "$OUT/logs/phase199-compile.log" || true
   exit "$rc"
 fi
-if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
-  "$OUT/logs/phase199-compile.log" > "$OUT/logs/compiler-errors.txt"; then
-  cat "$OUT/logs/compiler-errors.txt"
-  exit 1
-fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' "$OUT/logs/phase199-compile.log" > "$OUT/logs/compiler-errors.txt"; then cat "$OUT/logs/compiler-errors.txt"; exit 1; fi
 
 test -s "$BUILD/arch/arm64/boot/Image"
-grep -Fq 'drivers/a52_secure/a52_ack_secure_flight_recorder.o' \
-  "$OUT/logs/phase199-compile.log"
-for marker in \
-  'A52R0199' \
-  'phase199 triple-copy RS+CRC32C recorder enabled' \
-  'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c' \
-  'DRMPOST thread-create enter' \
-  'DRMPOST vblank enter crtc=%d' \
-  'DRMPOST irq-install enter irq=%d' \
-  'DRMPOST dev-register enter' \
-  'DRMPOST splash-config enter' \
-  'DRMPOST postinit enter' \
-  'DRMPOST poll-init enter' \
-  'KMSBLK catalog enter rev=0x%x' \
-  'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u'; do
-  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
-done
+grep -Fq 'drivers/a52_secure/a52_ack_secure_flight_recorder.o' "$OUT/logs/phase199-compile.log"
+for marker in 'A52R0199' 'phase199 triple-copy RS+CRC32C recorder enabled' 'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c' 'DRMPOST thread-create enter' 'DRMPOST vblank enter crtc=%d' 'DRMPOST irq-install enter irq=%d' 'DRMPOST dev-register enter' 'DRMPOST splash-config enter' 'DRMPOST postinit enter' 'DRMPOST poll-init enter' 'KMSBLK catalog enter rev=0x%x' 'CAT success ctl=%u sspp=%u mixer=%u intf=%u wb=%u'; do grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"; done
 
 cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
-gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
-gzip -t "$OUT/package/Image.gz"
-python3 scripts/38_repack_a52_p1_boot.py \
-  --source "$PHASE198/package/boot.img" \
-  --kernel "$OUT/package/Image.gz" \
-  --output "$OUT/package/boot.img" \
-  --report "$OUT/package/repack-report.json"
-python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test | \
-  tee "$OUT/logs/phase199-base-decoder-self-test.log"
-python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test | \
-  tee "$OUT/logs/phase199-triple-decoder-self-test.log"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"; gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py --source "$PHASE198/package/boot.img" --kernel "$OUT/package/Image.gz" --output "$OUT/package/boot.img" --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test | tee "$OUT/logs/phase199-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test | tee "$OUT/logs/phase199-triple-decoder-self-test.log"
 
 cat > "$OUT/README-FIRST.txt" <<'README'
 A52 GKI 5.10 Phase 199 post-KMS trace with triple-copy RS + CRC32C
 
-FLASH ONLY:
-  package/boot.img -> BOOT partition
+FLASH ONLY: package/boot.img to BOOT.
 
-This candidate preserves the full Phase 198 catalog trace and the Phase 195
-post-KMS checkpoints. The functional display path is unchanged.
+Recorder guarantees:
+- three independent physical RAMOOPS copies
+- 32 Reed-Solomon parity symbols per copy
+- CRC32C over record metadata and message
+- R99 fixed 255-byte transport
+- 896 initial records
+- post-capacity retention for DRMPOST, KMSPOST, KMSBLK, CAT and A52GDSC
 
-Recorder format:
-  - three independent physical RAMOOPS banks at +0x00000, +0x40000, +0x80000
-  - 157 protected data bytes plus 32 Reed-Solomon parity symbols per copy
-  - CRC32C over record metadata and message
-  - fixed 255-byte R99 transport
-  - 896-record initial retention
-  - DRMPOST, KMSPOST, KMSBLK, CAT and A52GDSC remain retained after capacity
-
-The previous Phase 198 capture proved that the hardware catalog and SDE KMS
-hardware initialization complete. This image retains the already-present
-checkpoints for thread creation, vblank setup, IRQ installation, DRM device
-registration, mode reset, continuous splash, debugfs, KMS post-init and polling.
-
-Collect the untouched full 1 MiB RAMOOPS snapshot. The raw collector can remain
-unchanged. Decode on a computer with:
-  python3 tools/decode-a52-r199-crc32c-triple.py RAW_OR_ZIP --output decoded-r199
-
-Every accepted decoded record must pass CRC32C. The decoder also attempts
-same-offset majority and clear-bit OR fusion across the three physical copies.
+The display control flow is unchanged from Phase 198. Collect the untouched full
+1 MiB RAMOOPS image. Decode using tools/decode-a52-r199-crc32c-triple.py.
 
 Compile-audited, not hardware validated.
 README
 
 python3 - <<'PY'
-import hashlib
-import json
+import hashlib,json
 from pathlib import Path
-
-root = Path('artifacts/a52xq-post-kms-crc32c')
-base_root = Path('workspace/phase198-artifact')
-base = json.loads((base_root / 'final-audit.json').read_text())
-repack = json.loads((root / 'package/repack-report.json').read_text())
-image = root / 'compile/Image'
-boot = root / 'package/boot.img'
-rec = (root / 'stage/recorder-after-phase199.c').read_text()
-
-audit = dict(base)
-audit.update({
-    'status': 'a52-post-kms-crc32c-audited',
-    'phase': 199,
-    'base_phase': 198,
-    'base_artifact_sha256': '99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6',
-    'hardware_validated': False,
-    'flashable_candidate': True,
-    'functional_change_from_phase198': 'recorder-integrity-and-retention-only',
-    'display_control_flow_changed': False,
-    'return_codes_changed': False,
-    'catalog_trace_preserved': True,
-    'post_kms_trace_preserved': True,
-    'phase194_mdss_core_gdsc_fix_preserved': True,
-    'recorder_format': 'R99-base64-RS-CRC32C',
-    'recorder_copy_count': 3,
-    'recorder_banks': ['record', 'console', 'ftrace'],
-    'recorder_data_bytes': 157,
-    'recorder_message_bytes': 89,
-    'recorder_parity_symbols_per_copy': 32,
-    'recorder_crc': 'CRC32C',
-    'recorder_crc_polynomial_reflected': '0x82f63b78',
-    'recorder_initial_capacity': 896,
-    'post_capacity_retention': ['BOOT', 'HB', 'REFGEN', 'DISP', 'WDT', 'DRMPOST', 'KMSPOST', 'KMSBLK', 'CAT', 'A52GDSC'],
-    'decoder_cross_copy_fusion': ['bit-majority', 'clear-bit-OR'],
-    'iommu_bypass_added': False,
-    'continuous_splash_forced': False,
-    'gdsc_keep_on_forced': False,
-    'dtb_changed': False,
-    'dtbo_changed': False,
-    'panel_commands_changed': False,
-    'display_timing_changed': False,
-    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
-    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
-    'boot_bytes': boot.stat().st_size,
-    'dtb_preserved': repack['invariants']['dtb_preserved'],
-    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
-    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
-})
-for key in (
-    'catalog_trace_preserved',
-    'post_kms_trace_preserved',
-    'phase194_mdss_core_gdsc_fix_preserved',
-    'dtb_preserved',
-    'ramdisk_preserved',
-    'recovery_dtbo_preserved',
-):
-    assert audit[key] is True, key
-assert audit['recorder_copy_count'] == 3
-assert audit['recorder_parity_symbols_per_copy'] == 32
-assert audit['recorder_crc'] == 'CRC32C'
+root=Path('artifacts/a52xq-post-kms-crc32c'); base=json.loads(Path('workspace/phase198-artifact/final-audit.json').read_text()); repack=json.loads((root/'package/repack-report.json').read_text()); image=root/'compile/Image'; boot=root/'package/boot.img'; rec=(root/'stage/recorder-after-phase199.c').read_text()
+base.update({'status':'a52-post-kms-crc32c-audited','phase':199,'base_phase':198,'base_artifact_sha256':'99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6','hardware_validated':False,'flashable_candidate':True,'functional_change_from_phase198':'recorder-integrity-and-retention-only','display_control_flow_changed':False,'return_codes_changed':False,'catalog_trace_preserved':True,'post_kms_trace_preserved':True,'phase194_mdss_core_gdsc_fix_preserved':True,'recorder_format':'R99-base64-RS-CRC32C','recorder_copy_count':3,'recorder_banks':['record','console','ftrace'],'recorder_data_bytes':157,'recorder_message_bytes':89,'recorder_parity_symbols_per_copy':32,'recorder_crc':'CRC32C','recorder_crc_polynomial_reflected':'0x82f63b78','recorder_initial_capacity':896,'post_capacity_retention':['BOOT','HB','REFGEN','DISP','WDT','DRMPOST','KMSPOST','KMSBLK','CAT','A52GDSC'],'decoder_cross_copy_fusion':['bit-majority','clear-bit-OR'],'iommu_bypass_added':False,'continuous_splash_forced':False,'gdsc_keep_on_forced':False,'dtb_changed':False,'dtbo_changed':False,'panel_commands_changed':False,'display_timing_changed':False,'image_sha256':hashlib.sha256(image.read_bytes()).hexdigest(),'boot_sha256':hashlib.sha256(boot.read_bytes()).hexdigest(),'boot_bytes':boot.stat().st_size,'dtb_preserved':repack['invariants']['dtb_preserved'],'ramdisk_preserved':repack['invariants']['ramdisk_preserved'],'recovery_dtbo_preserved':repack['invariants']['recovery_dtbo_preserved']})
+for k in ('catalog_trace_preserved','post_kms_trace_preserved','phase194_mdss_core_gdsc_fix_preserved','dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'): assert base[k] is True,k
+assert base['recorder_copy_count']==3 and base['recorder_parity_symbols_per_copy']==32 and base['recorder_crc']=='CRC32C'
 assert 'copies=3 crc=0' not in rec
-(root / 'final-audit.json').write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n')
+(root/'final-audit.json').write_text(json.dumps(base,indent=2,sort_keys=True)+'\n')
 PY
 
-(
-  cd "$OUT"
-  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
-    xargs -0 sha256sum > SHA256SUMS
-  sha256sum -c SHA256SUMS
-)
+(cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS && sha256sum -c SHA256SUMS)

--- a/scripts/199_runtime_fix_binary_audit.py
+++ b/scripts/199_runtime_fix_binary_audit.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+PATH = Path("scripts/199_ci.sh")
+
+OLD = "for marker in 'A52R0199' 'phase199 triple-copy RS+CRC32C recorder enabled'"
+NEW = "for marker in 'phase199 triple-copy RS+CRC32C recorder enabled'"
+
+
+def main() -> int:
+    text = PATH.read_text(encoding="utf-8")
+    if NEW in text and OLD not in text:
+        print("phase199 binary audit already ignores optimized record magic")
+        return 0
+    count = text.count(OLD)
+    if count != 1:
+        raise SystemExit(f"expected one binary magic audit anchor, found {count}")
+    text = text.replace(OLD, NEW, 1)
+    PATH.write_text(text, encoding="utf-8")
+    verify = PATH.read_text(encoding="utf-8")
+    if OLD in verify or NEW not in verify:
+        raise SystemExit("binary audit repair verification failed")
+    print("phase199 binary audit repaired: source validates A52R0199, Image validates runtime strings")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/199_runtime_fix_crc_anchor.py
+++ b/scripts/199_runtime_fix_crc_anchor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+PATH = Path("scripts/199_apply_recorder_crc32c.py")
+
+OLD = '''    text = replace_once(
+        text,
+        "extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,\\n"
+        "\\t\\t\\t\\t\\t     unsigned int targets);\\n\\n",
+        "extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,\\n"
+        "\\t\\t\\t\\t\\t     unsigned int targets);\\n\\n"
+        + crc_function,
+        "crc32c function insertion",
+    )
+'''
+
+NEW = '''    text = replace_once(
+        text,
+        "static int a52_r179_base64_encode(",
+        crc_function + "static int a52_r179_base64_encode(",
+        "crc32c function insertion",
+    )
+'''
+
+
+def main() -> int:
+    text = PATH.read_text(encoding="utf-8")
+    if NEW in text:
+        print("phase199 CRC anchor already fixed")
+        return 0
+    count = text.count(OLD)
+    if count != 1:
+        raise SystemExit(f"expected one brittle CRC anchor, found {count}")
+    text = text.replace(OLD, NEW, 1)
+    PATH.write_text(text, encoding="utf-8")
+    verify = PATH.read_text(encoding="utf-8")
+    if NEW not in verify or OLD in verify:
+        raise SystemExit("CRC anchor runtime repair verification failed")
+    print("phase199 CRC anchor repaired to base64 function boundary")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/199_runtime_fix_crc_anchor_v2.py
+++ b/scripts/199_runtime_fix_crc_anchor_v2.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+PATH = Path("scripts/199_apply_recorder_crc32c.py")
+
+BRITTLE = '''    text = replace_once(
+        text,
+        "extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,\\n"
+        "\\t\\t\\t\\t\\t     unsigned int targets);\\n\\n",
+        "extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,\\n"
+        "\\t\\t\\t\\t\\t     unsigned int targets);\\n\\n"
+        + crc_function,
+        "crc32c function insertion",
+    )
+'''
+
+BASE64_BOUNDARY = '''    text = replace_once(
+        text,
+        "static int a52_r179_base64_encode(",
+        crc_function + "static int a52_r179_base64_encode(",
+        "crc32c function insertion",
+    )
+'''
+
+FINAL = '''    text = replace_once(
+        text,
+        "extern unsigned int a52_ackfr_ramoops_write(",
+        crc_function + "extern unsigned int a52_ackfr_ramoops_write(",
+        "crc32c function insertion",
+    )
+'''
+
+
+def main() -> int:
+    text = PATH.read_text(encoding="utf-8")
+    if FINAL in text:
+        print("phase199 CRC anchor v2 already applied")
+        return 0
+
+    matches = text.count(BRITTLE) + text.count(BASE64_BOUNDARY)
+    if matches != 1:
+        raise SystemExit(f"expected one replaceable CRC anchor, found {matches}")
+    if BRITTLE in text:
+        text = text.replace(BRITTLE, FINAL, 1)
+    else:
+        text = text.replace(BASE64_BOUNDARY, FINAL, 1)
+    PATH.write_text(text, encoding="utf-8")
+
+    verify = PATH.read_text(encoding="utf-8")
+    if FINAL not in verify or BRITTLE in verify or BASE64_BOUNDARY in verify:
+        raise SystemExit("CRC anchor v2 verification failed")
+    print("phase199 CRC anchor repaired to writer declaration prefix")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stage/recorder-after-phase197.c
+++ b/stage/recorder-after-phase197.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * A52 GKI 5.10 display takeover recorder, phase 179.
+ *
+ * Records are fixed-size, Reed-Solomon protected, and written independently
+ * to the record, console and ftrace RAMOOPS banks. CRC is intentionally not used in
+ * this phase. Payloads remain metadata-only.
+ */
+#undef pr_fmt
+#define pr_fmt(fmt) "A52R179: " fmt
+
+#define A52_R179_CAPACITY 768U
+#define A52_R179_MESSAGE_LEN 94U
+#define A52_R179_COMMIT 0x5a52c179U
+#define A52_R179_VERSION 1U
+#define A52_R179_PREFIX "R79"
+
+struct a52_r179_data {
+	u8 magic[8];
+	__le16 version;
+	__le16 header_len;
+	__le64 seq;
+	__le64 monotonic_ns;
+	__le32 pid;
+	__le32 tgid;
+	__le32 cpu;
+	__le16 kind;
+	__le16 message_len;
+	char comm[TASK_COMM_LEN];
+	char message[A52_R179_MESSAGE_LEN - 1];
+	__le32 commit;
+} __packed;
+
+extern unsigned int a52_ackfr_ramoops_write(const char *buf, size_t len,
+					     unsigned int targets);
+
+static void a52_r179_pack(const struct a52_r179_event *event,
+			  struct a52_r179_data *data)
+{
+	size_t message_len;
+
+	memset(data, 0, sizeof(*data));
+	memcpy(data->magic, "A52R0179", sizeof(data->magic));
+	data->version = cpu_to_le16(A52_R179_VERSION);
+	data->header_len = cpu_to_le16(60U);
+	message_len = strnlen(event->message, sizeof(data->message));
+	data->message_len = cpu_to_le16((u16)message_len);
+	memcpy(data->comm, event->comm, sizeof(data->comm));
+	memcpy(data->message, event->message, message_len);
+	data->commit = cpu_to_le32(A52_R179_COMMIT);
+}
+
+static bool a52_r179_is_critical_message(const char *message)
+{
+	return !strncmp(message, "BOOT ", 5) ||
+	       !strncmp(message, "HB ", 3) ||
+	       !strncmp(message, "REFGEN ", 7) ||
+	       !strncmp(message, "DISP ", 5) ||
+	       !strncmp(message, "WDT ", 4);
+}
+
+static void a52_r179_write_control(const char *kind)
+{
+	a52_ackfr_record("BOOT ctl=%s rel=%s cap=%u rs=%u copies=3 crc=0",
+			  kind, init_utsname()->release, A52_R179_CAPACITY,
+			  A52_R179_RS_ROOTS);
+}
+
+static int __init a52_r179_rs_init(void)
+{
+	a52_ackfr_record("BOOT rs=ready phase=197 roots=%u copies=3 crc=0",
+			  A52_R179_RS_ROOTS);
+	return 0;
+}
+
+static int __init a52_r179_late(void)
+{
+	pr_info("phase197 triple-copy recorder enabled stored=%llu dropped=%llu\n",
+		(unsigned long long)0, (unsigned long long)0);
+	return 0;
+}

--- a/tools/decode-a52-r199-crc32c-base.py
+++ b/tools/decode-a52-r199-crc32c-base.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Phase 199 CRC32C format adapter for the Phase 179 RS decoder core."""
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib.util
+import json
+import random
+import struct
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+def load_legacy():
+    path = Path(__file__).with_name("decode-a52-r179-rs-recorder.py")
+    if not path.is_file():
+        raise RuntimeError(f"missing RS decoder core beside this file: {path}")
+    spec = importlib.util.spec_from_file_location("a52_r179_core_for_r199", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load RS decoder core: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CORE = load_legacy()
+
+PHASE = 199
+PREFIX = b"R99"
+TEXT_BYTES = CORE.TEXT_BYTES
+BASE64_BYTES = CORE.BASE64_BYTES
+DATA_BYTES = CORE.DATA_BYTES
+PARITY_BYTES = CORE.PARITY_BYTES
+CODE_BYTES = CORE.CODE_BYTES
+MAGIC = b"A52R0199"
+VERSION = 2
+HEADER_LEN = 60
+COMMIT = 0x5A52C199
+RECORD_STRUCT = struct.Struct("<8sHHQQIIIHH16s89sII")
+CRC_OFFSET = DATA_BYTES - 8
+assert RECORD_STRUCT.size == DATA_BYTES
+
+DecodeFailure = CORE.DecodeFailure
+DecodedRecord = CORE.DecodedRecord
+RS = CORE.RS
+PERSISTENT_RAM_SIG = CORE.PERSISTENT_RAM_SIG
+BANK_BYTES = CORE.BANK_BYTES
+BANK_HEADER_BYTES = CORE.BANK_HEADER_BYTES
+RAMOOPS_TOTAL_BYTES = CORE.RAMOOPS_TOTAL_BYTES
+
+
+def crc32c(data: bytes) -> int:
+    crc = 0xFFFFFFFF
+    for value in data:
+        crc ^= value
+        for _ in range(8):
+            crc = (crc >> 1) ^ (0x82F63B78 if crc & 1 else 0)
+    return crc ^ 0xFFFFFFFF
+
+
+def encode_record_for_test(
+    seq: int, message: str, *, monotonic_ns: int = 123456789, bank: str = "test"
+) -> bytes:
+    message_bytes = message.encode("utf-8")[:89]
+    message_padded = message_bytes.ljust(89, b"\0")
+    comm = b"self-test".ljust(16, b"\0")
+    data = bytearray(
+        RECORD_STRUCT.pack(
+            MAGIC,
+            VERSION,
+            HEADER_LEN,
+            seq,
+            monotonic_ns,
+            10,
+            10,
+            2,
+            0,
+            len(message_bytes),
+            comm,
+            message_padded,
+            0,
+            COMMIT,
+        )
+    )
+    struct.pack_into("<I", data, CRC_OFFSET, crc32c(bytes(data[:CRC_OFFSET])))
+    codeword = RS.encode(bytes(data))
+    transport = PREFIX + base64.b64encode(codeword)
+    assert len(transport) == TEXT_BYTES
+    return transport
+
+
+def parse_record_data(
+    data: bytes,
+    *,
+    bank: str,
+    offset: int,
+    prefix_distance: int,
+    erasures: int,
+    corrected_symbols: int,
+) -> DecodedRecord:
+    if len(data) != DATA_BYTES:
+        raise DecodeFailure("incorrect data length")
+    (
+        magic,
+        version,
+        header_len,
+        seq,
+        monotonic_ns,
+        pid,
+        tgid,
+        cpu,
+        kind,
+        message_len,
+        comm_raw,
+        message_raw,
+        stored_crc32c,
+        commit,
+    ) = RECORD_STRUCT.unpack(data)
+    if magic != MAGIC:
+        raise DecodeFailure("record magic mismatch")
+    if version != VERSION:
+        raise DecodeFailure("record version mismatch")
+    if header_len != HEADER_LEN:
+        raise DecodeFailure("record header length mismatch")
+    if commit != COMMIT:
+        raise DecodeFailure("record commit mismatch")
+    if stored_crc32c != crc32c(data[:CRC_OFFSET]):
+        raise DecodeFailure("record CRC32C mismatch")
+    if not (1 <= seq <= 10_000_000_000):
+        raise DecodeFailure("implausible sequence number")
+    if message_len > len(message_raw):
+        raise DecodeFailure("invalid message length")
+    comm = comm_raw.split(b"\0", 1)[0].decode("utf-8", errors="replace")
+    message = message_raw[:message_len].decode("utf-8", errors="replace")
+    return DecodedRecord(
+        bank=bank,
+        offset=offset,
+        prefix_distance=prefix_distance,
+        erasures=erasures,
+        corrected_symbols=corrected_symbols,
+        seq=seq,
+        monotonic_ns=monotonic_ns,
+        pid=pid,
+        tgid=tgid,
+        cpu=cpu,
+        kind=kind,
+        comm=comm,
+        message=message,
+        raw_data_hex=data.hex(),
+    )
+
+
+CORE.PHASE = PHASE
+CORE.PREFIX = PREFIX
+CORE.MAGIC = MAGIC
+CORE.VERSION = VERSION
+CORE.HEADER_LEN = HEADER_LEN
+CORE.COMMIT = COMMIT
+CORE.RECORD_STRUCT = RECORD_STRUCT
+CORE.parse_record_data = parse_record_data
+CORE.encode_record_for_test = encode_record_for_test
+
+decode_base64_with_erasures = CORE.decode_base64_with_erasures
+hamming_prefix = CORE.hamming_prefix
+try_decode_transport = CORE.try_decode_transport
+chronological_ring = CORE.chronological_ring
+candidate_offsets = CORE.candidate_offsets
+decode_bank = CORE.decode_bank
+select_best = CORE.select_best
+find_snapshots = CORE.find_snapshots
+
+
+def self_test() -> None:
+    rng = random.Random(0xA52199)
+    for errors in (0, 1, 5, 16):
+        for iteration in range(20):
+            transport = encode_record_for_test(
+                iteration + 1, f"DRMPOST self errors={errors} iter={iteration}"
+            )
+            codeword = bytearray(base64.b64decode(transport[3:]))
+            for position in rng.sample(range(CODE_BYTES), errors):
+                codeword[position] ^= rng.randrange(1, 256)
+            damaged = PREFIX + base64.b64encode(codeword)
+            record = try_decode_transport(damaged, bank="test", offset=0)
+            if record.seq != iteration + 1:
+                raise AssertionError("RS recovery returned the wrong sequence")
+
+    transport = encode_record_for_test(100, "DRMPOST CRC rejection")
+    codeword = bytearray(base64.b64decode(transport[3:]))
+    codeword[CRC_OFFSET - 1] ^= 0x01
+    reencoded = RS.encode(bytes(codeword[:DATA_BYTES]))
+    try:
+        try_decode_transport(PREFIX + base64.b64encode(reencoded), bank="crc", offset=0)
+    except DecodeFailure as exc:
+        if "CRC32C" not in str(exc):
+            raise
+    else:
+        raise AssertionError("CRC32C mismatch was accepted")
+    print("phase199 CRC32C decoder self-test: PASS")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Test the Phase 199 CRC32C RS decoder core")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.self_test:
+        parser.error("use the triple decoder for captures, or pass --self-test")
+    self_test()
+    print(json.dumps({"status": "ok", "phase": PHASE, "crc": "CRC32C"}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/decode-a52-r199-crc32c-triple.py
+++ b/tools/decode-a52-r199-crc32c-triple.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Decode the A52 Phase 199 triple-copy RS + CRC32C recorder.
+
+Each record is written independently to the record, console, and ftrace banks.
+The decoder first performs ordinary per-copy Reed-Solomon correction, then tries
+same-offset bit-majority and clear-bit OR fusion across copies. Every accepted
+record must pass CRC32C after correction or fusion.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import importlib.util
+import itertools
+import json
+import random
+import struct
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+PHASE = 199
+BANK_BYTES = 0x40000
+BANK_HEADER_BYTES = 12
+RAMOOPS_TOTAL_BYTES = 0x100000
+BANK_OFFSETS = {
+    "record": 0x00000,
+    "console": 0x40000,
+    "ftrace": 0x80000,
+}
+BANK_ORDER = ("record", "console", "ftrace")
+
+
+def load_base():
+    path = Path(__file__).with_name("decode-a52-r199-crc32c-base.py")
+    if not path.is_file():
+        raise RuntimeError(f"missing Phase 199 base decoder beside this file: {path}")
+    spec = importlib.util.spec_from_file_location("a52_r199_crc32c_base", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load Phase 199 base decoder: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = load_base()
+DecodeFailure = BASE.DecodeFailure
+
+
+def bank_name_for_file(path: Path) -> str:
+    lower = path.name.lower()
+    if "ftrace" in lower:
+        return "ftrace"
+    if "record" in lower or "dmesg" in lower:
+        return "record"
+    return "console"
+
+
+def extract_banks(snapshot: Path) -> dict[str, bytes]:
+    raw = snapshot.read_bytes()
+    if len(raw) == RAMOOPS_TOTAL_BYTES:
+        return {
+            name: raw[offset : offset + BANK_BYTES]
+            for name, offset in BANK_OFFSETS.items()
+        }
+    if len(raw) == BANK_BYTES:
+        return {bank_name_for_file(snapshot): raw}
+    raise DecodeFailure("unsupported snapshot size")
+
+
+def merge_records(
+    records_by_source: dict[str, Sequence[object]],
+) -> tuple[list[object], dict[str, object]]:
+    by_seq: dict[int, list[object]] = defaultdict(list)
+    for records in records_by_source.values():
+        for record in records:
+            by_seq[record.seq].append(record)
+
+    merged: list[object] = []
+    only_by_source = Counter()
+    copy_count_histogram = Counter()
+    disagreements = 0
+    duplicates = 0
+    for seq in sorted(by_seq):
+        candidates = by_seq[seq]
+        sources = {item.bank for item in candidates}
+        physical_banks = {source for source in sources if source in BANK_ORDER}
+        copy_count_histogram[len(physical_banks)] += 1
+        if len(sources) == 1:
+            only_by_source[next(iter(sources))] += 1
+        payloads = {item.raw_data_hex for item in candidates}
+        if len(payloads) > 1:
+            disagreements += 1
+        if len(candidates) > len(sources):
+            duplicates += len(candidates) - len(sources)
+        merged.append(BASE.select_best(candidates))
+
+    stats: dict[str, object] = {
+        "merged_sequences": len(merged),
+        "recovered_only_from_record": only_by_source["record"],
+        "recovered_only_from_console": only_by_source["console"],
+        "recovered_only_from_ftrace": only_by_source["ftrace"],
+        "recovered_only_from_fusion_or": only_by_source["fusion-or"],
+        "recovered_only_from_fusion_majority": only_by_source["fusion-majority"],
+        "recovered_from_one_physical_bank": copy_count_histogram[1],
+        "recovered_from_two_physical_banks": copy_count_histogram[2],
+        "recovered_from_all_three_physical_banks": copy_count_histogram[3],
+        "sequence_disagreements": disagreements,
+        "duplicate_records_within_sources": duplicates,
+        "first_sequence": merged[0].seq if merged else None,
+        "last_sequence": merged[-1].seq if merged else None,
+        "missing_sequences_between_first_and_last": (
+            merged[-1].seq - merged[0].seq + 1 - len(merged) if merged else 0
+        ),
+    }
+    return merged, stats
+
+
+def bit_majority(blocks: Sequence[bytes]) -> bytes:
+    if len(blocks) != 3:
+        raise ValueError("bit majority requires exactly three blocks")
+    left, middle, right = blocks
+    return bytes((a & b) | (a & c) | (b & c) for a, b, c in zip(left, middle, right))
+
+
+def bit_or(blocks: Sequence[bytes]) -> bytes:
+    if not blocks:
+        raise ValueError("bit OR requires at least one block")
+    output = bytearray(blocks[0])
+    for block in blocks[1:]:
+        for index, value in enumerate(block):
+            output[index] |= value
+    return bytes(output)
+
+
+def decoded_codeword(block: bytes) -> bytes:
+    if len(block) != BASE.TEXT_BYTES:
+        raise DecodeFailure("short fusion transport")
+    codeword, _erasures = BASE.decode_base64_with_erasures(block[3:])
+    return codeword
+
+
+def fusion_candidate_offsets(banks: dict[str, bytes]) -> list[int]:
+    offsets: set[int] = set()
+    for bank in banks.values():
+        data = bank[BANK_HEADER_BYTES:]
+        offsets.update(BASE.candidate_offsets(data))
+    return sorted(offsets)
+
+
+def decode_fused_records(
+    banks: dict[str, bytes],
+) -> tuple[list[object], dict[str, object]]:
+    if len(banks) < 2:
+        return [], {"candidate_offsets": 0, "valid_records": 0, "variants": {}}
+
+    data_by_bank = {
+        name: raw[BANK_HEADER_BYTES:]
+        for name, raw in banks.items()
+    }
+    offsets = fusion_candidate_offsets(banks)
+    records: list[object] = []
+    seen: set[tuple[int, str]] = set()
+    variant_success = Counter()
+    failures = Counter()
+
+    for offset in offsets:
+        codewords: list[bytes] = []
+        for name in BANK_ORDER:
+            data = data_by_bank.get(name)
+            if data is None or offset + BASE.TEXT_BYTES > len(data):
+                continue
+            try:
+                codewords.append(decoded_codeword(data[offset : offset + BASE.TEXT_BYTES]))
+            except DecodeFailure as exc:
+                failures[str(exc)] += 1
+        if len(codewords) < 2:
+            continue
+
+        variants: list[tuple[str, bytes]] = []
+        if len(codewords) == 3:
+            variants.append(("fusion-majority", bit_majority(codewords)))
+            variants.append(("fusion-or", bit_or(codewords)))
+        for pair in itertools.combinations(range(len(codewords)), 2):
+            variants.append(("fusion-or", bit_or([codewords[pair[0]], codewords[pair[1]]])))
+
+        unique_variants: set[bytes] = set()
+        for source, codeword in variants:
+            if codeword in unique_variants:
+                continue
+            unique_variants.add(codeword)
+            transport = BASE.PREFIX + base64.b64encode(codeword)
+            try:
+                record = BASE.try_decode_transport(transport, bank=source, offset=offset)
+            except DecodeFailure as exc:
+                failures[str(exc)] += 1
+                continue
+            key = (record.seq, record.raw_data_hex)
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append(record)
+            variant_success[source] += 1
+
+    records.sort(key=lambda item: (item.seq, item.quality, item.offset))
+    return records, {
+        "candidate_offsets": len(offsets),
+        "valid_records": len(records),
+        "variants": dict(variant_success),
+        "failure_reasons": dict(failures.most_common()),
+        "crc_required": True,
+    }
+
+
+def write_outputs(
+    output_dir: Path,
+    source: Path,
+    records_by_source: dict[str, Sequence[object]],
+    merged: Sequence[object],
+    summary: dict[str, object],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    fieldnames = [
+        "seq", "monotonic_ns", "monotonic_ms", "pid", "tgid", "cpu", "kind",
+        "comm", "message", "selected_source", "corrected_symbols", "erasures",
+        "prefix_distance", "bank_offset",
+    ]
+    with (output_dir / "events.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for item in merged:
+            writer.writerow({
+                "seq": item.seq,
+                "monotonic_ns": item.monotonic_ns,
+                "monotonic_ms": f"{item.monotonic_ns / 1_000_000:.3f}",
+                "pid": item.pid,
+                "tgid": item.tgid,
+                "cpu": item.cpu,
+                "kind": item.kind,
+                "comm": item.comm,
+                "message": item.message,
+                "selected_source": item.bank,
+                "corrected_symbols": item.corrected_symbols,
+                "erasures": item.erasures,
+                "prefix_distance": item.prefix_distance,
+                "bank_offset": item.offset,
+            })
+
+    with (output_dir / "timeline.txt").open("w", encoding="utf-8") as handle:
+        handle.write(f"source={source}\n")
+        handle.write(f"records={len(merged)}\n\n")
+        for item in merged:
+            handle.write(
+                f"{item.seq:08d} {item.monotonic_ns / 1_000_000:12.3f}ms "
+                f"cpu={item.cpu:02d} pid={item.pid:<6d} {item.comm:<16.16s} "
+                f"src={item.bank:<15s} rs={item.corrected_symbols:<2d} "
+                f"eras={item.erasures:<2d} {item.message}\n"
+            )
+
+    for name, records in records_by_source.items():
+        safe_name = name.replace("/", "-")
+        with (output_dir / f"{safe_name}-records.jsonl").open("w", encoding="utf-8") as handle:
+            for item in records:
+                handle.write(json.dumps(asdict(item), sort_keys=True) + "\n")
+
+
+def decode_snapshot(snapshot: Path, output_dir: Path) -> dict[str, object]:
+    banks = extract_banks(snapshot)
+    records_by_source: dict[str, list[object]] = {}
+    bank_stats: dict[str, object] = {}
+    for bank_name, bank_data in banks.items():
+        records, stats = BASE.decode_bank(bank_data, bank_name)
+        records_by_source[bank_name] = records
+        bank_stats[bank_name] = stats
+
+    fused, fusion_stats = decode_fused_records(banks)
+    by_fusion_source: dict[str, list[object]] = defaultdict(list)
+    for record in fused:
+        by_fusion_source[record.bank].append(record)
+    records_by_source.update(by_fusion_source)
+
+    merged, merge_stats = merge_records(records_by_source)
+    summary: dict[str, object] = {
+        "status": "a52-r199-crc32c-rs-triple-decoded",
+        "phase": PHASE,
+        "source": str(snapshot),
+        "record_format": {
+            "transport_bytes": BASE.TEXT_BYTES,
+            "prefix": BASE.PREFIX.decode("ascii"),
+            "data_bytes": BASE.DATA_BYTES,
+            "parity_symbols": BASE.PARITY_BYTES,
+            "maximum_correctable_unknown_symbols_per_copy": BASE.PARITY_BYTES // 2,
+            "copies": list(BANK_ORDER),
+            "crc": "CRC32C",
+            "crc_scope": "record metadata and message before the CRC field",
+        },
+        "banks": bank_stats,
+        "fusion": fusion_stats,
+        "merge": merge_stats,
+    }
+    write_outputs(output_dir, snapshot, records_by_source, merged, summary)
+    return summary
+
+
+def self_test() -> None:
+    BASE.self_test()
+    transport = BASE.encode_record_for_test(199, "DRMPOST triple-copy CRC self-test")
+    copies: dict[str, object] = {}
+    corruption = {"record": 7, "console": 3, "ftrace": 1}
+    rng = random.Random(0xA52199)
+    for bank, errors in corruption.items():
+        codeword = bytearray(base64.b64decode(transport[3:]))
+        for position in rng.sample(range(BASE.CODE_BYTES), errors):
+            codeword[position] ^= rng.randrange(1, 256)
+        damaged = transport[:3] + base64.b64encode(codeword)
+        copies[bank] = BASE.try_decode_transport(damaged, bank=bank, offset=0)
+
+    merged, stats = merge_records({name: [record] for name, record in copies.items()})
+    if len(merged) != 1 or merged[0].bank != "ftrace":
+        raise AssertionError("triple-copy quality selection failed")
+    if stats["recovered_from_all_three_physical_banks"] != 1:
+        raise AssertionError("triple-copy merge accounting failed")
+
+    original_codeword = base64.b64decode(transport[3:])
+    nonzero_positions = [i for i, value in enumerate(original_codeword) if value]
+    selected = nonzero_positions[:60]
+    synthetic_banks: dict[str, bytes] = {}
+    offset = 510
+    for bank_index, bank in enumerate(BANK_ORDER):
+        damaged = bytearray(original_codeword)
+        for position in selected[bank_index * 20 : (bank_index + 1) * 20]:
+            damaged[position] = 0
+        damaged_transport = BASE.PREFIX + base64.b64encode(damaged)
+        try:
+            BASE.try_decode_transport(damaged_transport, bank=bank, offset=offset)
+        except DecodeFailure:
+            pass
+        else:
+            raise AssertionError("individually uncorrectable fusion fixture decoded")
+        raw = bytearray(BANK_BYTES)
+        struct.pack_into("<III", raw, 0, BASE.PERSISTENT_RAM_SIG, offset + BASE.TEXT_BYTES, offset + BASE.TEXT_BYTES)
+        raw[BANK_HEADER_BYTES + offset : BANK_HEADER_BYTES + offset + BASE.TEXT_BYTES] = damaged_transport
+        synthetic_banks[bank] = bytes(raw)
+
+    fused, fusion_stats = decode_fused_records(synthetic_banks)
+    if not any(record.seq == 199 and record.bank.startswith("fusion-") for record in fused):
+        raise AssertionError("cross-copy fusion failed")
+    if fusion_stats["valid_records"] < 1:
+        raise AssertionError("fusion accounting failed")
+    print("phase199 triple-copy RS + CRC32C decoder self-test: PASS")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Decode A52 Phase 199 triple-copy Reed-Solomon and CRC32C records"
+    )
+    parser.add_argument("input", type=Path, nargs="?")
+    parser.add_argument("--output", type=Path, default=Path("decoded-a52-r199"))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        self_test()
+        return 0
+    if args.input is None:
+        parser.error("input is required unless --self-test is used")
+
+    snapshots = BASE.find_snapshots(args.input)
+    summaries = []
+    for index, snapshot in enumerate(snapshots):
+        destination = args.output if len(snapshots) == 1 else args.output / f"snapshot-{index:02d}"
+        summaries.append(decode_snapshot(snapshot, destination))
+    print(json.dumps(summaries[0] if len(summaries) == 1 else summaries, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DecodeFailure as exc:
+        print(f"decode error: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## What changed

- Adds CRC32C validation to every protected recorder record.
- Preserves three physical RAMOOPS copies and 32 Reed-Solomon parity symbols per copy.
- Retains DRMPOST, KMSPOST, KMSBLK, CAT, and A52GDSC checkpoints after the initial recorder capacity.
- Raises initial retained capacity from 768 to 896 records.
- Adds a Phase 199 decoder with CRC enforcement, triple-copy selection, bit-majority fusion, and clear-bit OR fusion.

## Why

The Phase 198 hardware capture proved that catalog initialization and SDE KMS hardware initialization complete, but the existing recorder discarded the detailed post-KMS markers after sequence 768. Phase 199 preserves those markers to identify the exact later msm_drm_init stage.

## Safety and validation

- Display control flow and return values are unchanged.
- DTB, DTBO, ramdisk, panel commands, timing, IOMMU policy, splash policy, and GDSC policy remain unchanged.
- Local patcher and decoder self-tests pass.
- The workflow compiles, repacks, audits markers and invariants, and publishes a not-hardware-validated boot image.