### PR TITLE
Build Phase 200 SMMU deferred-probe trace

### DIFF
--- a/.github/workflows/200-a52-smmu-defer-trace.yml
+++ b/.github/workflows/200-a52-smmu-defer-trace.yml
@@ -1,0 +1,121 @@
+name: 200 - A52 SMMU deferred-probe trace
+
+run-name: Build Phase 200 SMMU deferred-probe candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-smmu-client-defer-trace-v1
+    paths:
+      - .github/workflows/200-a52-smmu-defer-trace.yml
+      - scripts/200_apply_smmu_defer_trace.py
+      - scripts/200_ci.sh
+  pull_request:
+    branches:
+      - agent/a52-post-kms-crc32c-rs3-v1
+    paths:
+      - .github/workflows/200-a52-smmu-defer-trace.yml
+      - scripts/200_apply_smmu_defer_trace.py
+      - scripts/200_ci.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-smmu-defer-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 200 SMMU deferred-probe candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out Phase 200 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_runtime_fix_binary_audit.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/200_apply_smmu_defer_trace.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 200
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_runtime_fix_binary_audit.py
+          python3 scripts/200_apply_smmu_defer_trace.py --self-test
+          bash scripts/200_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-smmu-defer-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-smmu-defer-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 200 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-smmu-defer-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-smmu-defer-trace
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/200_apply_smmu_defer_trace.py
+++ b/scripts/200_apply_smmu_defer_trace.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+SMMU = Path('drivers/a52_display/msm/msm_smmu.c')
+KMS = Path('drivers/a52_display/msm/sde/sde_kms.c')
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+
+def rep(text, old, new, label):
+    n=text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old,new,1)
+
+def patch_smmu(t):
+    if 'SMMU create defer domain=%d' in t:
+        return t
+    t=rep(t, '#include <linux/module.h>\n', '#include <linux/module.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n', 'recorder include')
+    old='''\tif (!client || !client->domain)\n\t\treturn -ENODEV;\n\n\tret = iommu_map(client->domain, dest_address, dest_address,\n\t\t\tsize, prot);\n'''
+    new='''\ta52_ackfr_record("SMMU map client=%d domain=%d base=0x%x size=0x%x",\n\t\t!!client, client && client->domain, dest_address, size);\n\tif (!client || !client->domain) {\n\t\ta52_ackfr_record("SMMU map fail rc=%d client=%d domain=%d",\n\t\t\t-ENODEV, !!client, client && client->domain);\n\t\treturn -ENODEV;\n\t}\n\n\tret = iommu_map(client->domain, dest_address, dest_address,\n\t\t\tsize, prot);\n\ta52_ackfr_record("SMMU map exit rc=%d", ret);\n'''
+    t=rep(t,old,new,'one-to-one map trace')
+    old='''\tchild = of_find_compatible_node(dev->of_node, NULL, compat);\n\tif (!child) {\n\t\tDRM_DEBUG("unable to find compatible node for %s\\n", compat);\n\t\treturn ERR_PTR(-ENODEV);\n\t}\n\n\tpdev = of_platform_device_create(child, NULL, dev);\n\tif (!pdev) {\n\t\tDRM_ERROR("unable to create smmu platform dev for domain %d\\n",\n\t\t\t\tdomain);\n\t\treturn ERR_PTR(-ENODEV);\n\t}\n\n\tsmmu->client = platform_get_drvdata(pdev);\n\n\treturn &pdev->dev;\n'''
+    new='''\ta52_ackfr_record("SMMU create enter domain=%d compat=%s", domain, compat);\n\tchild = of_find_compatible_node(dev->of_node, NULL, compat);\n\tif (!child) {\n\t\ta52_ackfr_record("SMMU create no-node domain=%d", domain);\n\t\tDRM_DEBUG("unable to find compatible node for %s\\n", compat);\n\t\treturn ERR_PTR(-ENODEV);\n\t}\n\n\tpdev = of_platform_device_create(child, NULL, dev);\n\tif (!pdev) {\n\t\ta52_ackfr_record("SMMU create no-pdev domain=%d", domain);\n\t\tDRM_ERROR("unable to create smmu platform dev for domain %d\\n",\n\t\t\t\tdomain);\n\t\treturn ERR_PTR(-ENODEV);\n\t}\n\n\tsmmu->client = platform_get_drvdata(pdev);\n\ta52_ackfr_record("SMMU create state domain=%d driver=%d client=%d",\n\t\tdomain, !!pdev->dev.driver, !!smmu->client);\n\tif (!smmu->client) {\n\t\t/* 5.10 may create the child before its IOMMU domain is ready. */\n\t\ta52_ackfr_record("SMMU create defer domain=%d", domain);\n\t\tof_node_clear_flag(child, OF_POPULATED);\n\t\tplatform_device_unregister(pdev);\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n\t}\n\n\ta52_ackfr_record("SMMU create ready domain=%d secure=%d", domain,\n\t\tsmmu->client->secure);\n\treturn &pdev->dev;\n'''
+    t=rep(t,old,new,'device create defer')
+    old='''\tmatch = of_match_device(msm_smmu_dt_match, &pdev->dev);\n\tif (!match || !match->data) {\n'''
+    new='''\tmatch = of_match_device(msm_smmu_dt_match, &pdev->dev);\n\ta52_ackfr_record("SMMU probe enter match=%d driver=%d", !!match,\n\t\t!!pdev->dev.driver);\n\tif (!match || !match->data) {\n'''
+    t=rep(t,old,new,'probe enter')
+    old='''\tclient->dev = &pdev->dev;\n\tclient->domain = iommu_get_domain_for_dev(client->dev);\n\tif (!client->domain) {\n\t\tdev_err(&pdev->dev, "iommu get domain for dev failed\\n");\n\t\treturn -EINVAL;\n\t}\n'''
+    new='''\tclient->dev = &pdev->dev;\n\tclient->domain = iommu_get_domain_for_dev(client->dev);\n\ta52_ackfr_record("SMMU probe domain compat=%s ready=%d",\n\t\tmatch->compatible, !!client->domain);\n\tif (!client->domain) {\n\t\tdev_err(&pdev->dev, "iommu get domain for dev deferred\\n");\n\t\ta52_ackfr_record("SMMU probe defer compat=%s", match->compatible);\n\t\treturn -EPROBE_DEFER;\n\t}\n'''
+    t=rep(t,old,new,'probe defer')
+    old='''\tplatform_set_drvdata(pdev, client);\n\n\treturn 0;\n'''
+    new='''\tplatform_set_drvdata(pdev, client);\n\ta52_ackfr_record("SMMU probe ready compat=%s secure=%d",\n\t\tmatch->compatible, client->secure);\n\n\treturn 0;\n'''
+    t=rep(t,old,new,'probe ready')
+    old='''\tret = platform_driver_register(&msm_smmu_driver);\n\tif (ret)\n\t\tpr_err("mdss_smmu_register_driver() failed!\\n");\n\n\treturn ret;\n'''
+    new='''\ta52_ackfr_record("SMMU driver-register enter");\n\tret = platform_driver_register(&msm_smmu_driver);\n\ta52_ackfr_record("SMMU driver-register exit rc=%d", ret);\n\tif (ret)\n\t\tpr_err("mdss_smmu_register_driver() failed!\\n");\n\n\treturn ret;\n'''
+    t=rep(t,old,new,'driver register trace')
+    return t
+
+def patch_kms(t):
+    if 'KMSMMU required-domain fail domain=%d rc=%d' in t:
+        return t
+    old='''\t\tif (IS_ERR(mmu)) {\n\t\t\tret = PTR_ERR(mmu);\n\t\t\tSDE_DEBUG("failed to init iommu id %d: rc:%d\\n",\n\t\t\t\t\t\t\t\ti, ret);\n\t\t\tcontinue;\n\t\t}\n'''
+    new='''\t\tif (IS_ERR(mmu)) {\n\t\t\tret = PTR_ERR(mmu);\n\t\t\tSDE_DEBUG("failed to init iommu id %d: rc:%d\\n",\n\t\t\t\t\t\t\t\ti, ret);\n\t\t\tif ((i == MSM_SMMU_DOMAIN_UNSECURE) &&\n\t\t\t\t\tsde_kms->splash_data.num_splash_regions) {\n\t\t\t\ta52_ackfr_record("KMSMMU required-domain fail domain=%d rc=%d",\n\t\t\t\t\ti, ret);\n\t\t\t\tgoto fail;\n\t\t\t}\n\t\t\tcontinue;\n\t\t}\n'''
+    return rep(t,old,new,'required unsecure domain')
+
+def patch_rec(t):
+    if '!strncmp(message, "SMMU ", 5)' in t:
+        return t
+    old='''\t       !strncmp(message, "CAT ", 4) ||\n\t       !strncmp(message, "A52GDSC ", 8);\n'''
+    new='''\t       !strncmp(message, "CAT ", 4) ||\n\t       !strncmp(message, "SMMU ", 5) ||\n\t       !strncmp(message, "A52GDSC ", 8);\n'''
+    return rep(t,old,new,'SMMU retention')
+
+def run(root):
+    for rel,fn in ((SMMU,patch_smmu),(KMS,patch_kms),(REC,patch_rec)):
+        p=root/rel
+        text=p.read_text()
+        p.write_text(fn(text))
+    print('phase200 SMMU deferred-probe trace applied')
+
+def self_test():
+    smmu = '#include <linux/module.h>\nstatic int msm_smmu_one_to_one_map(struct msm_mmu *mmu, uint32_t iova,\n\t\tuint32_t dest_address, uint32_t size, int prot)\n{\n\tstruct msm_smmu *smmu = to_msm_smmu(mmu);\n\tstruct msm_smmu_client *client = msm_smmu_to_client(smmu);\n\tint ret = 0;\n\n\tif (!client || !client->domain)\n\t\treturn -ENODEV;\n\n\tret = iommu_map(client->domain, dest_address, dest_address,\n\t\t\tsize, prot);\n\tif (ret)\n\t\tpr_err("smmu map failed\\n");\n\n\treturn ret;\n}\n\nstatic int msm_smmu_map(struct msm_mmu *mmu, uint64_t iova,\n\t\tstruct sg_table *sgt, unsigned int len, int prot)\n{\n\tstruct msm_smmu *smmu = to_msm_smmu(mmu);\n\tstruct msm_smmu_client *client = msm_smmu_to_client(smmu);\nstatic struct device *msm_smmu_device_create(struct device *dev,\n\t\tenum msm_mmu_domain_type domain,\n\t\tstruct msm_smmu *smmu)\n{\n\tstruct device_node *child;\n\tstruct platform_device *pdev;\n\tint i;\n\tconst char *compat = NULL;\n\n\tfor (i = 0; i < ARRAY_SIZE(msm_smmu_dt_match); i++) {\n\t\tif (msm_smmu_dt_match[i].data == &msm_smmu_domains[domain]) {\n\t\t\tcompat = msm_smmu_dt_match[i].compatible;\n\t\t\tbreak;\n\t\t}\n\t}\n\n\tif (!compat) {\n\t\tDRM_DEBUG("unable to find matching domain for %d\\n", domain);\n\t\treturn ERR_PTR(-ENOENT);\n\t}\n\tDRM_DEBUG("found domain %d compat: %s\\n", domain, compat);\n\n\tchild = of_find_compatible_node(dev->of_node, NULL, compat);\n\tif (!child) {\n\t\tDRM_DEBUG("unable to find compatible node for %s\\n", compat);\n\t\treturn ERR_PTR(-ENODEV);\n\t}\n\n\tpdev = of_platform_device_create(child, NULL, dev);\n\tif (!pdev) {\n\t\tDRM_ERROR("unable to create smmu platform dev for domain %d\\n",\n\t\t\t\tdomain);\n\t\treturn ERR_PTR(-ENODEV);\n\t}\n\n\tsmmu->client = platform_get_drvdata(pdev);\n\n\treturn &pdev->dev;\n}\n\nstatic int msm_smmu_probe(struct platform_device *pdev)\n{\n\tconst struct of_device_id *match;\n\tstruct msm_smmu_client *client;\n\tconst struct msm_smmu_domain *domain;\n\n\tmatch = of_match_device(msm_smmu_dt_match, &pdev->dev);\n\tif (!match || !match->data) {\n\t\tdev_err(&pdev->dev, "probe failed as match data is invalid\\n");\n\t\treturn -EINVAL;\n\t}\n\n\tdomain = match->data;\n\tif (!domain) {\n\t\tdev_err(&pdev->dev, "no matching device found\\n");\n\t\treturn -EINVAL;\n\t}\n\n\tDRM_INFO("probing device %s\\n", match->compatible);\n\n\tclient = devm_kzalloc(&pdev->dev, sizeof(*client), GFP_KERNEL);\n\tif (!client)\n\t\treturn -ENOMEM;\n\n\tclient->dev = &pdev->dev;\n\tclient->domain = iommu_get_domain_for_dev(client->dev);\n\tif (!client->domain) {\n\t\tdev_err(&pdev->dev, "iommu get domain for dev failed\\n");\n\t\treturn -EINVAL;\n\t}\n\tclient->secure = domain->secure;\n\tclient->domain_attached = true;\n\n\tif (!client->dev->dma_parms)\n\t\tclient->dev->dma_parms = devm_kzalloc(client->dev,\n\t\t\t\tsizeof(*client->dev->dma_parms), GFP_KERNEL);\n\tdma_set_max_seg_size(client->dev, ~0U);\n\tdma_set_seg_boundary(client->dev, ~0UL);\n\n\tiommu_set_fault_handler(client->domain,\n\t\t\tmsm_smmu_fault_handler, (void *)client);\n\n\tDRM_INFO("Created domain %s, secure=%d\\n",\n\t\t\tdomain->label, domain->secure);\n\n\tplatform_set_drvdata(pdev, client);\n\n\treturn 0;\n}\nint __init msm_smmu_driver_init(void)\n{\n\tint ret;\n\n\tret = platform_driver_register(&msm_smmu_driver);\n\tif (ret)\n\t\tpr_err("mdss_smmu_register_driver() failed!\\n");\n\n\treturn ret;\n}\n\nvoid __exit msm_smmu_driver_cleanup(void)\n'
+    kms = '\t\tif (IS_ERR(mmu)) {\n\t\t\tret = PTR_ERR(mmu);\n\t\t\tSDE_DEBUG("failed to init iommu id %d: rc:%d\\n",\n\t\t\t\t\t\t\t\ti, ret);\n\t\t\tcontinue;\n\t\t}\n'
+    rec = '\t       !strncmp(message, "CAT ", 4) ||\n\t       !strncmp(message, "A52GDSC ", 8);\n'
+    smmu = patch_smmu(smmu)
+    kms = patch_kms(kms)
+    rec = patch_rec(rec)
+    for marker in ('SMMU create defer domain=%d','return -EPROBE_DEFER;','SMMU probe domain compat=%s ready=%d','SMMU driver-register exit rc=%d'):
+        assert marker in smmu, marker
+    assert 'KMSMMU required-domain fail domain=%d rc=%d' in kms
+    assert '!strncmp(message, "SMMU ", 5)' in rec
+    print('phase200 patcher self-test: PASS')
+
+def main():
+    ap=argparse.ArgumentParser(); ap.add_argument('--root',type=Path); ap.add_argument('--self-test',action='store_true'); a=ap.parse_args()
+    if a.self_test: self_test(); return
+    if not a.root: ap.error('--root required')
+    run(a.root)
+if __name__=='__main__': main()

