### PR TITLE
Build Phase 201 SMMU component dependency

### DIFF
--- a/.github/workflows/201-a52-smmu-component-dependency.yml
+++ b/.github/workflows/201-a52-smmu-component-dependency.yml
@@ -1,0 +1,121 @@
+name: 201 - A52 SMMU component dependency
+
+run-name: Build Phase 201 SMMU component dependency candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-smmu-component-dependency-v1
+    paths:
+      - .github/workflows/201-a52-smmu-component-dependency.yml
+      - scripts/201_apply_smmu_component_dependency.py
+      - scripts/201_ci.sh
+  pull_request:
+    branches:
+      - agent/a52-smmu-client-defer-trace-v1
+    paths:
+      - .github/workflows/201-a52-smmu-component-dependency.yml
+      - scripts/201_apply_smmu_component_dependency.py
+      - scripts/201_ci.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-smmu-component-dependency-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 201 SMMU component dependency candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+
+    steps:
+      - name: Check out Phase 201 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_runtime_fix_binary_audit.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/200_apply_smmu_defer_trace.py \
+            scripts/201_apply_smmu_component_dependency.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 201
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_runtime_fix_binary_audit.py
+          bash scripts/201_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-smmu-component-dependency-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-smmu-component-dependency
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 201 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-smmu-component-dependency-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-smmu-component-dependency
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/201_apply_smmu_component_dependency.py
+++ b/scripts/201_apply_smmu_component_dependency.py
@@ -16,7 +16,7 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
 
 
 def patch_msm_drv(text: str) -> str:
-    if "DRMCOMP smmu-match ready=" in text:
+    if "DRMCOMP smmu-match added node=%s" in text:
         return text
 
     text = replace_once(
@@ -43,6 +43,7 @@ def patch_msm_drv(text: str) -> str:
         "\t\t{\n"
         "\t\t\tstruct device_node *smmu_node;\n"
         "\t\t\tstruct platform_device *smmu_pdev;\n"
+        "\t\t\tbool smmu_existing = false;\n"
         "\n"
         "\t\t\tsmmu_node = of_find_compatible_node(np, NULL,\n"
         "\t\t\t\t\t\t\"qcom,smmu_sde_unsec\");\n"
@@ -52,11 +53,15 @@ def patch_msm_drv(text: str) -> str:
         "\t\t\t}\n"
         "\n"
         "\t\t\tsmmu_pdev = of_find_device_by_node(smmu_node);\n"
-        "\t\t\tif (!smmu_pdev)\n"
+        "\t\t\tif (smmu_pdev) {\n"
+        "\t\t\t\tsmmu_existing = true;\n"
+        "\t\t\t} else {\n"
         "\t\t\t\tsmmu_pdev = of_platform_device_create(smmu_node,\n"
         "\t\t\t\t\t\tNULL, dev);\n"
-        "\t\t\ta52_ackfr_record(\"DRMCOMP smmu-match ready=%d driver=%d client=%d\",\n"
-        "\t\t\t\t\t!!smmu_pdev, smmu_pdev && !!smmu_pdev->dev.driver,\n"
+        "\t\t\t}\n"
+        "\t\t\ta52_ackfr_record(\"DRMCOMP smmu-match ready=%d existing=%d driver=%d client=%d\",\n"
+        "\t\t\t\t\t!!smmu_pdev, smmu_existing,\n"
+        "\t\t\t\t\tsmmu_pdev && !!smmu_pdev->dev.driver,\n"
         "\t\t\t\t\tsmmu_pdev && !!platform_get_drvdata(smmu_pdev));\n"
         "\t\t\tif (!smmu_pdev) {\n"
         "\t\t\t\tof_node_put(smmu_node);\n"
@@ -66,7 +71,8 @@ def patch_msm_drv(text: str) -> str:
         "\t\t\tcomponent_match_add(dev, matchptr, compare_of, smmu_node);\n"
         "\t\t\ta52_ackfr_record(\"DRMCOMP smmu-match added node=%s\",\n"
         "\t\t\t\t\tsmmu_node->full_name);\n"
-        "\t\t\tput_device(&smmu_pdev->dev);\n"
+        "\t\t\tif (smmu_existing)\n"
+        "\t\t\t\tput_device(&smmu_pdev->dev);\n"
         "\t\t}\n"
         "\n"
         "\t\ta52_ackfr_record(\"DRMCOMP collect exit rc=0 match=%u\",\n"
@@ -112,21 +118,19 @@ def patch_msm_smmu(text: str) -> str:
         "\tkfree(smmu);\n",
         "conditional context-device unregister",
     )
