### PR TITLE
Compare Phase 203 Apps SMMU against TouchGrass

### DIFF
--- a/.github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
+++ b/.github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
@@ -1,0 +1,200 @@
+name: 203 - Compare TouchGrass Apps SMMU
+
+run-name: Compare pinned TouchGrass Apps SMMU with Phase 202 GKI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-apps-smmu-touchgrass-compare-v1
+    paths:
+      - .github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-apps-smmu-touchgrass-compare-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE202_ARTIFACT_ID: '8823289525'
+
+jobs:
+  compare:
+    name: Compare exact TouchGrass and Phase 202 SMMU inputs
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out comparison branch
+        uses: actions/checkout@v4
+
+      - name: Prepare tools
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git unzip python3
+
+      - name: Clone exact TouchGrass source
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+
+      - name: Download audited Phase 202 artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/phase202-artifact workspace/phase202.zip
+          mkdir -p workspace/phase202-artifact
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${PHASE202_ARTIFACT_ID}/zip" \
+            > workspace/phase202.zip
+          unzip -q workspace/phase202.zip -d workspace/phase202-artifact
+          test -s workspace/phase202-artifact/config/final.config
+          (cd workspace/phase202-artifact && sha256sum -c SHA256SUMS)
+
+      - name: Generate exact comparison package
+        run: |
+          set -Eeuo pipefail
+          TG="$PWD/workspace/touchgrass-a52xq"
+          P202="$PWD/workspace/phase202-artifact"
+          OUT="$PWD/artifacts/phase203-touchgrass-apps-smmu-compare"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"/{touchgrass-files,phase202,logs}
+
+          git -C "$TG" show -s --format=fuller HEAD > "$OUT/TOUCHGRASS-COMMIT.txt"
+          cp "$P202/config/final.config" "$OUT/phase202/final.config"
+          cp "$P202/final-audit.json" "$OUT/phase202/final-audit.json"
+
+          git -C "$TG" grep -n -I -E \
+            '15000000|apps[-_]?smmu|apps_smmu|qcom,[A-Za-z0-9_-]*smmu|arm,smmu|ARM_SMMU|QCOM_IOMMU' \
+            -- arch/arm64/boot/dts arch/arm64/configs drivers/iommu drivers/firmware drivers/soc \
+            > "$OUT/logs/touchgrass-all-hits.txt" || true
+
+          git -C "$TG" grep -n -I -E \
+            '15000000|apps[-_]?smmu|apps_smmu' \
+            -- arch/arm64/boot/dts \
+            > "$OUT/logs/touchgrass-apps-smmu-dts-hits.txt" || true
+
+          git -C "$TG" grep -n -I -E \
+            'arm_smmu_of_match|qcom.*smmu|smmu.*of_match|platform_driver.*smmu' \
+            -- drivers/iommu \
+            > "$OUT/logs/touchgrass-driver-match-hits.txt" || true
+
+          grep -nE '^(CONFIG_(ARM_SMMU|ARM_SMMU_V3|IOMMU_SUPPORT|OF_IOMMU|QCOM_IOMMU|QCOM_SMMU|IOMMU_IO_PGTABLE|IOMMU_DEFAULT_PASSTHROUGH|IOMMU_DEFAULT_DMA_STRICT|IOMMU_DEFAULT_DMA_LAZY|IOMMU_DEBUGFS|IOMMU_IOVA))=' \
+            "$P202/config/final.config" > "$OUT/phase202/iommu-config.txt" || true
+
+          find "$TG/arch/arm64/configs" -type f -print0 | sort -z | \
+            xargs -0 grep -HnE '^(CONFIG_(ARM_SMMU|ARM_SMMU_V3|IOMMU_SUPPORT|OF_IOMMU|QCOM_IOMMU|QCOM_SMMU|IOMMU_IO_PGTABLE|IOMMU_DEFAULT_PASSTHROUGH|IOMMU_DEFAULT_DMA_STRICT|IOMMU_DEFAULT_DMA_LAZY|IOMMU_DEBUGFS|IOMMU_IOVA))=' \
+            > "$OUT/logs/touchgrass-iommu-config-hits.txt" || true
+
+          python3 - "$TG" "$OUT" <<'PY'
+          from pathlib import Path
+          import re, shutil, sys
+
+          tg = Path(sys.argv[1])
+          out = Path(sys.argv[2])
+          hit_file = out / 'logs/touchgrass-apps-smmu-dts-hits.txt'
+          driver_file = out / 'logs/touchgrass-driver-match-hits.txt'
+          lines = hit_file.read_text(errors='replace').splitlines() if hit_file.exists() else []
+          paths = []
+          for line in lines:
+              m = re.match(r'([^:]+):(\d+):(.*)', line)
+              if m and m.group(1) not in paths:
+                  paths.append(m.group(1))
+
+          contexts = []
+          for rel in paths:
+              src = tg / rel
+              if not src.is_file():
+                  continue
+              dst = out / 'touchgrass-files' / rel
+              dst.parent.mkdir(parents=True, exist_ok=True)
+              shutil.copy2(src, dst)
+              text = src.read_text(errors='replace').splitlines()
+              hit_nums = []
+              for line in lines:
+                  m = re.match(rf'{re.escape(rel)}:(\d+):', line)
+                  if m:
+                      hit_nums.append(int(m.group(1)))
+              for n in hit_nums:
+                  start = max(1, n - 24)
+                  end = min(len(text), n + 45)
+                  contexts.append(f'===== {rel}:{start}-{end} (hit {n}) =====')
+                  contexts.extend(f'{i:6d}: {text[i-1]}' for i in range(start, end + 1))
+                  contexts.append('')
+          (out / 'TOUCHGRASS-APPS-SMMU-DTS-CONTEXT.txt').write_text('\n'.join(contexts) + '\n')
+
+          driver_lines = driver_file.read_text(errors='replace').splitlines() if driver_file.exists() else []
+          driver_paths = []
+          for line in driver_lines:
+              m = re.match(r'([^:]+):(\d+):(.*)', line)
+              if m and m.group(1) not in driver_paths:
+                  driver_paths.append(m.group(1))
+          for rel in driver_paths:
+              src = tg / rel
+              if src.is_file():
+                  dst = out / 'touchgrass-files' / rel
+                  dst.parent.mkdir(parents=True, exist_ok=True)
+                  shutil.copy2(src, dst)
+
+          p202_cfg = (out / 'phase202/iommu-config.txt').read_text(errors='replace')
+          tg_cfg = (out / 'logs/touchgrass-iommu-config-hits.txt').read_text(errors='replace')
+          dts_hits = hit_file.read_text(errors='replace') if hit_file.exists() else ''
+          drv_hits = driver_file.read_text(errors='replace') if driver_file.exists() else ''
+
+          report = [
+              'Phase 203 exact TouchGrass vs Phase 202 Apps SMMU comparison',
+              '',
+              'TouchGrass commit:',
+              '  6bf351bdf18bdb228db79e66f14a7a9c0178e5d7',
+              '',
+              'Phase 202 artifact:',
+              '  8823289525',
+              '',
+              'TouchGrass Apps SMMU DTS hits:',
+              dts_hits or '  NONE',
+              '',
+              'TouchGrass ARM/Qualcomm SMMU driver-match hits:',
+              drv_hits or '  NONE',
+              '',
+              'Phase 202 final IOMMU config:',
+              p202_cfg or '  NONE',
+              '',
+              'TouchGrass defconfig IOMMU options:',
+              tg_cfg or '  NONE',
+          ]
+          (out / 'COMPARISON-REPORT.txt').write_text('\n'.join(report) + '\n')
+          PY
+
+          test -s "$OUT/COMPARISON-REPORT.txt"
+          test -s "$OUT/TOUCHGRASS-APPS-SMMU-DTS-CONTEXT.txt"
+          test -s "$OUT/logs/touchgrass-driver-match-hits.txt"
+
+          (
+            cd "$OUT"
+            find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+              xargs -0 sha256sum > SHA256SUMS
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Upload exact comparison
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase203-touchgrass-apps-smmu-exact-comparison
+          path: artifacts/phase203-touchgrass-apps-smmu-compare
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
+++ b/.github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
@@ -10,12 +10,14 @@ on:
     paths:
       - .github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
       - scripts/203_compare_touchgrass_apps_smmu.sh
+      - scripts/203_compare_exact_gki_smmu.sh
   pull_request:
     branches:
       - agent/a52-smmu-driver-core-trace-v1
     paths:
       - .github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
       - scripts/203_compare_touchgrass_apps_smmu.sh
+      - scripts/203_compare_exact_gki_smmu.sh
 
 permissions:
   contents: read
@@ -28,6 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
   TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
   TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
   PHASE202_ARTIFACT_ID: '8823289525'
@@ -47,6 +50,19 @@ jobs:
           set -Eeuo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git unzip python3
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Verify pinned GKI source
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test "$(git -C gki/common rev-parse HEAD)" = "${GKI_COMMON_SHA}"
 
       - name: Clone exact TouchGrass source
         run: |
@@ -78,10 +94,16 @@ jobs:
       - name: Generate exact comparison package
         run: |
           set -Eeuo pipefail
+          OUT="$PWD/artifacts/phase203-touchgrass-apps-smmu-compare"
           bash scripts/203_compare_touchgrass_apps_smmu.sh \
             "$PWD/workspace/touchgrass-a52xq" \
             "$PWD/workspace/phase202-artifact" \
-            "$PWD/artifacts/phase203-touchgrass-apps-smmu-compare"
+            "$OUT"
+          bash scripts/203_compare_exact_gki_smmu.sh \
+            "$PWD/gki/common" \
+            "$PWD/workspace/touchgrass-a52xq" \
+            "$PWD/workspace/phase202-artifact" \
+            "$OUT"
 
       - name: Upload exact comparison
         id: upload
@@ -103,6 +125,6 @@ jobs:
           COMMENT=artifacts/phase203-touchgrass-apps-smmu-compare/PR-COMMENT-WITH-ARTIFACT.md
           {
             printf 'Artifact ID: `%s`\n\n' "$ARTIFACT_ID"
-            cat artifacts/phase203-touchgrass-apps-smmu-compare/PR-COMMENT.md
+            cat artifacts/phase203-touchgrass-apps-smmu-compare/PR-COMMENT-V2.md
           } > "$COMMENT"
           gh pr comment "$PR_NUMBER" --body-file "$COMMENT"

--- a/.github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
+++ b/.github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
@@ -9,10 +9,19 @@ on:
       - agent/a52-apps-smmu-touchgrass-compare-v1
     paths:
       - .github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
+      - scripts/203_compare_touchgrass_apps_smmu.sh
+  pull_request:
+    branches:
+      - agent/a52-smmu-driver-core-trace-v1
+    paths:
+      - .github/workflows/203-a52-apps-smmu-touchgrass-compare.yml
+      - scripts/203_compare_touchgrass_apps_smmu.sh
 
 permissions:
   contents: read
   actions: read
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: a52-apps-smmu-touchgrass-compare-${{ github.ref }}
@@ -69,132 +78,31 @@ jobs:
       - name: Generate exact comparison package
         run: |
           set -Eeuo pipefail
-          TG="$PWD/workspace/touchgrass-a52xq"
-          P202="$PWD/workspace/phase202-artifact"
-          OUT="$PWD/artifacts/phase203-touchgrass-apps-smmu-compare"
-          rm -rf "$OUT"
-          mkdir -p "$OUT"/{touchgrass-files,phase202,logs}
-
-          git -C "$TG" show -s --format=fuller HEAD > "$OUT/TOUCHGRASS-COMMIT.txt"
-          cp "$P202/config/final.config" "$OUT/phase202/final.config"
-          cp "$P202/final-audit.json" "$OUT/phase202/final-audit.json"
-
-          git -C "$TG" grep -n -I -E \
-            '15000000|apps[-_]?smmu|apps_smmu|qcom,[A-Za-z0-9_-]*smmu|arm,smmu|ARM_SMMU|QCOM_IOMMU' \
-            -- arch/arm64/boot/dts arch/arm64/configs drivers/iommu drivers/firmware drivers/soc \
-            > "$OUT/logs/touchgrass-all-hits.txt" || true
-
-          git -C "$TG" grep -n -I -E \
-            '15000000|apps[-_]?smmu|apps_smmu' \
-            -- arch/arm64/boot/dts \
-            > "$OUT/logs/touchgrass-apps-smmu-dts-hits.txt" || true
-
-          git -C "$TG" grep -n -I -E \
-            'arm_smmu_of_match|qcom.*smmu|smmu.*of_match|platform_driver.*smmu' \
-            -- drivers/iommu \
-            > "$OUT/logs/touchgrass-driver-match-hits.txt" || true
-
-          grep -nE '^(CONFIG_(ARM_SMMU|ARM_SMMU_V3|IOMMU_SUPPORT|OF_IOMMU|QCOM_IOMMU|QCOM_SMMU|IOMMU_IO_PGTABLE|IOMMU_DEFAULT_PASSTHROUGH|IOMMU_DEFAULT_DMA_STRICT|IOMMU_DEFAULT_DMA_LAZY|IOMMU_DEBUGFS|IOMMU_IOVA))=' \
-            "$P202/config/final.config" > "$OUT/phase202/iommu-config.txt" || true
-
-          find "$TG/arch/arm64/configs" -type f -print0 | sort -z | \
-            xargs -0 grep -HnE '^(CONFIG_(ARM_SMMU|ARM_SMMU_V3|IOMMU_SUPPORT|OF_IOMMU|QCOM_IOMMU|QCOM_SMMU|IOMMU_IO_PGTABLE|IOMMU_DEFAULT_PASSTHROUGH|IOMMU_DEFAULT_DMA_STRICT|IOMMU_DEFAULT_DMA_LAZY|IOMMU_DEBUGFS|IOMMU_IOVA))=' \
-            > "$OUT/logs/touchgrass-iommu-config-hits.txt" || true
-
-          python3 - "$TG" "$OUT" <<'PY'
-          from pathlib import Path
-          import re, shutil, sys
-
-          tg = Path(sys.argv[1])
-          out = Path(sys.argv[2])
-          hit_file = out / 'logs/touchgrass-apps-smmu-dts-hits.txt'
-          driver_file = out / 'logs/touchgrass-driver-match-hits.txt'
-          lines = hit_file.read_text(errors='replace').splitlines() if hit_file.exists() else []
-          paths = []
-          for line in lines:
-              m = re.match(r'([^:]+):(\d+):(.*)', line)
-              if m and m.group(1) not in paths:
-                  paths.append(m.group(1))
-
-          contexts = []
-          for rel in paths:
-              src = tg / rel
-              if not src.is_file():
-                  continue
-              dst = out / 'touchgrass-files' / rel
-              dst.parent.mkdir(parents=True, exist_ok=True)
-              shutil.copy2(src, dst)
-              text = src.read_text(errors='replace').splitlines()
-              hit_nums = []
-              for line in lines:
-                  m = re.match(rf'{re.escape(rel)}:(\d+):', line)
-                  if m:
-                      hit_nums.append(int(m.group(1)))
-              for n in hit_nums:
-                  start = max(1, n - 24)
-                  end = min(len(text), n + 45)
-                  contexts.append(f'===== {rel}:{start}-{end} (hit {n}) =====')
-                  contexts.extend(f'{i:6d}: {text[i-1]}' for i in range(start, end + 1))
-                  contexts.append('')
-          (out / 'TOUCHGRASS-APPS-SMMU-DTS-CONTEXT.txt').write_text('\n'.join(contexts) + '\n')
-
-          driver_lines = driver_file.read_text(errors='replace').splitlines() if driver_file.exists() else []
-          driver_paths = []
-          for line in driver_lines:
-              m = re.match(r'([^:]+):(\d+):(.*)', line)
-              if m and m.group(1) not in driver_paths:
-                  driver_paths.append(m.group(1))
-          for rel in driver_paths:
-              src = tg / rel
-              if src.is_file():
-                  dst = out / 'touchgrass-files' / rel
-                  dst.parent.mkdir(parents=True, exist_ok=True)
-                  shutil.copy2(src, dst)
-
-          p202_cfg = (out / 'phase202/iommu-config.txt').read_text(errors='replace')
-          tg_cfg = (out / 'logs/touchgrass-iommu-config-hits.txt').read_text(errors='replace')
-          dts_hits = hit_file.read_text(errors='replace') if hit_file.exists() else ''
-          drv_hits = driver_file.read_text(errors='replace') if driver_file.exists() else ''
-
-          report = [
-              'Phase 203 exact TouchGrass vs Phase 202 Apps SMMU comparison',
-              '',
-              'TouchGrass commit:',
-              '  6bf351bdf18bdb228db79e66f14a7a9c0178e5d7',
-              '',
-              'Phase 202 artifact:',
-              '  8823289525',
-              '',
-              'TouchGrass Apps SMMU DTS hits:',
-              dts_hits or '  NONE',
-              '',
-              'TouchGrass ARM/Qualcomm SMMU driver-match hits:',
-              drv_hits or '  NONE',
-              '',
-              'Phase 202 final IOMMU config:',
-              p202_cfg or '  NONE',
-              '',
-              'TouchGrass defconfig IOMMU options:',
-              tg_cfg or '  NONE',
-          ]
-          (out / 'COMPARISON-REPORT.txt').write_text('\n'.join(report) + '\n')
-          PY
-
-          test -s "$OUT/COMPARISON-REPORT.txt"
-          test -s "$OUT/TOUCHGRASS-APPS-SMMU-DTS-CONTEXT.txt"
-          test -s "$OUT/logs/touchgrass-driver-match-hits.txt"
-
-          (
-            cd "$OUT"
-            find . -type f ! -name SHA256SUMS -print0 | sort -z | \
-              xargs -0 sha256sum > SHA256SUMS
-            sha256sum -c SHA256SUMS
-          )
+          bash scripts/203_compare_touchgrass_apps_smmu.sh \
+            "$PWD/workspace/touchgrass-a52xq" \
+            "$PWD/workspace/phase202-artifact" \
+            "$PWD/artifacts/phase203-touchgrass-apps-smmu-compare"
 
       - name: Upload exact comparison
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: phase203-touchgrass-apps-smmu-exact-comparison
           path: artifacts/phase203-touchgrass-apps-smmu-compare
           if-no-files-found: error
           retention-days: 30
+
+      - name: Publish comparison to PR
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+        run: |
+          set -Eeuo pipefail
+          COMMENT=artifacts/phase203-touchgrass-apps-smmu-compare/PR-COMMENT-WITH-ARTIFACT.md
+          {
+            printf 'Artifact ID: `%s`\n\n' "$ARTIFACT_ID"
+            cat artifacts/phase203-touchgrass-apps-smmu-compare/PR-COMMENT.md
+          } > "$COMMENT"
+          gh pr comment "$PR_NUMBER" --body-file "$COMMENT"

--- a/scripts/203_compare_exact_gki_smmu.sh
+++ b/scripts/203_compare_exact_gki_smmu.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+GKI="${1:?GKI source path required}"
+TG="${2:?TouchGrass source path required}"
+P202="${3:?Phase 202 artifact path required}"
+OUT="${4:?Output path required}"
+EXPECTED_GKI_SHA=f960ed27302b1ff8e61e152fc202554d778deccd
+
+actual_sha="$(git -C "$GKI" rev-parse HEAD)"
+test "$actual_sha" = "$EXPECTED_GKI_SHA"
+
+mkdir -p "$OUT"/{gki-files,logs,phase202}
+git -C "$GKI" show -s --format=fuller HEAD > "$OUT/GKI-COMMIT.txt"
+
+for rel in \
+  drivers/iommu/arm/Kconfig \
+  drivers/iommu/arm/Makefile \
+  drivers/iommu/arm/arm-smmu/arm-smmu.c \
+  drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c \
+  drivers/iommu/arm/arm-smmu/arm-smmu-qcom.h \
+  drivers/iommu/arm/arm-smmu/arm-smmu.h; do
+  src="$GKI/$rel"
+  if [ -f "$src" ]; then
+    dst="$OUT/gki-files/$rel"
+    mkdir -p "$(dirname "$dst")"
+    cp "$src" "$dst"
+  fi
+done
+
+git -C "$GKI" grep -n -I -E \
+  'qcom,qsmmu-v500|qcom,[A-Za-z0-9_-]*smmu|arm_smmu_of_match|qcom_smmu_impl_init|ARM_SMMU_QCOM|platform_driver' \
+  -- drivers/iommu/arm \
+  > "$OUT/logs/gki-smmu-driver-hits.txt" || true
+
+git -C "$TG" grep -n -I -E \
+  'qcom,qsmmu-v500|qcom,[A-Za-z0-9_-]*smmu|arm_smmu_of_match|qsmmuv500_arch_ops|platform_driver' \
+  -- drivers/iommu/arm-smmu.c \
+  > "$OUT/logs/touchgrass-exact-smmu-driver-hits.txt" || true
+
+grep -nE 'CONFIG_.*(SMMU|IOMMU)' "$P202/config/final.config" \
+  > "$OUT/phase202/all-smmu-iommu-config.txt" || true
+
+grep -nE 'CONFIG_.*(SMMU|IOMMU)' "$TG/arch/arm64/configs/a52xq_defconfig" \
+  > "$OUT/logs/touchgrass-a52xq-all-smmu-iommu-config.txt" || true
+
+grep -nE 'CONFIG_.*(SMMU|IOMMU)' "$TG/arch/arm64/configs/vendor/a52xq_eur_open_defconfig" \
+  > "$OUT/logs/touchgrass-a52xq-eur-all-smmu-iommu-config.txt" || true
+
+python3 - "$GKI" "$TG" "$P202" "$OUT" <<'PY'
+from pathlib import Path
+import re, sys
+
+gki, tg, p202, out = map(Path, sys.argv[1:])
+
+def read(path):
+    return path.read_text(errors='replace') if path.is_file() else ''
+
+tg_dts = read(tg / 'arch/arm64/boot/dts/vendor/qcom/msm-arm-smmu-lagoon.dtsi')
+tg_drv = read(tg / 'drivers/iommu/arm-smmu.c')
+gki_core = read(gki / 'drivers/iommu/arm/arm-smmu/arm-smmu.c')
+gki_qcom = read(gki / 'drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c')
+gki_kconfig = read(gki / 'drivers/iommu/arm/Kconfig')
+p202_cfg = read(p202 / 'config/final.config')
+tg_cfg = read(tg / 'arch/arm64/configs/a52xq_defconfig')
+
+compat_m = re.search(r'apps_smmu:\s*apps-smmu@15000000\s*\{.*?compatible\s*=\s*"([^"]+)"', tg_dts, re.S)
+compat = compat_m.group(1) if compat_m else 'NOT FOUND'
+
+def enabled(text, name):
+    if f'{name}=y' in text:
+        return 'y'
+    if f'{name}=m' in text:
+        return 'm'
+    if f'# {name} is not set' in text:
+        return 'not set'
+    return 'absent'
+
+gki_all = gki_core + '\n' + gki_qcom
+strings = sorted(set(re.findall(r'\.compatible\s*=\s*"([^"]*smmu[^"]*)"', gki_all, re.I)))
+key = [
+    'Phase 203 key findings: exact TouchGrass versus pinned GKI Apps SMMU',
+    '',
+    f'TouchGrass Apps SMMU DT compatible: {compat}',
+    f'TouchGrass driver matches qcom,qsmmu-v500: {"yes" if "qcom,qsmmu-v500" in tg_drv else "no"}',
+    f'Pinned GKI driver matches qcom,qsmmu-v500: {"yes" if "qcom,qsmmu-v500" in gki_all else "no"}',
+    f'Pinned GKI contains Qualcomm SMMU implementation source: {"yes" if gki_qcom else "no"}',
+    '',
+    'Configuration:',
+    f'  TouchGrass CONFIG_ARM_SMMU: {enabled(tg_cfg, "CONFIG_ARM_SMMU")}',
+    f'  Phase 202 CONFIG_ARM_SMMU: {enabled(p202_cfg, "CONFIG_ARM_SMMU")}',
+    f'  Phase 202 CONFIG_ARM_SMMU_QCOM: {enabled(p202_cfg, "CONFIG_ARM_SMMU_QCOM")}',
+    f'  Phase 202 CONFIG_ARM_SMMU_LEGACY_DT_BINDINGS: {enabled(p202_cfg, "CONFIG_ARM_SMMU_LEGACY_DT_BINDINGS")}',
+    f'  Phase 202 CONFIG_QCOM_IOMMU: {enabled(p202_cfg, "CONFIG_QCOM_IOMMU")}',
+    '',
+    'Pinned GKI SMMU compatible strings:',
+]
+key.extend(f'  {s}' for s in strings)
+key.extend([
+    '',
+    'Interpretation:',
+    '  If the pinned GKI list does not contain qcom,qsmmu-v500, the existing',
+    '  TouchGrass DT node cannot bind to the GKI ARM SMMU platform driver.',
+    '  CONFIG_ARM_SMMU=y alone is therefore insufficient.',
+])
+(out / 'KEY-FINDINGS.txt').write_text('\n'.join(key) + '\n')
+
+# Extract compact match/config evidence for review.
+def selected_lines(text, patterns):
+    result=[]
+    for i,line in enumerate(text.splitlines(),1):
+        if any(re.search(p,line,re.I) for p in patterns):
+            result.append(f'{i}: {line}')
+    return result
+
+ev = ['Exact evidence', '', 'TouchGrass driver:']
+ev += selected_lines(tg_drv, [r'qcom,qsmmu-v500', r'qcom_smmuv500', r'arm_smmu_of_match'])
+ev += ['', 'Pinned GKI core driver:']
+ev += selected_lines(gki_core, [r'qcom,qsmmu-v500', r'arm_smmu_of_match', r'qcom_smmu'])
+ev += ['', 'Pinned GKI Qualcomm implementation:']
+ev += selected_lines(gki_qcom, [r'\.compatible', r'qcom_smmu_impl_init', r'qsmmu'])
+ev += ['', 'Pinned GKI Kconfig:']
+ev += selected_lines(gki_kconfig, [r'ARM_SMMU', r'QCOM'])
+(out / 'EXACT-MATCH-EVIDENCE.txt').write_text('\n'.join(ev) + '\n')
+
+comment = [
+    '## Exact GKI source comparison',
+    '',
+    '```text',
+    *(out / 'KEY-FINDINGS.txt').read_text(errors='replace').splitlines(),
+    '```',
+    '',
+    'The artifact includes the pinned GKI ARM SMMU core, Qualcomm implementation, Kconfig, TouchGrass downstream driver, Lagoon DTS context, final Phase 202 config, and checksums.',
+]
+(out / 'PR-COMMENT-V2.md').write_text('\n'.join(comment) + '\n')
+PY
+
+test -s "$OUT/KEY-FINDINGS.txt"
+test -s "$OUT/EXACT-MATCH-EVIDENCE.txt"
+test -s "$OUT/PR-COMMENT-V2.md"
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/203_compare_touchgrass_apps_smmu.sh
+++ b/scripts/203_compare_touchgrass_apps_smmu.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TG="${1:?TouchGrass source path required}"
+P202="${2:?Phase 202 artifact path required}"
+OUT="${3:?Output path required}"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{touchgrass-files,phase202,logs}
+
+git -C "$TG" show -s --format=fuller HEAD > "$OUT/TOUCHGRASS-COMMIT.txt"
+cp "$P202/config/final.config" "$OUT/phase202/final.config"
+cp "$P202/final-audit.json" "$OUT/phase202/final-audit.json"
+
+git -C "$TG" grep -n -I -E \
+  '15000000|apps[-_]?smmu|apps_smmu|qcom,[A-Za-z0-9_-]*smmu|arm,smmu|ARM_SMMU|QCOM_IOMMU' \
+  -- arch/arm64/boot/dts arch/arm64/configs drivers/iommu drivers/firmware drivers/soc \
+  > "$OUT/logs/touchgrass-all-hits.txt" || true
+
+git -C "$TG" grep -n -I -E \
+  '15000000|apps[-_]?smmu|apps_smmu' \
+  -- arch/arm64/boot/dts \
+  > "$OUT/logs/touchgrass-apps-smmu-dts-hits.txt" || true
+
+git -C "$TG" grep -n -I -E \
+  'arm_smmu_of_match|qcom.*smmu|smmu.*of_match|platform_driver.*smmu' \
+  -- drivers/iommu \
+  > "$OUT/logs/touchgrass-driver-match-hits.txt" || true
+
+grep -nE '^(CONFIG_(ARM_SMMU|ARM_SMMU_V3|IOMMU_SUPPORT|OF_IOMMU|QCOM_IOMMU|QCOM_SMMU|IOMMU_IO_PGTABLE|IOMMU_DEFAULT_PASSTHROUGH|IOMMU_DEFAULT_DMA_STRICT|IOMMU_DEFAULT_DMA_LAZY|IOMMU_DEBUGFS|IOMMU_IOVA))=' \
+  "$P202/config/final.config" > "$OUT/phase202/iommu-config.txt" || true
+
+find "$TG/arch/arm64/configs" -type f -print0 | sort -z | \
+  xargs -0 grep -HnE '^(CONFIG_(ARM_SMMU|ARM_SMMU_V3|IOMMU_SUPPORT|OF_IOMMU|QCOM_IOMMU|QCOM_SMMU|IOMMU_IO_PGTABLE|IOMMU_DEFAULT_PASSTHROUGH|IOMMU_DEFAULT_DMA_STRICT|IOMMU_DEFAULT_DMA_LAZY|IOMMU_DEBUGFS|IOMMU_IOVA))=' \
+  > "$OUT/logs/touchgrass-iommu-config-hits.txt" || true
+
+python3 - "$TG" "$OUT" <<'PY'
+from pathlib import Path
+import re, shutil, sys
+
+tg = Path(sys.argv[1])
+out = Path(sys.argv[2])
+hit_file = out / 'logs/touchgrass-apps-smmu-dts-hits.txt'
+driver_file = out / 'logs/touchgrass-driver-match-hits.txt'
+lines = hit_file.read_text(errors='replace').splitlines() if hit_file.exists() else []
+paths = []
+for line in lines:
+    m = re.match(r'([^:]+):(\d+):(.*)', line)
+    if m and m.group(1) not in paths:
+        paths.append(m.group(1))
+
+contexts = []
+for rel in paths:
+    src = tg / rel
+    if not src.is_file():
+        continue
+    dst = out / 'touchgrass-files' / rel
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    text = src.read_text(errors='replace').splitlines()
+    hit_nums = []
+    for line in lines:
+        m = re.match(rf'{re.escape(rel)}:(\d+):', line)
+        if m:
+            hit_nums.append(int(m.group(1)))
+    for n in hit_nums:
+        start = max(1, n - 24)
+        end = min(len(text), n + 45)
+        contexts.append(f'===== {rel}:{start}-{end} (hit {n}) =====')
+        contexts.extend(f'{i:6d}: {text[i-1]}' for i in range(start, end + 1))
+        contexts.append('')
+(out / 'TOUCHGRASS-APPS-SMMU-DTS-CONTEXT.txt').write_text('\n'.join(contexts) + '\n')
+
+driver_lines = driver_file.read_text(errors='replace').splitlines() if driver_file.exists() else []
+driver_paths = []
+for line in driver_lines:
+    m = re.match(r'([^:]+):(\d+):(.*)', line)
+    if m and m.group(1) not in driver_paths:
+        driver_paths.append(m.group(1))
+for rel in driver_paths:
+    src = tg / rel
+    if src.is_file():
+        dst = out / 'touchgrass-files' / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+p202_cfg = (out / 'phase202/iommu-config.txt').read_text(errors='replace')
+tg_cfg = (out / 'logs/touchgrass-iommu-config-hits.txt').read_text(errors='replace')
+dts_hits = hit_file.read_text(errors='replace') if hit_file.exists() else ''
+drv_hits = driver_file.read_text(errors='replace') if driver_file.exists() else ''
+
+report = [
+    'Phase 203 exact TouchGrass vs Phase 202 Apps SMMU comparison',
+    '',
+    'TouchGrass commit:',
+    '  6bf351bdf18bdb228db79e66f14a7a9c0178e5d7',
+    '',
+    'Phase 202 artifact:',
+    '  8823289525',
+    '',
+    'TouchGrass Apps SMMU DTS hits:',
+    dts_hits or '  NONE',
+    '',
+    'TouchGrass ARM/Qualcomm SMMU driver-match hits:',
+    drv_hits or '  NONE',
+    '',
+    'Phase 202 final IOMMU config:',
+    p202_cfg or '  NONE',
+    '',
+    'TouchGrass defconfig IOMMU options:',
+    tg_cfg or '  NONE',
+]
+(out / 'COMPARISON-REPORT.txt').write_text('\n'.join(report) + '\n')
+
+comment = [
+    '## Automated exact comparison completed',
+    '',
+    'The workflow compared pinned TouchGrass commit `6bf351bdf18bdb228db79e66f14a7a9c0178e5d7` with audited Phase 202 artifact `8823289525`.',
+    '',
+    '```text',
+]
+comment.extend((out / 'COMPARISON-REPORT.txt').read_text(errors='replace').splitlines()[:220])
+comment.extend(['```', '', 'The complete artifact includes copied DTS and SMMU driver source files plus full grep results and checksums.'])
+(out / 'PR-COMMENT.md').write_text('\n'.join(comment) + '\n')
+PY
+
+test -s "$OUT/COMPARISON-REPORT.txt"
+test -s "$OUT/TOUCHGRASS-APPS-SMMU-DTS-CONTEXT.txt"
+test -s "$OUT/logs/touchgrass-driver-match-hits.txt"
+test -s "$OUT/PR-COMMENT.md"
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase 202 hardware result

The Phase 202 capture proved that the `qcom,smmu_sde_unsec` child matches `msmdrm_smmu` and reaches `really_probe()`, but `device_links_check_suppliers()` returns `-EPROBE_DEFER` because supplier `15000000.apps-smmu` remains `DL_DEV_NO_DRIVER`.

## Objective

Before adding Phase 203 runtime tracing or changing behavior, compare the exact working TouchGrass source at commit `6bf351bdf18bdb228db79e66f14a7a9c0178e5d7` against the audited Phase 202 GKI artifact.

The workflow extracts and compares:

- the exact Apps SMMU DTS node and surrounding includes/overrides;
- its compatible string and resources;
- ARM/Qualcomm SMMU driver match tables and platform-driver registration;
- TouchGrass defconfig IOMMU/SMMU options;
- the final Phase 202 GKI IOMMU/SMMU configuration.

This PR is comparison-only. It changes no kernel source, DTB, IOMMU policy, component dependency, or recorder format.