--- a/scripts/200_ci.sh
+++ b/scripts/200_ci.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-post-kms-crc32c"
+OUT="$PWD/artifacts/a52xq-smmu-defer-trace"
+BUILD="$PWD/workspace/gki-phase199-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/199_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase200.config"
+cp "$ROOT/drivers/a52_display/msm/msm_smmu.c" "$OUT/stage/msm-smmu-before-phase200.c"
+cp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" "$OUT/stage/sde-kms-before-phase200.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" "$OUT/stage/recorder-before-phase200.c"
+sha256sum \
+  "$ROOT/fs/pstore/ram.c" \
+  "$ROOT/init/main.c" \
+  "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
+  "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  > "$OUT/stage/phase199-invariants-before-phase200.sha256"
+
+python3 scripts/200_apply_smmu_defer_trace.py --self-test | tee "$OUT/logs/phase200-patcher-self-test.log"
+python3 scripts/200_apply_smmu_defer_trace.py --root "$ROOT" | tee "$OUT/logs/phase200-apply.log"
+
+cp "$ROOT/drivers/a52_display/msm/msm_smmu.c" "$OUT/stage/msm-smmu-after-phase200.c"
+cp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" "$OUT/stage/sde-kms-after-phase200.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" "$OUT/stage/recorder-after-phase200.c"
+cp scripts/200_apply_smmu_defer_trace.py "$OUT/stage/"
+
+git -C "$ROOT" diff --check
+sha256sum -c "$OUT/stage/phase199-invariants-before-phase200.sha256"
+cmp "$OUT/config/before-phase200.config" "$BUILD/.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+smmu = (root / 'drivers/a52_display/msm/msm_smmu.c').read_text()
+kms = (root / 'drivers/a52_display/msm/sde/sde_kms.c').read_text()
+rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+for marker in (
+    '#include <linux/a52_ack_secure_flight_recorder.h>',
+    'SMMU driver-register exit rc=%d',
+    'SMMU probe domain compat=%s ready=%d',
+    'SMMU probe defer compat=%s',
+    'SMMU create state domain=%d driver=%d client=%d',
+    'SMMU create defer domain=%d',
+    'of_node_clear_flag(child, OF_POPULATED);',
+    'return ERR_PTR(-EPROBE_DEFER);',
+    'SMMU map fail rc=%d client=%d domain=%d',
+):
+    assert marker in smmu, marker
+assert 'KMSMMU required-domain fail domain=%d rc=%d' in kms
+assert '!strncmp(message, "SMMU ", 5)' in rec
+for marker in (
+    'copies=3 crc=crc32c',
+    '#define A52_R179_PREFIX "R99"',
+    'a52_r199_crc32c',
+):
+    assert marker in rec, marker
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > "$OUT/stage/phase200-smmu-defer-trace.patch"
+test -s "$OUT/stage/phase200-smmu-defer-trace.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase200-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase200-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase200-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase200-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for object in \
+  'drivers/a52_display/msm/msm_smmu.o' \
+  'drivers/a52_display/msm/sde/sde_kms.o' \
+  'drivers/a52_secure/a52_ack_secure_flight_recorder.o'; do
+  grep -Fq "$object" "$OUT/logs/phase200-compile.log"
+done
+for marker in \
+  'SMMU driver-register exit rc=%d' \
+  'SMMU probe domain compat=%s ready=%d' \
+  'SMMU probe defer compat=%s' \
+  'SMMU create defer domain=%d' \
+  'SMMU map fail rc=%d client=%d domain=%d' \
+  'KMSMMU required-domain fail domain=%d rc=%d' \
+  'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source "$BASE_OUT/package/boot.img" \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test | tee "$OUT/logs/phase200-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test | tee "$OUT/logs/phase200-triple-decoder-self-test.log"
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 200 SMMU client deferred-probe trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 199 capture result:
+  - hardware catalog completed
+  - unsecure SDE address-space object was created
+  - continuous-splash one-to-one map returned -ENODEV
+  - msm_smmu_new() had returned success even though its context-bank client or
+    IOMMU domain was not usable
+
+TouchGrass comparison:
+  The DT nodes, SMMU compatibles and one-to-one mapping implementation match the
+  TouchGrass kernel. The compatibility issue is probe timing under the 5.10
+  generic IOMMU/device model.
+
+Phase 200 changes:
+  - return -EPROBE_DEFER when the dynamically created SMMU context-bank device
+    has not obtained driver data yet
+  - return -EPROBE_DEFER from the SMMU context-bank probe while its IOMMU domain
+    is unavailable
+  - propagate failure/defer for the required unsecure display domain when a
+    splash region must be mapped
+  - add detailed SMMU driver, probe, client, domain and map checkpoints
+  - preserve three physical recorder copies, 32 RS parity symbols and CRC32C
+
+No IOMMU bypass is added. DTB, DTBO, ramdisk, panel commands and display timing
+remain unchanged.
+
+Collect the untouched full 1 MiB RAMOOPS image with collector 3.1 and decode it
+using the included Phase 199 R99 decoder.
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-smmu-defer-trace')
+base = json.loads(Path('artifacts/a52xq-post-kms-crc32c/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+base.update({
+    'status': 'a52-smmu-defer-trace-audited',
+    'phase': 200,
+    'base_phase': 199,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'phase199_crc32c_rs3_preserved': True,
+    'functional_change_from_phase199': 'required-smmu-context-deferred-probe-fix-and-trace',
+    'iommu_bypass_added': False,
+    'smmu_context_missing_drvdata_returns_probe_defer': True,
+    'smmu_missing_domain_returns_probe_defer': True,
+    'required_unsecure_splash_domain_failure_propagated': True,
+    'touchgrass_smmu_dt_and_map_path_compared': True,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'recorder_copy_count': 3,
+    'recorder_parity_symbols_per_copy': 32,
+    'recorder_crc': 'CRC32C',
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase199_crc32c_rs3_preserved',
+    'smmu_context_missing_drvdata_returns_probe_defer',
+    'smmu_missing_domain_returns_probe_defer',
+    'required_unsecure_splash_domain_failure_propagated',
+    'touchgrass_smmu_dt_and_map_path_compared',
+    'dtb_preserved', 'ramdisk_preserved', 'recovery_dtbo_preserved',
+):
+    assert base[key] is True, key
+assert base['recorder_copy_count'] == 3
+assert base['recorder_parity_symbols_per_copy'] == 32
+assert base['recorder_crc'] == 'CRC32C'
+(root / 'final-audit.json').write_text(json.dumps(base, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## What changed

- Preserves the Phase 199 recorder with three physical copies, 32 Reed-Solomon parity symbols per copy, and CRC32C validation.
- Adds detailed SMMU driver-registration, context-bank probe, client, domain, and one-to-one mapping checkpoints.
- Returns `-EPROBE_DEFER` when a dynamically created display SMMU context-bank device has not produced driver data yet.
- Returns `-EPROBE_DEFER` when the context-bank probe cannot yet obtain an IOMMU domain.
- Propagates failure for the required unsecure display domain when continuous-splash memory must be mapped.

## Why

The Phase 199 hardware capture reached the continuous-splash mapping path and failed with `-ENODEV`. Comparison with the exact TouchGrass kernel revision showed that the DT nodes, compatible strings, and mapping implementation match. The remaining compatibility issue is the old synchronous probe assumption: the child platform device may exist before its driver data or IOMMU domain is ready under the 5.10 device model.

## Safety

- No IOMMU bypass.
- No DTB, DTBO, ramdisk, panel-command, or display-timing changes.
- The workflow compiles, repacks, checks source and binary markers, runs both CRC32C/RS decoder self-tests, and publishes a not-hardware-validated boot image.