-
-    old_create_decls = (
+    text = replace_once(
+        text,
         "\tstruct device_node *child;\n"
         "\tstruct platform_device *pdev;\n"
         "\tint i;\n"
-        "\tconst char *compat = NULL;\n"
-    )
-    new_create_decls = (
+        "\tconst char *compat = NULL;\n",
         "\tstruct device_node *child;\n"
         "\tstruct platform_device *pdev;\n"
         "\tbool existing = false;\n"
         "\tint i;\n"
-        "\tconst char *compat = NULL;\n"
+        "\tconst char *compat = NULL;\n",
+        "create declarations",
     )
-    text = replace_once(text, old_create_decls, new_create_decls, "create declarations")
 
     old_create = (
         "\tpdev = of_platform_device_create(child, NULL, dev);\n"
@@ -218,7 +222,15 @@ static const struct component_ops msm_smmu_component_ops = {
         component_ops + "/**\n * msm_smmu_probe()\n",
         "component ops insertion",
     )
-
+    text = replace_once(
+        text,
+        "\tstruct msm_smmu_client *client;\n"
+        "\tconst struct msm_smmu_domain *domain;\n",
+        "\tstruct msm_smmu_client *client;\n"
+        "\tconst struct msm_smmu_domain *domain;\n"
+        "\tint ret;\n",
+        "probe return declaration",
+    )
     text = replace_once(
         text,
         "\tplatform_set_drvdata(pdev, client);\n"
@@ -236,15 +248,6 @@ static const struct component_ops msm_smmu_component_ops = {
         "\ta52_ackfr_record(\"SMMU component-add exit rc=%d\", ret);\n"
         "\treturn ret;\n",
         "component registration",
-    )
-    text = replace_once(
-        text,
-        "\tstruct msm_smmu_client *client;\n"
-        "\tconst struct msm_smmu_domain *domain;\n",
-        "\tstruct msm_smmu_client *client;\n"
-        "\tconst struct msm_smmu_domain *domain;\n"
-        "\tint ret;\n",
-        "probe return declaration",
     )
     text = replace_once(
         text,
@@ -266,24 +269,33 @@ static const struct component_ops msm_smmu_component_ops = {
 def run(root: Path) -> None:
     drv_path = root / MSM_DRV
     smmu_path = root / MSM_SMMU
-    drv_path.write_text(patch_msm_drv(drv_path.read_text()), encoding="utf-8")
-    smmu_path.write_text(patch_msm_smmu(smmu_path.read_text()), encoding="utf-8")
+    drv_path.write_text(patch_msm_drv(drv_path.read_text(encoding="utf-8")), encoding="utf-8")
+    smmu_path.write_text(patch_msm_smmu(smmu_path.read_text(encoding="utf-8")), encoding="utf-8")
 
 
 def self_test() -> None:
-    root = Path(__file__).resolve().parents[1]
-    drv_fixture = root / "stage" / "msm-drv-after-phase195.c"
-    smmu_fixture = root / "stage" / "msm-smmu-after-phase200.c"
-    if not drv_fixture.is_file() or not smmu_fixture.is_file():
-        print("phase201 patcher self-test: fixtures unavailable, syntax-only PASS")
-        return
-    drv = patch_msm_drv(drv_fixture.read_text())
-    smmu = patch_msm_smmu(smmu_fixture.read_text())
-    assert "DRMPOST helper propagate rc=%d" in drv
-    assert "DRMCOMP smmu-match added node=%s" in drv
-    assert "SMMU component-add exit rc=%d" in smmu
-    assert "client_dev_owned" in smmu
-    print("phase201 SMMU component dependency patcher self-test: PASS")
+    repo = Path(__file__).resolve().parents[1]
+    candidates = [
+        (
+            repo / "workspace/phase198-artifact/stage/msm-drv-after-phase195.c",
+            repo / "artifacts/a52xq-smmu-defer-trace/stage/msm-smmu-after-phase200.c",
+        ),
+        (
+            repo / "stage/msm-drv-after-phase195.c",
+            repo / "stage/msm-smmu-after-phase200.c",
+        ),
+    ]
+    for drv_fixture, smmu_fixture in candidates:
+        if drv_fixture.is_file() and smmu_fixture.is_file():
+            drv = patch_msm_drv(drv_fixture.read_text(encoding="utf-8"))
+            smmu = patch_msm_smmu(smmu_fixture.read_text(encoding="utf-8"))
+            assert "DRMPOST helper propagate rc=%d" in drv
+            assert "DRMCOMP smmu-match added node=%s" in drv
+            assert "SMMU component-add exit rc=%d" in smmu
+            assert "client_dev_owned" in smmu
+            print("phase201 SMMU component dependency patcher self-test: PASS")
+            return
+    raise SystemExit("phase201 self-test fixtures unavailable")
 
 
 def main() -> int:

--- a/scripts/201_apply_smmu_component_dependency.py
+++ b/scripts/201_apply_smmu_component_dependency.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+MSM_DRV = Path("drivers/a52_display/msm/msm_drv.c")
+MSM_SMMU = Path("drivers/a52_display/msm/msm_smmu.c")
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{label}: expected exactly one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_msm_drv(text: str) -> str:
+    if "DRMCOMP smmu-match ready=" in text:
+        return text
+
+    text = replace_once(
+        text,
+        "\tif (IS_ERR_OR_NULL(kms)) {\n"
+        "\t\tdev_err(dev, \"msm_drm_init_helper failed\\n\");\n"
+        "\t\tgoto fail;\n"
+        "\t}\n",
+        "\tif (IS_ERR_OR_NULL(kms)) {\n"
+        "\t\tret = IS_ERR(kms) ? PTR_ERR(kms) : -ENODEV;\n"
+        "\t\ta52_ackfr_record(\"DRMPOST helper propagate rc=%d\", ret);\n"
+        "\t\tdev_err(dev, \"msm_drm_init_helper failed: %d\\n\", ret);\n"
+        "\t\tgoto fail;\n"
+        "\t}\n",
+        "helper error propagation",
+    )
+
+    needle = (
+        "\t\ta52_ackfr_record(\"DRMCOMP collect exit rc=0 match=%u\",\n"
+        "\t\t\t\t   !!*matchptr);\n"
+        "\t\treturn 0;\n"
+    )
+    replacement = (
+        "\t\t{\n"
+        "\t\t\tstruct device_node *smmu_node;\n"
+        "\t\t\tstruct platform_device *smmu_pdev;\n"
+        "\n"
+        "\t\t\tsmmu_node = of_find_compatible_node(np, NULL,\n"
+        "\t\t\t\t\t\t\"qcom,smmu_sde_unsec\");\n"
+        "\t\t\tif (!smmu_node) {\n"
+        "\t\t\t\ta52_ackfr_record(\"DRMCOMP smmu-match no-node\");\n"
+        "\t\t\t\treturn -ENODEV;\n"
+        "\t\t\t}\n"
+        "\n"
+        "\t\t\tsmmu_pdev = of_find_device_by_node(smmu_node);\n"
+        "\t\t\tif (!smmu_pdev)\n"
+        "\t\t\t\tsmmu_pdev = of_platform_device_create(smmu_node,\n"
+        "\t\t\t\t\t\tNULL, dev);\n"
+        "\t\t\ta52_ackfr_record(\"DRMCOMP smmu-match ready=%d driver=%d client=%d\",\n"
+        "\t\t\t\t\t!!smmu_pdev, smmu_pdev && !!smmu_pdev->dev.driver,\n"
+        "\t\t\t\t\tsmmu_pdev && !!platform_get_drvdata(smmu_pdev));\n"
+        "\t\t\tif (!smmu_pdev) {\n"
+        "\t\t\t\tof_node_put(smmu_node);\n"
+        "\t\t\t\treturn -EPROBE_DEFER;\n"
+        "\t\t\t}\n"
+        "\n"
+        "\t\t\tcomponent_match_add(dev, matchptr, compare_of, smmu_node);\n"
+        "\t\t\ta52_ackfr_record(\"DRMCOMP smmu-match added node=%s\",\n"
+        "\t\t\t\t\tsmmu_node->full_name);\n"
+        "\t\t\tput_device(&smmu_pdev->dev);\n"
+        "\t\t}\n"
+        "\n"
+        "\t\ta52_ackfr_record(\"DRMCOMP collect exit rc=0 match=%u\",\n"
+        "\t\t\t\t   !!*matchptr);\n"
+        "\t\treturn 0;\n"
+    )
+    text = replace_once(text, needle, replacement, "unsecure SMMU component match")
+    return text
+
+
+def patch_msm_smmu(text: str) -> str:
+    if "SMMU component-add exit rc=%d" in text:
+        return text
+
+    text = replace_once(
+        text,
+        "#include <linux/module.h>\n",
+        "#include <linux/module.h>\n#include <linux/component.h>\n",
+        "component include",
+    )
+    text = replace_once(
+        text,
+        "struct msm_smmu {\n"
+        "\tstruct msm_mmu base;\n"
+        "\tstruct device *client_dev;\n"
+        "\tstruct msm_smmu_client *client;\n"
+        "};\n",
+        "struct msm_smmu {\n"
+        "\tstruct msm_mmu base;\n"
+        "\tstruct device *client_dev;\n"
+        "\tstruct msm_smmu_client *client;\n"
+        "\tbool client_dev_owned;\n"
+        "};\n",
+        "ownership field",
+    )
+    text = replace_once(
+        text,
+        "\tif (smmu->client_dev)\n"
+        "\t\tplatform_device_unregister(pdev);\n"
+        "\tkfree(smmu);\n",
+        "\tif (smmu->client_dev && smmu->client_dev_owned)\n"
+        "\t\tplatform_device_unregister(pdev);\n"
+        "\tkfree(smmu);\n",
+        "conditional context-device unregister",
+    )
+
+    old_create_decls = (
+        "\tstruct device_node *child;\n"
+        "\tstruct platform_device *pdev;\n"
+        "\tint i;\n"
+        "\tconst char *compat = NULL;\n"
+    )
+    new_create_decls = (
+        "\tstruct device_node *child;\n"
+        "\tstruct platform_device *pdev;\n"
+        "\tbool existing = false;\n"
+        "\tint i;\n"
+        "\tconst char *compat = NULL;\n"
+    )
+    text = replace_once(text, old_create_decls, new_create_decls, "create declarations")
+
+    old_create = (
+        "\tpdev = of_platform_device_create(child, NULL, dev);\n"
+        "\tif (!pdev) {\n"
+        "\t\ta52_ackfr_record(\"SMMU create no-pdev domain=%d\", domain);\n"
+        "\t\tDRM_ERROR(\"unable to create smmu platform dev for domain %d\\n\",\n"
+        "\t\t\t\tdomain);\n"
+        "\t\treturn ERR_PTR(-ENODEV);\n"
+        "\t}\n"
+        "\n"
+        "\tsmmu->client = platform_get_drvdata(pdev);\n"
+        "\ta52_ackfr_record(\"SMMU create state domain=%d driver=%d client=%d\",\n"
+        "\t\tdomain, !!pdev->dev.driver, !!smmu->client);\n"
+        "\tif (!smmu->client) {\n"
+        "\t\t/* 5.10 may create the child before its IOMMU domain is ready. */\n"
+        "\t\ta52_ackfr_record(\"SMMU create defer domain=%d\", domain);\n"
+        "\t\tof_node_clear_flag(child, OF_POPULATED);\n"
+        "\t\tplatform_device_unregister(pdev);\n"
+        "\t\treturn ERR_PTR(-EPROBE_DEFER);\n"
+        "\t}\n"
+        "\n"
+        "\ta52_ackfr_record(\"SMMU create ready domain=%d secure=%d\", domain,\n"
+        "\t\tsmmu->client->secure);\n"
+        "\treturn &pdev->dev;\n"
+    )
+    new_create = (
+        "\tpdev = of_find_device_by_node(child);\n"
+        "\tif (pdev) {\n"
+        "\t\texisting = true;\n"
+        "\t} else {\n"
+        "\t\tpdev = of_platform_device_create(child, NULL, dev);\n"
+        "\t}\n"
+        "\tif (!pdev) {\n"
+        "\t\ta52_ackfr_record(\"SMMU create no-pdev domain=%d\", domain);\n"
+        "\t\tDRM_ERROR(\"unable to create smmu platform dev for domain %d\\n\",\n"
+        "\t\t\t\tdomain);\n"
+        "\t\treturn ERR_PTR(-ENODEV);\n"
+        "\t}\n"
+        "\n"
+        "\tsmmu->client = platform_get_drvdata(pdev);\n"
+        "\ta52_ackfr_record(\"SMMU create state domain=%d existing=%d driver=%d client=%d\",\n"
+        "\t\tdomain, existing, !!pdev->dev.driver, !!smmu->client);\n"
+        "\tif (!smmu->client) {\n"
+        "\t\ta52_ackfr_record(\"SMMU create defer domain=%d existing=%d\",\n"
+        "\t\t\tdomain, existing);\n"
+        "\t\tif (existing)\n"
+        "\t\t\tput_device(&pdev->dev);\n"
+        "\t\telse {\n"
+        "\t\t\tof_node_clear_flag(child, OF_POPULATED);\n"
+        "\t\t\tplatform_device_unregister(pdev);\n"
+        "\t\t}\n"
+        "\t\treturn ERR_PTR(-EPROBE_DEFER);\n"
+        "\t}\n"
+        "\n"
+        "\tsmmu->client_dev_owned = !existing;\n"
+        "\ta52_ackfr_record(\"SMMU create ready domain=%d secure=%d owned=%d\", domain,\n"
+        "\t\tsmmu->client->secure, smmu->client_dev_owned);\n"
+        "\tif (existing)\n"
+        "\t\tput_device(&pdev->dev);\n"
+        "\treturn &pdev->dev;\n"
+    )
+    text = replace_once(text, old_create, new_create, "reuse precreated SMMU device")
+
+    component_ops = r'''
+static int msm_smmu_component_bind(struct device *dev,
+		struct device *master, void *data)
+{
+	a52_ackfr_record("SMMU component-bind dev=%s master=%s",
+		dev_name(dev), dev_name(master));
+	return 0;
+}
+
+static void msm_smmu_component_unbind(struct device *dev,
+		struct device *master, void *data)
+{
+	a52_ackfr_record("SMMU component-unbind dev=%s master=%s",
+		dev_name(dev), dev_name(master));
+}
+
+static const struct component_ops msm_smmu_component_ops = {
+	.bind = msm_smmu_component_bind,
+	.unbind = msm_smmu_component_unbind,
+};
+
+'''
+    text = replace_once(
+        text,
+        "/**\n * msm_smmu_probe()\n",
+        component_ops + "/**\n * msm_smmu_probe()\n",
+        "component ops insertion",
+    )
+
+    text = replace_once(
+        text,
+        "\tplatform_set_drvdata(pdev, client);\n"
+        "\ta52_ackfr_record(\"SMMU probe ready compat=%s secure=%d\",\n"
+        "\t\tmatch->compatible, client->secure);\n"
+        "\n"
+        "\treturn 0;\n",
+        "\tplatform_set_drvdata(pdev, client);\n"
+        "\ta52_ackfr_record(\"SMMU probe ready compat=%s secure=%d\",\n"
+        "\t\tmatch->compatible, client->secure);\n"
+        "\n"
+        "\ta52_ackfr_record(\"SMMU component-add enter compat=%s\",\n"
+        "\t\tmatch->compatible);\n"
+        "\tret = component_add(&pdev->dev, &msm_smmu_component_ops);\n"
+        "\ta52_ackfr_record(\"SMMU component-add exit rc=%d\", ret);\n"
+        "\treturn ret;\n",
+        "component registration",
+    )
+    text = replace_once(
+        text,
+        "\tstruct msm_smmu_client *client;\n"
+        "\tconst struct msm_smmu_domain *domain;\n",
+        "\tstruct msm_smmu_client *client;\n"
+        "\tconst struct msm_smmu_domain *domain;\n"
+        "\tint ret;\n",
+        "probe return declaration",
+    )
+    text = replace_once(
+        text,
+        "\tclient = platform_get_drvdata(pdev);\n"
+        "\tclient->domain_attached = false;\n"
+        "\n"
+        "\treturn 0;\n",
+        "\tcomponent_del(&pdev->dev, &msm_smmu_component_ops);\n"
+        "\tclient = platform_get_drvdata(pdev);\n"
+        "\tif (client)\n"
+        "\t\tclient->domain_attached = false;\n"
+        "\n"
+        "\treturn 0;\n",
+        "component removal",
+    )
+    return text
+
+
+def run(root: Path) -> None:
+    drv_path = root / MSM_DRV
+    smmu_path = root / MSM_SMMU
+    drv_path.write_text(patch_msm_drv(drv_path.read_text()), encoding="utf-8")
+    smmu_path.write_text(patch_msm_smmu(smmu_path.read_text()), encoding="utf-8")
+
+
+def self_test() -> None:
+    root = Path(__file__).resolve().parents[1]
+    drv_fixture = root / "stage" / "msm-drv-after-phase195.c"
+    smmu_fixture = root / "stage" / "msm-smmu-after-phase200.c"
+    if not drv_fixture.is_file() or not smmu_fixture.is_file():
+        print("phase201 patcher self-test: fixtures unavailable, syntax-only PASS")
+        return
+    drv = patch_msm_drv(drv_fixture.read_text())
+    smmu = patch_msm_smmu(smmu_fixture.read_text())
+    assert "DRMPOST helper propagate rc=%d" in drv
+    assert "DRMCOMP smmu-match added node=%s" in drv
+    assert "SMMU component-add exit rc=%d" in smmu
+    assert "client_dev_owned" in smmu
+    print("phase201 SMMU component dependency patcher self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.root is None:
+        parser.error("--root is required")
+    run(args.root)
+    print("phase201 SMMU component dependency and helper error propagation applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/201_ci.sh
+++ b/scripts/201_ci.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-smmu-defer-trace"
+OUT="$PWD/artifacts/a52xq-smmu-component-dependency"
+BUILD="$PWD/workspace/gki-phase199-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/200_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase201.config"
+cp "$ROOT/drivers/a52_display/msm/msm_drv.c" "$OUT/stage/msm-drv-before-phase201.c"
+cp "$ROOT/drivers/a52_display/msm/msm_smmu.c" "$OUT/stage/msm-smmu-before-phase201.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" "$OUT/stage/recorder-before-phase201.c"
+sha256sum \
+  "$ROOT/fs/pstore/ram.c" \
+  "$ROOT/init/main.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
+  "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  > "$OUT/stage/phase200-invariants-before-phase201.sha256"
+
+python3 scripts/201_apply_smmu_component_dependency.py --self-test | \
+  tee "$OUT/logs/phase201-patcher-self-test.log"
+python3 scripts/201_apply_smmu_component_dependency.py --root "$ROOT" | \
+  tee "$OUT/logs/phase201-apply.log"
+
+cp "$ROOT/drivers/a52_display/msm/msm_drv.c" "$OUT/stage/msm-drv-after-phase201.c"
+cp "$ROOT/drivers/a52_display/msm/msm_smmu.c" "$OUT/stage/msm-smmu-after-phase201.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" "$OUT/stage/recorder-after-phase201.c"
+cp scripts/201_apply_smmu_component_dependency.py "$OUT/stage/"
+
+git -C "$ROOT" diff --check
+sha256sum -c "$OUT/stage/phase200-invariants-before-phase201.sha256"
+cmp "$OUT/config/before-phase201.config" "$BUILD/.config"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+drv = (root / 'drivers/a52_display/msm/msm_drv.c').read_text()
+smmu = (root / 'drivers/a52_display/msm/msm_smmu.c').read_text()
+rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+for marker in (
+    'DRMPOST helper propagate rc=%d',
+    'ret = IS_ERR(kms) ? PTR_ERR(kms) : -ENODEV;',
+    'DRMCOMP smmu-match ready=%d existing=%d driver=%d client=%d',
+    'DRMCOMP smmu-match added node=%s',
+    'component_match_add(dev, matchptr, compare_of, smmu_node);',
+):
+    assert marker in drv, marker
+for marker in (
+    '#include <linux/component.h>',
+    'bool client_dev_owned;',
+    'SMMU component-add enter compat=%s',
+    'SMMU component-add exit rc=%d',
+    'SMMU component-bind dev=%s master=%s',
+    'component_del(&pdev->dev, &msm_smmu_component_ops);',
+    'pdev = of_find_device_by_node(child);',
+    'SMMU create state domain=%d existing=%d driver=%d client=%d',
+):
+    assert marker in smmu, marker
+assert 'if (smmu->client_dev && smmu->client_dev_owned)' in smmu
+for marker in (
+    'copies=3 crc=crc32c',
+    '#define A52_R179_PREFIX "R99"',
+    'a52_r199_crc32c',
+    '!strncmp(message, "SMMU ", 5)',
+):
+    assert marker in rec, marker
+assert 'iommu_bypass' not in drv.lower()
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff > \
+  "$OUT/stage/phase201-smmu-component-dependency.patch"
+test -s "$OUT/stage/phase201-smmu-component-dependency.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase201-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase201-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase201-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase201-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for object in \
+  'drivers/a52_display/msm/msm_drv.o' \
+  'drivers/a52_display/msm/msm_smmu.o'; do
+  grep -Fq "$object" "$OUT/logs/phase201-compile.log"
+done
+for marker in \
+  'DRMPOST helper propagate rc=%d' \
+  'DRMCOMP smmu-match ready=%d existing=%d driver=%d client=%d' \
+  'DRMCOMP smmu-match added node=%s' \
+  'SMMU component-add exit rc=%d' \
+  'SMMU component-bind dev=%s master=%s' \
+  'SMMU create state domain=%d existing=%d driver=%d client=%d' \
+  'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source "$BASE_OUT/package/boot.img" \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test | \
+  tee "$OUT/logs/phase201-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test | \
+  tee "$OUT/logs/phase201-triple-decoder-self-test.log"
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 201 SMMU component dependency
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 200 capture result:
+  - the unsecure SMMU child platform device was created
+  - its driver and client were not ready
+  - Phase 200 correctly returned -EPROBE_DEFER
+  - msm_drm_init() then accidentally returned stale rc=0, so the component
+    framework considered the failed bind successful and did not retry it
+
+Phase 201 changes:
+  - propagate PTR_ERR(kms), including -EPROBE_DEFER, from msm_drm_init()
+  - pre-create the unsecure SDE SMMU context-bank device before master binding
+  - register the ready SMMU context bank as a component
+  - add that component to the DRM master match list, so DRM bind cannot begin
+    until the context-bank probe has a real IOMMU domain
+  - reuse the pre-created device during msm_smmu_new()
+  - preserve three recorder copies, 32 RS symbols and CRC32C
+
+No IOMMU bypass is added. DTB, DTBO, ramdisk, panel commands and display timing
+remain unchanged.
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-smmu-component-dependency')
+base = json.loads(Path('artifacts/a52xq-smmu-defer-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+base.update({
+    'status': 'a52-smmu-component-dependency-audited',
+    'phase': 201,
+    'base_phase': 200,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'phase199_crc32c_rs3_preserved': True,
+    'phase200_smmu_defer_trace_preserved': True,
+    'functional_change_from_phase200': 'smmu-component-readiness-dependency-and-helper-error-propagation',
+    'iommu_bypass_added': False,
+    'drm_helper_error_propagated': True,
+    'unsecure_smmu_precreated': True,
+    'unsecure_smmu_component_dependency': True,
+    'precreated_smmu_reused': True,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'recorder_copy_count': 3,
+    'recorder_parity_symbols_per_copy': 32,
+    'recorder_crc': 'CRC32C',
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase199_crc32c_rs3_preserved',
+    'phase200_smmu_defer_trace_preserved',
+    'drm_helper_error_propagated',
+    'unsecure_smmu_precreated',
+    'unsecure_smmu_component_dependency',
+    'precreated_smmu_reused',
+    'dtb_preserved', 'ramdisk_preserved', 'recovery_dtbo_preserved',
+):
+    assert base[key] is True, key
+assert base['recorder_copy_count'] == 3
+assert base['recorder_parity_symbols_per_copy'] == 32
+assert base['recorder_crc'] == 'CRC32C'
+(root / 'final-audit.json').write_text(json.dumps(base, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Capture result

The Phase 200 capture showed that the unsecure SMMU child platform device was created with no bound driver and no client, so Phase 200 correctly returned `-EPROBE_DEFER`. The error then reached `_msm_drm_init_helper()`, but `msm_drm_init()` returned its stale `ret = 0`, causing the component master to be treated as successfully bound.

## Changes

- Propagate `PTR_ERR(kms)`, including `-EPROBE_DEFER`, from `msm_drm_init()`.
- Pre-create the unsecure SDE SMMU context-bank platform device during DRM component collection.
- Register a ready SMMU context bank as a component.
- Add the unsecure SMMU node to the DRM master match list, preventing DRM bind until the context-bank probe has a real IOMMU domain.
- Reuse the pre-created context-bank device in `msm_smmu_new()` and avoid unregistering a device owned by the component topology.
- Preserve the Phase 199 R99 recorder: three physical copies, 32 Reed-Solomon parity symbols per copy, and CRC32C validation.

## Safety

- No IOMMU bypass.
- No DTB, DTBO, ramdisk, panel-command, or display-timing changes.
- The workflow rebuilds through Phase 200, compiles the Phase 201 delta, audits source and Image markers, repacks the boot image, and runs both R99 decoder self-tests.