### PR TITLE
Trace Phase 203 Lagoon Apps SMMU parent probe

### DIFF
--- a/.github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
+++ b/.github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
@@ -1,6 +1,6 @@
-name: 203 - A52 Apps SMMU qsmmuv500 compatibility
+name: 203 - A52 Apps SMMU parent trace
 
-run-name: Build Phase 203 Lagoon Apps SMMU compatibility candidate
+run-name: Build Phase 203 Lagoon Apps SMMU parent trace candidate
 
 on:
   workflow_dispatch:
@@ -11,6 +11,7 @@ on:
       - .github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
       - scripts/203_apply_apps_smmu_qsmmuv500_compat.py
       - scripts/203_ci.sh
+      - scripts/203_ci_parent_trace.sh
   pull_request:
     branches:
       - agent/a52-smmu-driver-core-trace-v1
@@ -18,13 +19,14 @@ on:
       - .github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
       - scripts/203_apply_apps_smmu_qsmmuv500_compat.py
       - scripts/203_ci.sh
+      - scripts/203_ci_parent_trace.sh
 
 permissions:
   contents: read
   actions: read
 
 concurrency:
-  group: a52-apps-smmu-qsmmuv500-compat-${{ github.ref }}
+  group: a52-apps-smmu-parent-trace-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -38,7 +40,7 @@ env:
 
 jobs:
   build-package:
-    name: Build Phase 203 Lagoon Apps SMMU compatibility candidate
+    name: Build Phase 203 Lagoon Apps SMMU parent trace candidate
     runs-on: ubuntu-22.04
     timeout-minutes: 300
 
@@ -67,6 +69,7 @@ jobs:
             tools/decode-a52-r199-crc32c-base.py \
             tools/decode-a52-r199-crc32c-triple.py
           bash -n scripts/203_ci.sh
+          bash -n scripts/203_ci_parent_trace.sh
 
       - name: Restore pinned GKI source
         id: gki-cache
@@ -103,13 +106,13 @@ jobs:
           test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
           python3 scripts/199_runtime_fix_crc_anchor_v2.py
           python3 scripts/199_runtime_fix_binary_audit.py
-          bash scripts/203_ci.sh
+          bash scripts/203_ci_parent_trace.sh
 
       - name: Upload failed diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-apps-smmu-qsmmuv500-compat-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          name: a52xq-apps-smmu-parent-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
           path: artifacts/a52xq-apps-smmu-qsmmuv500-compat
           if-no-files-found: warn
           retention-days: 7
@@ -118,7 +121,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-apps-smmu-qsmmuv500-compat-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          name: a52xq-apps-smmu-parent-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
           path: artifacts/a52xq-apps-smmu-qsmmuv500-compat
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
+++ b/.github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
@@ -1,0 +1,124 @@
+name: 203 - A52 Apps SMMU qsmmuv500 compatibility
+
+run-name: Build Phase 203 Lagoon Apps SMMU compatibility candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-apps-smmu-qsmmuv500-compat-v1
+    paths:
+      - .github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
+      - scripts/203_apply_apps_smmu_qsmmuv500_compat.py
+      - scripts/203_ci.sh
+  pull_request:
+    branches:
+      - agent/a52-smmu-driver-core-trace-v1
+    paths:
+      - .github/workflows/203-a52-apps-smmu-qsmmuv500-compat.yml
+      - scripts/203_apply_apps_smmu_qsmmuv500_compat.py
+      - scripts/203_ci.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-apps-smmu-qsmmuv500-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 203 Lagoon Apps SMMU compatibility candidate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+
+    steps:
+      - name: Check out Phase 203 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_runtime_fix_binary_audit.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/200_apply_smmu_defer_trace.py \
+            scripts/201_apply_smmu_component_dependency.py \
+            scripts/202_apply_driver_core_trace.py \
+            scripts/203_apply_apps_smmu_qsmmuv500_compat.py \
+            scripts/38_repack_a52_p1_boot.py \
+            tools/decode-a52-r199-crc32c-base.py \
+            tools/decode-a52-r199-crc32c-triple.py
+          bash -n scripts/203_ci.sh
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 203
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_runtime_fix_binary_audit.py
+          bash scripts/203_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-apps-smmu-qsmmuv500-compat-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-apps-smmu-qsmmuv500-compat
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 203 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-apps-smmu-qsmmuv500-compat-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-apps-smmu-qsmmuv500-compat
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/203_apply_apps_smmu_qsmmuv500_compat.py
+++ b/scripts/203_apply_apps_smmu_qsmmuv500_compat.py
@@ -1,166 +1,49 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import argparse, shutil, tempfile
+C=Path('drivers/iommu/arm/arm-smmu/arm-smmu.c')
+Q=Path('drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c')
 
-CORE = Path('drivers/iommu/arm/arm-smmu/arm-smmu.c')
-QCOM = Path('drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c')
+def one(s,a,b,n):
+    if s.count(a)!=1: raise SystemExit(f'{n}: expected 1, got {s.count(a)}')
+    return s.replace(a,b,1)
 
+def pc(s):
+    if 'SMMU parent-probe enter dev=%s driver=%s' in s: return s
+    s=one(s,'#include <linux/slab.h>\n','#include <linux/slab.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n','include')
+    s=one(s,'static bool using_legacy_binding, using_generic_binding;\n','''static bool using_legacy_binding, using_generic_binding;\n\nstatic bool a52_apps_smmu(const struct device *dev)\n{\n\treturn dev && dev->of_node &&\n\t\tof_device_is_compatible(dev->of_node, "qcom,qsmmu-v500");\n}\n\n''','helper')
+    s=one(s,'''static int arm_smmu_device_probe(struct platform_device *pdev)\n{\n\tstruct resource *res;\n\tresource_size_t ioaddr;\n\tstruct arm_smmu_device *smmu;\n\tstruct device *dev = &pdev->dev;\n\tint num_irqs, i, err;\n\tirqreturn_t (*global_fault)(int irq, void *dev);\n\n''','''static int arm_smmu_device_probe(struct platform_device *pdev)\n{\n\tstruct resource *res;\n\tresource_size_t ioaddr;\n\tstruct arm_smmu_device *smmu;\n\tstruct device *dev = &pdev->dev;\n\tbool trace = a52_apps_smmu(dev);\n\tint num_irqs, i, err;\n\tirqreturn_t (*global_fault)(int irq, void *dev);\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-probe enter dev=%s driver=%s",\n\t\t\tdev_name(dev), dev->driver ? dev->driver->name : "-");\n\n''','probe enter')
+    s=one(s,'''\tif (err)\n\t\treturn err;\n\n\tsmmu->base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);\n''','''\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-dt rc=%d model=%d skip=%d lvl3=%d",\n\t\t\terr, err ? -1 : smmu->model, smmu->skip_init,\n\t\t\tsmmu->use_3lvl_tables);\n\tif (err)\n\t\treturn err;\n\n\tsmmu->base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);\n''','dt')
+    s=one(s,'''\tsmmu = arm_smmu_impl_init(smmu);\n\tif (IS_ERR(smmu))\n\t\treturn PTR_ERR(smmu);\n''','''\tsmmu = arm_smmu_impl_init(smmu);\n\tif (IS_ERR(smmu)) {\n\t\terr = PTR_ERR(smmu);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-impl rc=%d", err);\n\t\treturn err;\n\t}\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-impl rc=0 impl=%d", !!smmu->impl);\n''','impl')
+    s=one(s,'''\terr = arm_smmu_device_cfg_probe(smmu);\n\tif (err)\n\t\treturn err;\n''','''\terr = arm_smmu_device_cfg_probe(smmu);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-cfg rc=%d groups=%u cbs=%u", err,\n\t\t\tsmmu->num_mapping_groups, smmu->num_context_banks);\n\tif (err)\n\t\treturn err;\n''','cfg')
+    s=one(s,'''\terr = iommu_device_register(&smmu->iommu);\n\tif (err) {\n''','''\terr = iommu_device_register(&smmu->iommu);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-register rc=%d", err);\n\tif (err) {\n''','register')
+    s=one(s,'''\tif (!using_legacy_binding)\n\t\treturn arm_smmu_bus_init(&arm_smmu_ops);\n\n\treturn 0;\n}\n''','''\tif (!using_legacy_binding) {\n\t\terr = arm_smmu_bus_init(&arm_smmu_ops);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-probe exit rc=%d", err);\n\t\treturn err;\n\t}\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-probe exit rc=0");\n\treturn 0;\n}\n''','exit')
+    return s
 
-def ro(text, old, new, label):
-    n = text.count(old)
-    if n != 1:
-        raise SystemExit(f'{label}: expected 1, got {n}')
-    return text.replace(old, new, 1)
+def pq(s):
+    if 'SMMU parent-qcom scm=%d' in s: return s
+    s=one(s,'#include <linux/qcom_scm.h>\n','#include <linux/qcom_scm.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n','q include')
+    s=one(s,'''\tstruct qcom_smmu *qsmmu;\n\n\t/* Check to make sure qcom_scm has finished probing */\n\tif (!qcom_scm_is_available())\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n''','''\tstruct qcom_smmu *qsmmu;\n\tbool trace = smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node, "qcom,qsmmu-v500");\n\tbool scm = qcom_scm_is_available();\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom scm=%d", scm);\n\t/* Check to make sure qcom_scm has finished probing */\n\tif (!scm)\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n''','q scm')
+    return s
 
+def apply(r):
+    for p,f in ((C,pc),(Q,pq)):
+        x=r/p; x.write_text(f(x.read_text()))
 
-def patch_core(t):
-    if 'SMMU parent-probe enter dev=%s' in t:
-        return t
-    t = ro(t,
-        '#include <linux/slab.h>\n',
-        '#include <linux/slab.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
-        'core include')
-    t = ro(t,
-        'static bool using_legacy_binding, using_generic_binding;\n',
-        '''static bool using_legacy_binding, using_generic_binding;\n\nstatic bool arm_smmu_qsmmuv500_node(const struct arm_smmu_device *smmu)\n{\n\treturn smmu && smmu->dev && smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node,\n\t\t\t\t\t"qcom,qsmmu-v500");\n}\n\nstatic bool arm_smmu_qsmmuv500_skip_init(const struct arm_smmu_device *smmu)\n{\n\treturn arm_smmu_qsmmuv500_node(smmu) &&\n\t\tof_property_read_bool(smmu->dev->of_node, "qcom,skip-init");\n}\n''',
-        'core helpers')
-    t = ro(t,
-        '''\t\tif (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH64) {\n\t\t\tfmt = ARM_64_LPAE_S1;\n\t\t} else if (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH32_L) {\n''',
-        '''\t\tif (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH64) {\n\t\t\tfmt = ARM_64_LPAE_S1;\n\t\t\tif (arm_smmu_qsmmuv500_node(smmu) &&\n\t\t\t    of_property_read_bool(smmu->dev->of_node,\n\t\t\t\t\t\t  "qcom,use-3-lvl-tables")) {\n\t\t\t\tias = min(ias, 39UL);\n\t\t\t\ta52_ackfr_record("SMMU parent-domain 3lvl ias=%lu", ias);\n\t\t\t}\n\t\t} else if (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH32_L) {\n''',
-        '3lvl clamp')
-    t = ro(t,
-        '''static void arm_smmu_device_reset(struct arm_smmu_device *smmu)\n{\n\tint i;\n\tu32 reg;\n\n\t/* clear global FSR */\n''',
-        '''static void arm_smmu_device_reset(struct arm_smmu_device *smmu)\n{\n\tbool skip_init = arm_smmu_qsmmuv500_skip_init(smmu);\n\tint i;\n\tu32 reg;\n\n\tif (arm_smmu_qsmmuv500_node(smmu))\n\t\ta52_ackfr_record("SMMU parent-reset enter skip=%d groups=%u cbs=%u",\n\t\t\tskip_init, smmu->num_mapping_groups,\n\t\t\tsmmu->num_context_banks);\n\n\t/* clear global FSR */\n''',
-        'reset enter')
-    t = ro(t,
-        '''\t/*\n\t * Reset stream mapping groups: Initial values mark all SMRn as\n\t * invalid and all S2CRn as bypass unless overridden.\n\t */\n\tfor (i = 0; i < smmu->num_mapping_groups; ++i)\n\t\tarm_smmu_write_sme(smmu, i);\n\n\t/* Make sure all context banks are disabled and clear CB_FSR  */\n\tfor (i = 0; i < smmu->num_context_banks; ++i) {\n\t\tarm_smmu_write_context_bank(smmu, i);\n\t\tarm_smmu_cb_write(smmu, i, ARM_SMMU_CB_FSR, ARM_SMMU_FSR_FAULT);\n\t}\n''',
-        '''\t/*\n\t * TouchGrass marks the Lagoon Apps SMMU qcom,skip-init because the\n\t * boot firmware owns live stream/context mappings. Preserve them.\n\t */\n\tif (!skip_init) {\n\t\t/*\n\t\t * Reset stream mapping groups: Initial values mark all SMRn as\n\t\t * invalid and all S2CRn as bypass unless overridden.\n\t\t */\n\t\tfor (i = 0; i < smmu->num_mapping_groups; ++i)\n\t\t\tarm_smmu_write_sme(smmu, i);\n\n\t\t/* Make sure all context banks are disabled and clear CB_FSR  */\n\t\tfor (i = 0; i < smmu->num_context_banks; ++i) {\n\t\t\tarm_smmu_write_context_bank(smmu, i);\n\t\t\tarm_smmu_cb_write(smmu, i, ARM_SMMU_CB_FSR,\n\t\t\t\t\t  ARM_SMMU_FSR_FAULT);\n\t\t}\n\t}\n''',
-        'reset preserve mappings')
-    t = ro(t,
-        '''\t/* Push the button */\n\tarm_smmu_tlb_sync_global(smmu);\n\tarm_smmu_gr0_write(smmu, ARM_SMMU_GR0_sCR0, reg);\n}\n''',
-        '''\t/* Push the button */\n\tarm_smmu_tlb_sync_global(smmu);\n\tarm_smmu_gr0_write(smmu, ARM_SMMU_GR0_sCR0, reg);\n\tif (arm_smmu_qsmmuv500_node(smmu))\n\t\ta52_ackfr_record("SMMU parent-reset exit skip=%d scr0=%x",\n\t\t\tskip_init, reg);\n}\n''',
-        'reset exit')
-    t = ro(t,
-        '''ARM_SMMU_MATCH_DATA(qcom_smmuv2, ARM_SMMU_V2, QCOM_SMMUV2);\n''',
-        '''ARM_SMMU_MATCH_DATA(qcom_smmuv2, ARM_SMMU_V2, QCOM_SMMUV2);\nARM_SMMU_MATCH_DATA(qcom_qsmmuv500, ARM_SMMU_V2, QCOM_SMMUV2);\n''',
-        'match data')
-    t = ro(t,
-        '''\t{ .compatible = "qcom,smmu-v2", .data = &qcom_smmuv2 },\n\t{ },\n''',
-        '''\t{ .compatible = "qcom,smmu-v2", .data = &qcom_smmuv2 },\n\t{ .compatible = "qcom,qsmmu-v500", .data = &qcom_qsmmuv500 },\n\t{ },\n''',
-        'of match')
-    t = ro(t,
-        '''\tdata = of_device_get_match_data(dev);\n\tsmmu->version = data->version;\n\tsmmu->model = data->model;\n''',
-        '''\tdata = of_device_get_match_data(dev);\n\tif (!data)\n\t\treturn -ENODEV;\n\tsmmu->version = data->version;\n\tsmmu->model = data->model;\n\tif (of_device_is_compatible(dev->of_node, "qcom,qsmmu-v500"))\n\t\ta52_ackfr_record("SMMU parent-dt version=%d model=%d girq=%u skip=%d lvl3=%d",\n\t\t\tsmmu->version, smmu->model, smmu->num_global_irqs,\n\t\t\tof_property_read_bool(dev->of_node, "qcom,skip-init"),\n\t\t\tof_property_read_bool(dev->of_node,\n\t\t\t\t\t      "qcom,use-3-lvl-tables"));\n''',
-        'dt trace')
-    t = ro(t,
-        '''\tirqreturn_t (*global_fault)(int irq, void *dev);\n\n\tsmmu = devm_kzalloc(dev, sizeof(*smmu), GFP_KERNEL);\n''',
-        '''\tirqreturn_t (*global_fault)(int irq, void *dev);\n\tbool trace = dev->of_node &&\n\t\tof_device_is_compatible(dev->of_node, "qcom,qsmmu-v500");\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-probe enter dev=%s driver=%s",\n\t\t\tdev_name(dev), dev->driver ? dev->driver->name : "-");\n\tsmmu = devm_kzalloc(dev, sizeof(*smmu), GFP_KERNEL);\n''',
-        'probe enter')
-    t = ro(t,
-        '''\tif (err)\n\t\treturn err;\n\n\tsmmu->base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);\n\tif (IS_ERR(smmu->base))\n\t\treturn PTR_ERR(smmu->base);\n''',
-        '''\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-dt-probe rc=%d", err);\n\tif (err)\n\t\treturn err;\n\n\tsmmu->base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);\n\tif (IS_ERR(smmu->base)) {\n\t\terr = PTR_ERR(smmu->base);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-map rc=%d", err);\n\t\treturn err;\n\t}\n''',
-        'probe dt/map')
-    t = ro(t,
-        '''\tsmmu->numpage = resource_size(res);\n\n\tsmmu = arm_smmu_impl_init(smmu);\n\tif (IS_ERR(smmu))\n\t\treturn PTR_ERR(smmu);\n''',
-        '''\tsmmu->numpage = resource_size(res);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-map ok base=%pa bytes=%pa",\n\t\t\t&ioaddr, &smmu->numpage);\n\n\tsmmu = arm_smmu_impl_init(smmu);\n\tif (IS_ERR(smmu)) {\n\t\terr = PTR_ERR(smmu);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-impl rc=%d", err);\n\t\treturn err;\n\t}\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-impl rc=0 impl=%d", !!smmu->impl);\n''',
-        'probe impl')
-    t = ro(t,
-        '''\tsmmu->num_clks = err;\n\n\terr = clk_bulk_prepare_enable(smmu->num_clks, smmu->clks);\n\tif (err)\n\t\treturn err;\n\n\terr = arm_smmu_device_cfg_probe(smmu);\n\tif (err)\n\t\treturn err;\n''',
-        '''\tsmmu->num_clks = err;\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-res irqs=%d girq=%u cirq=%u clocks=%d",\n\t\t\tnum_irqs, smmu->num_global_irqs, smmu->num_context_irqs,\n\t\t\tsmmu->num_clks);\n\n\terr = clk_bulk_prepare_enable(smmu->num_clks, smmu->clks);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-clocks rc=%d", err);\n\tif (err)\n\t\treturn err;\n\n\terr = arm_smmu_device_cfg_probe(smmu);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-cfg rc=%d feat=%lx groups=%u cbs=%u",\n\t\t\terr, smmu->features, smmu->num_mapping_groups,\n\t\t\tsmmu->num_context_banks);\n\tif (err)\n\t\treturn err;\n''',
-        'probe resources/cfg')
-    t = ro(t,
-        '''\terr = iommu_device_register(&smmu->iommu);\n\tif (err) {\n\t\tdev_err(dev, "Failed to register iommu\\n");\n\t\treturn err;\n\t}\n\n\tplatform_set_drvdata(pdev, smmu);\n\tarm_smmu_device_reset(smmu);\n''',
-        '''\terr = iommu_device_register(&smmu->iommu);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-register rc=%d", err);\n\tif (err) {\n\t\tdev_err(dev, "Failed to register iommu\\n");\n\t\treturn err;\n\t}\n\n\tplatform_set_drvdata(pdev, smmu);\n\tarm_smmu_device_reset(smmu);\n''',
-        'probe register')
-    t = ro(t,
-        '''\tif (!using_legacy_binding)\n\t\treturn arm_smmu_bus_init(&arm_smmu_ops);\n\n\treturn 0;\n}\n''',
-        '''\tif (!using_legacy_binding) {\n\t\terr = arm_smmu_bus_init(&arm_smmu_ops);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-probe exit rc=%d legacy=0", err);\n\t\treturn err;\n\t}\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-probe exit rc=0 legacy=1");\n\treturn 0;\n}\n''',
-        'probe exit')
-    return t
+def test(r):
+    with tempfile.TemporaryDirectory() as d:
+        t=Path(d)
+        for p in (C,Q):
+            (t/p).parent.mkdir(parents=True,exist_ok=True); shutil.copy2(r/p,t/p)
+        apply(t); a=[(t/p).read_text() for p in (C,Q)]; apply(t)
+        assert a==[(t/p).read_text() for p in (C,Q)]
+        c,q=a
+        for m in ('SMMU parent-probe enter dev=%s driver=%s','SMMU parent-dt rc=%d model=%d skip=%d lvl3=%d','SMMU parent-impl rc=%d','SMMU parent-cfg rc=%d groups=%u cbs=%u','SMMU parent-register rc=%d','SMMU parent-probe exit rc=%d'): assert m in c
+        assert 'SMMU parent-qcom scm=%d' in q
+        assert '{ .compatible = "qcom,qsmmu-v500", .data = &arm_mmu500 },' in c
+        assert 'if (!smmu->skip_init)' in c and 'if (smmu->use_3lvl_tables)' in c
+    print('phase203 Apps SMMU parent trace self-test: PASS')
 
-
-def patch_qcom(t):
-    if 'SMMU parent-qcom-create scm=%d' in t:
-        return t
-    t = ro(t,
-        '#include <linux/qcom_scm.h>\n',
-        '#include <linux/qcom_scm.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
-        'qcom include')
-    t = ro(t,
-        '''static int qcom_sdm845_smmu500_cfg_probe(struct arm_smmu_device *smmu)\n{\n\tu32 s2cr;\n''',
-        '''static int qcom_sdm845_smmu500_cfg_probe(struct arm_smmu_device *smmu)\n{\n\tbool trace = smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node, "qcom,qsmmu-v500");\n\tu32 s2cr;\n''',
-        'qcom cfg enter var')
-    t = ro(t,
-        '''\tu32 s2cr;\n\tu32 smr;\n\tint i;\n\n\tfor (i = 0; i < smmu->num_mapping_groups; i++) {\n''',
-        '''\tu32 s2cr;\n\tu32 smr;\n\tint i;\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-cfg enter groups=%u",\n\t\t\tsmmu->num_mapping_groups);\n\tfor (i = 0; i < smmu->num_mapping_groups; i++) {\n''',
-        'qcom cfg trace enter')
-    t = ro(t,
-        '''\treturn 0;\n}\n\n#define QCOM_ADRENO_SMMU_GPU_SID 0\n''',
-        '''\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-cfg exit rc=0");\n\treturn 0;\n}\n\n#define QCOM_ADRENO_SMMU_GPU_SID 0\n''',
-        'qcom cfg exit')
-    t = ro(t,
-        '''\tstruct qcom_smmu *qsmmu;\n\n\t/* Check to make sure qcom_scm has finished probing */\n\tif (!qcom_scm_is_available())\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n''',
-        '''\tstruct qcom_smmu *qsmmu;\n\tbool trace = smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node, "qcom,qsmmu-v500");\n\tbool scm = qcom_scm_is_available();\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-create scm=%d", scm);\n\t/* Check to make sure qcom_scm has finished probing */\n\tif (!scm)\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n''',
-        'qcom create scm')
-    t = ro(t,
-        '''\tqsmmu->smmu.impl = impl;\n\tdevm_kfree(smmu->dev, smmu);\n\n\treturn &qsmmu->smmu;\n}\n''',
-        '''\tqsmmu->smmu.impl = impl;\n\tdevm_kfree(smmu->dev, smmu);\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-create rc=0");\n\treturn &qsmmu->smmu;\n}\n''',
-        'qcom create exit')
-    return t
-
-
-def apply(root):
-    for rel, fn in ((CORE, patch_core), (QCOM, patch_qcom)):
-        path = root / rel
-        old = path.read_text()
-        new = fn(old)
-        path.write_text(new)
-
-
-def self_test(root):
-    with tempfile.TemporaryDirectory() as td:
-        tmp = Path(td)
-        for rel in (CORE, QCOM):
-            dst = tmp / rel
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(root / rel, dst)
-        apply(tmp)
-        first = {rel: (tmp / rel).read_text() for rel in (CORE, QCOM)}
-        apply(tmp)
-        second = {rel: (tmp / rel).read_text() for rel in (CORE, QCOM)}
-        assert first == second
-        core = first[CORE]
-        qcom = first[QCOM]
-        for marker in (
-            'qcom,qsmmu-v500',
-            'SMMU parent-probe enter dev=%s',
-            'SMMU parent-reset enter skip=%d',
-            'SMMU parent-domain 3lvl ias=%lu',
-            'SMMU parent-probe exit rc=%d legacy=0',
-        ):
-            assert marker in core, marker
-        for marker in (
-            'SMMU parent-qcom-create scm=%d',
-            'SMMU parent-qcom-cfg enter groups=%u',
-            'SMMU parent-qcom-create rc=0',
-        ):
-            assert marker in qcom, marker
-        assert core.count('.compatible = "qcom,qsmmu-v500"') == 1
-        assert 'if (!skip_init)' in core
-        assert 'ias = min(ias, 39UL);' in core
-    print('phase203 qsmmuv500 compatibility patcher self-test: PASS')
-
-
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument('--root', type=Path, required=True)
-    ap.add_argument('--self-test', action='store_true')
-    args = ap.parse_args()
-    if args.self_test:
-        self_test(args.root)
-    else:
-        apply(args.root)
-        print('phase203 qsmmuv500 compatibility and parent trace applied')
-
-if __name__ == '__main__':
-    main()
+ap=argparse.ArgumentParser(); ap.add_argument('--root',type=Path,required=True); ap.add_argument('--self-test',action='store_true'); a=ap.parse_args()
+if a.self_test: test(a.root)
+else: apply(a.root); print('phase203 Apps SMMU parent trace applied')

--- a/scripts/203_apply_apps_smmu_qsmmuv500_compat.py
+++ b/scripts/203_apply_apps_smmu_qsmmuv500_compat.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse, shutil, tempfile
+
+CORE = Path('drivers/iommu/arm/arm-smmu/arm-smmu.c')
+QCOM = Path('drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c')
+
+
+def ro(text, old, new, label):
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1, got {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_core(t):
+    if 'SMMU parent-probe enter dev=%s' in t:
+        return t
+    t = ro(t,
+        '#include <linux/slab.h>\n',
+        '#include <linux/slab.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'core include')
+    t = ro(t,
+        'static bool using_legacy_binding, using_generic_binding;\n',
+        '''static bool using_legacy_binding, using_generic_binding;\n\nstatic bool arm_smmu_qsmmuv500_node(const struct arm_smmu_device *smmu)\n{\n\treturn smmu && smmu->dev && smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node,\n\t\t\t\t\t"qcom,qsmmu-v500");\n}\n\nstatic bool arm_smmu_qsmmuv500_skip_init(const struct arm_smmu_device *smmu)\n{\n\treturn arm_smmu_qsmmuv500_node(smmu) &&\n\t\tof_property_read_bool(smmu->dev->of_node, "qcom,skip-init");\n}\n''',
+        'core helpers')
+    t = ro(t,
+        '''\t\tif (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH64) {\n\t\t\tfmt = ARM_64_LPAE_S1;\n\t\t} else if (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH32_L) {\n''',
+        '''\t\tif (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH64) {\n\t\t\tfmt = ARM_64_LPAE_S1;\n\t\t\tif (arm_smmu_qsmmuv500_node(smmu) &&\n\t\t\t    of_property_read_bool(smmu->dev->of_node,\n\t\t\t\t\t\t  "qcom,use-3-lvl-tables")) {\n\t\t\t\tias = min(ias, 39UL);\n\t\t\t\ta52_ackfr_record("SMMU parent-domain 3lvl ias=%lu", ias);\n\t\t\t}\n\t\t} else if (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH32_L) {\n''',
+        '3lvl clamp')
+    t = ro(t,
+        '''static void arm_smmu_device_reset(struct arm_smmu_device *smmu)\n{\n\tint i;\n\tu32 reg;\n\n\t/* clear global FSR */\n''',
+        '''static void arm_smmu_device_reset(struct arm_smmu_device *smmu)\n{\n\tbool skip_init = arm_smmu_qsmmuv500_skip_init(smmu);\n\tint i;\n\tu32 reg;\n\n\tif (arm_smmu_qsmmuv500_node(smmu))\n\t\ta52_ackfr_record("SMMU parent-reset enter skip=%d groups=%u cbs=%u",\n\t\t\tskip_init, smmu->num_mapping_groups,\n\t\t\tsmmu->num_context_banks);\n\n\t/* clear global FSR */\n''',
+        'reset enter')
+    t = ro(t,
+        '''\t/*\n\t * Reset stream mapping groups: Initial values mark all SMRn as\n\t * invalid and all S2CRn as bypass unless overridden.\n\t */\n\tfor (i = 0; i < smmu->num_mapping_groups; ++i)\n\t\tarm_smmu_write_sme(smmu, i);\n\n\t/* Make sure all context banks are disabled and clear CB_FSR  */\n\tfor (i = 0; i < smmu->num_context_banks; ++i) {\n\t\tarm_smmu_write_context_bank(smmu, i);\n\t\tarm_smmu_cb_write(smmu, i, ARM_SMMU_CB_FSR, ARM_SMMU_FSR_FAULT);\n\t}\n''',
+        '''\t/*\n\t * TouchGrass marks the Lagoon Apps SMMU qcom,skip-init because the\n\t * boot firmware owns live stream/context mappings. Preserve them.\n\t */\n\tif (!skip_init) {\n\t\t/*\n\t\t * Reset stream mapping groups: Initial values mark all SMRn as\n\t\t * invalid and all S2CRn as bypass unless overridden.\n\t\t */\n\t\tfor (i = 0; i < smmu->num_mapping_groups; ++i)\n\t\t\tarm_smmu_write_sme(smmu, i);\n\n\t\t/* Make sure all context banks are disabled and clear CB_FSR  */\n\t\tfor (i = 0; i < smmu->num_context_banks; ++i) {\n\t\t\tarm_smmu_write_context_bank(smmu, i);\n\t\t\tarm_smmu_cb_write(smmu, i, ARM_SMMU_CB_FSR,\n\t\t\t\t\t  ARM_SMMU_FSR_FAULT);\n\t\t}\n\t}\n''',
+        'reset preserve mappings')
+    t = ro(t,
+        '''\t/* Push the button */\n\tarm_smmu_tlb_sync_global(smmu);\n\tarm_smmu_gr0_write(smmu, ARM_SMMU_GR0_sCR0, reg);\n}\n''',
+        '''\t/* Push the button */\n\tarm_smmu_tlb_sync_global(smmu);\n\tarm_smmu_gr0_write(smmu, ARM_SMMU_GR0_sCR0, reg);\n\tif (arm_smmu_qsmmuv500_node(smmu))\n\t\ta52_ackfr_record("SMMU parent-reset exit skip=%d scr0=%x",\n\t\t\tskip_init, reg);\n}\n''',
+        'reset exit')
+    t = ro(t,
+        '''ARM_SMMU_MATCH_DATA(qcom_smmuv2, ARM_SMMU_V2, QCOM_SMMUV2);\n''',
+        '''ARM_SMMU_MATCH_DATA(qcom_smmuv2, ARM_SMMU_V2, QCOM_SMMUV2);\nARM_SMMU_MATCH_DATA(qcom_qsmmuv500, ARM_SMMU_V2, QCOM_SMMUV2);\n''',
+        'match data')
+    t = ro(t,
+        '''\t{ .compatible = "qcom,smmu-v2", .data = &qcom_smmuv2 },\n\t{ },\n''',
+        '''\t{ .compatible = "qcom,smmu-v2", .data = &qcom_smmuv2 },\n\t{ .compatible = "qcom,qsmmu-v500", .data = &qcom_qsmmuv500 },\n\t{ },\n''',
+        'of match')
+    t = ro(t,
+        '''\tdata = of_device_get_match_data(dev);\n\tsmmu->version = data->version;\n\tsmmu->model = data->model;\n''',
+        '''\tdata = of_device_get_match_data(dev);\n\tif (!data)\n\t\treturn -ENODEV;\n\tsmmu->version = data->version;\n\tsmmu->model = data->model;\n\tif (of_device_is_compatible(dev->of_node, "qcom,qsmmu-v500"))\n\t\ta52_ackfr_record("SMMU parent-dt version=%d model=%d girq=%u skip=%d lvl3=%d",\n\t\t\tsmmu->version, smmu->model, smmu->num_global_irqs,\n\t\t\tof_property_read_bool(dev->of_node, "qcom,skip-init"),\n\t\t\tof_property_read_bool(dev->of_node,\n\t\t\t\t\t      "qcom,use-3-lvl-tables"));\n''',
+        'dt trace')
+    t = ro(t,
+        '''\tirqreturn_t (*global_fault)(int irq, void *dev);\n\n\tsmmu = devm_kzalloc(dev, sizeof(*smmu), GFP_KERNEL);\n''',
+        '''\tirqreturn_t (*global_fault)(int irq, void *dev);\n\tbool trace = dev->of_node &&\n\t\tof_device_is_compatible(dev->of_node, "qcom,qsmmu-v500");\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-probe enter dev=%s driver=%s",\n\t\t\tdev_name(dev), dev->driver ? dev->driver->name : "-");\n\tsmmu = devm_kzalloc(dev, sizeof(*smmu), GFP_KERNEL);\n''',
+        'probe enter')
+    t = ro(t,
+        '''\tif (err)\n\t\treturn err;\n\n\tsmmu->base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);\n\tif (IS_ERR(smmu->base))\n\t\treturn PTR_ERR(smmu->base);\n''',
+        '''\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-dt-probe rc=%d", err);\n\tif (err)\n\t\treturn err;\n\n\tsmmu->base = devm_platform_get_and_ioremap_resource(pdev, 0, &res);\n\tif (IS_ERR(smmu->base)) {\n\t\terr = PTR_ERR(smmu->base);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-map rc=%d", err);\n\t\treturn err;\n\t}\n''',
+        'probe dt/map')
+    t = ro(t,
+        '''\tsmmu->numpage = resource_size(res);\n\n\tsmmu = arm_smmu_impl_init(smmu);\n\tif (IS_ERR(smmu))\n\t\treturn PTR_ERR(smmu);\n''',
+        '''\tsmmu->numpage = resource_size(res);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-map ok base=%pa bytes=%pa",\n\t\t\t&ioaddr, &smmu->numpage);\n\n\tsmmu = arm_smmu_impl_init(smmu);\n\tif (IS_ERR(smmu)) {\n\t\terr = PTR_ERR(smmu);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-impl rc=%d", err);\n\t\treturn err;\n\t}\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-impl rc=0 impl=%d", !!smmu->impl);\n''',
+        'probe impl')
+    t = ro(t,
+        '''\tsmmu->num_clks = err;\n\n\terr = clk_bulk_prepare_enable(smmu->num_clks, smmu->clks);\n\tif (err)\n\t\treturn err;\n\n\terr = arm_smmu_device_cfg_probe(smmu);\n\tif (err)\n\t\treturn err;\n''',
+        '''\tsmmu->num_clks = err;\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-res irqs=%d girq=%u cirq=%u clocks=%d",\n\t\t\tnum_irqs, smmu->num_global_irqs, smmu->num_context_irqs,\n\t\t\tsmmu->num_clks);\n\n\terr = clk_bulk_prepare_enable(smmu->num_clks, smmu->clks);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-clocks rc=%d", err);\n\tif (err)\n\t\treturn err;\n\n\terr = arm_smmu_device_cfg_probe(smmu);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-cfg rc=%d feat=%lx groups=%u cbs=%u",\n\t\t\terr, smmu->features, smmu->num_mapping_groups,\n\t\t\tsmmu->num_context_banks);\n\tif (err)\n\t\treturn err;\n''',
+        'probe resources/cfg')
+    t = ro(t,
+        '''\terr = iommu_device_register(&smmu->iommu);\n\tif (err) {\n\t\tdev_err(dev, "Failed to register iommu\\n");\n\t\treturn err;\n\t}\n\n\tplatform_set_drvdata(pdev, smmu);\n\tarm_smmu_device_reset(smmu);\n''',
+        '''\terr = iommu_device_register(&smmu->iommu);\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-register rc=%d", err);\n\tif (err) {\n\t\tdev_err(dev, "Failed to register iommu\\n");\n\t\treturn err;\n\t}\n\n\tplatform_set_drvdata(pdev, smmu);\n\tarm_smmu_device_reset(smmu);\n''',
+        'probe register')
+    t = ro(t,
+        '''\tif (!using_legacy_binding)\n\t\treturn arm_smmu_bus_init(&arm_smmu_ops);\n\n\treturn 0;\n}\n''',
+        '''\tif (!using_legacy_binding) {\n\t\terr = arm_smmu_bus_init(&arm_smmu_ops);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("SMMU parent-probe exit rc=%d legacy=0", err);\n\t\treturn err;\n\t}\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-probe exit rc=0 legacy=1");\n\treturn 0;\n}\n''',
+        'probe exit')
+    return t
+
+
+def patch_qcom(t):
+    if 'SMMU parent-qcom-create scm=%d' in t:
+        return t
+    t = ro(t,
+        '#include <linux/qcom_scm.h>\n',
+        '#include <linux/qcom_scm.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'qcom include')
+    t = ro(t,
+        '''static int qcom_sdm845_smmu500_cfg_probe(struct arm_smmu_device *smmu)\n{\n\tu32 s2cr;\n''',
+        '''static int qcom_sdm845_smmu500_cfg_probe(struct arm_smmu_device *smmu)\n{\n\tbool trace = smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node, "qcom,qsmmu-v500");\n\tu32 s2cr;\n''',
+        'qcom cfg enter var')
+    t = ro(t,
+        '''\tu32 s2cr;\n\tu32 smr;\n\tint i;\n\n\tfor (i = 0; i < smmu->num_mapping_groups; i++) {\n''',
+        '''\tu32 s2cr;\n\tu32 smr;\n\tint i;\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-cfg enter groups=%u",\n\t\t\tsmmu->num_mapping_groups);\n\tfor (i = 0; i < smmu->num_mapping_groups; i++) {\n''',
+        'qcom cfg trace enter')
+    t = ro(t,
+        '''\treturn 0;\n}\n\n#define QCOM_ADRENO_SMMU_GPU_SID 0\n''',
+        '''\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-cfg exit rc=0");\n\treturn 0;\n}\n\n#define QCOM_ADRENO_SMMU_GPU_SID 0\n''',
+        'qcom cfg exit')
+    t = ro(t,
+        '''\tstruct qcom_smmu *qsmmu;\n\n\t/* Check to make sure qcom_scm has finished probing */\n\tif (!qcom_scm_is_available())\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n''',
+        '''\tstruct qcom_smmu *qsmmu;\n\tbool trace = smmu->dev->of_node &&\n\t\tof_device_is_compatible(smmu->dev->of_node, "qcom,qsmmu-v500");\n\tbool scm = qcom_scm_is_available();\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-create scm=%d", scm);\n\t/* Check to make sure qcom_scm has finished probing */\n\tif (!scm)\n\t\treturn ERR_PTR(-EPROBE_DEFER);\n''',
+        'qcom create scm')
+    t = ro(t,
+        '''\tqsmmu->smmu.impl = impl;\n\tdevm_kfree(smmu->dev, smmu);\n\n\treturn &qsmmu->smmu;\n}\n''',
+        '''\tqsmmu->smmu.impl = impl;\n\tdevm_kfree(smmu->dev, smmu);\n\n\tif (trace)\n\t\ta52_ackfr_record("SMMU parent-qcom-create rc=0");\n\treturn &qsmmu->smmu;\n}\n''',
+        'qcom create exit')
+    return t
+
+
+def apply(root):
+    for rel, fn in ((CORE, patch_core), (QCOM, patch_qcom)):
+        path = root / rel
+        old = path.read_text()
+        new = fn(old)
+        path.write_text(new)
+
+
+def self_test(root):
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for rel in (CORE, QCOM):
+            dst = tmp / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(root / rel, dst)
+        apply(tmp)
+        first = {rel: (tmp / rel).read_text() for rel in (CORE, QCOM)}
+        apply(tmp)
+        second = {rel: (tmp / rel).read_text() for rel in (CORE, QCOM)}
+        assert first == second
+        core = first[CORE]
+        qcom = first[QCOM]
+        for marker in (
+            'qcom,qsmmu-v500',
+            'SMMU parent-probe enter dev=%s',
+            'SMMU parent-reset enter skip=%d',
+            'SMMU parent-domain 3lvl ias=%lu',
+            'SMMU parent-probe exit rc=%d legacy=0',
+        ):
+            assert marker in core, marker
+        for marker in (
+            'SMMU parent-qcom-create scm=%d',
+            'SMMU parent-qcom-cfg enter groups=%u',
+            'SMMU parent-qcom-create rc=0',
+        ):
+            assert marker in qcom, marker
+        assert core.count('.compatible = "qcom,qsmmu-v500"') == 1
+        assert 'if (!skip_init)' in core
+        assert 'ias = min(ias, 39UL);' in core
+    print('phase203 qsmmuv500 compatibility patcher self-test: PASS')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--self-test', action='store_true')
+    args = ap.parse_args()
+    if args.self_test:
+        self_test(args.root)
+    else:
+        apply(args.root)
+        print('phase203 qsmmuv500 compatibility and parent trace applied')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/203_ci.sh
+++ b/scripts/203_ci.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-smmu-driver-core-trace"
+OUT="$PWD/artifacts/a52xq-apps-smmu-qsmmuv500-compat"
+BUILD="$PWD/workspace/gki-phase199-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+bash scripts/202_ci.sh
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+cp "$BUILD/.config" "$OUT/config/before-phase203.config"
+cp "$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c" \
+  "$OUT/stage/arm-smmu-before-phase203.c"
+cp "$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c" \
+  "$OUT/stage/arm-smmu-qcom-before-phase203.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-before-phase203.c"
+sha256sum \
+  "$ROOT/fs/pstore/ram.c" \
+  "$ROOT/init/main.c" \
+  "$ROOT/drivers/base/dd.c" \
+  "$ROOT/drivers/base/core.c" \
+  "$ROOT/drivers/base/platform.c" \
+  "$ROOT/drivers/of/device.c" \
+  "$ROOT/drivers/iommu/of_iommu.c" \
+  "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+  "$ROOT/drivers/a52_display/msm/msm_smmu.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+  "$ROOT/drivers/a52_display/msm/sde/sde_hw_catalog.c" \
+  "$ROOT/drivers/regulator/a52-legacy-gdsc-regulator.c" \
+  "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  > "$OUT/stage/phase202-invariants-before-phase203.sha256"
+
+python3 scripts/203_apply_apps_smmu_qsmmuv500_compat.py \
+  --root "$ROOT" --self-test | tee "$OUT/logs/phase203-patcher-self-test.log"
+python3 scripts/203_apply_apps_smmu_qsmmuv500_compat.py \
+  --root "$ROOT" | tee "$OUT/logs/phase203-apply.log"
+
+cp "$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c" \
+  "$OUT/stage/arm-smmu-after-phase203.c"
+cp "$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c" \
+  "$OUT/stage/arm-smmu-qcom-after-phase203.c"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-after-phase203.c"
+cp scripts/203_apply_apps_smmu_qsmmuv500_compat.py "$OUT/stage/"
+
+git -C "$ROOT" diff --check
+sha256sum -c "$OUT/stage/phase202-invariants-before-phase203.sha256"
+cmp "$OUT/config/before-phase203.config" "$BUILD/.config"
+cmp "$OUT/stage/recorder-before-phase203.c" "$OUT/stage/recorder-after-phase203.c"
+
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+core = (root / 'drivers/iommu/arm/arm-smmu/arm-smmu.c').read_text()
+qcom = (root / 'drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c').read_text()
+rec = (root / 'drivers/a52_secure/a52_ack_secure_flight_recorder.c').read_text()
+for marker in (
+    '{ .compatible = "qcom,qsmmu-v500", .data = &qcom_qsmmuv500 },',
+    'ARM_SMMU_MATCH_DATA(qcom_qsmmuv500, ARM_SMMU_V2, QCOM_SMMUV2);',
+    'arm_smmu_qsmmuv500_skip_init',
+    'if (!skip_init)',
+    'ias = min(ias, 39UL);',
+    'SMMU parent-probe enter dev=%s driver=%s',
+    'SMMU parent-dt version=%d model=%d girq=%u skip=%d lvl3=%d',
+    'SMMU parent-reset enter skip=%d groups=%u cbs=%u',
+    'SMMU parent-register rc=%d',
+    'SMMU parent-probe exit rc=%d legacy=0',
+):
+    assert marker in core, marker
+for marker in (
+    'SMMU parent-qcom-create scm=%d',
+    'SMMU parent-qcom-cfg enter groups=%u',
+    'SMMU parent-qcom-cfg exit rc=0',
+    'SMMU parent-qcom-create rc=0',
+):
+    assert marker in qcom, marker
+for marker in (
+    'copies=3 crc=crc32c',
+    '#define A52_R179_PREFIX "R99"',
+    'a52_r199_crc32c',
+    '!strncmp(message, "SMMU ", 5)',
+):
+    assert marker in rec, marker
+assert core.count('.compatible = "qcom,qsmmu-v500"') == 1
+assert 'iommu_bypass' not in (core + qcom).lower()
+assert 'qcom,skip-init' in core
+assert 'qcom,use-3-lvl-tables' in core
+PY
+
+git -C "$ROOT" diff --binary --no-ext-diff -- \
+  drivers/iommu/arm/arm-smmu/arm-smmu.c \
+  drivers/iommu/arm/arm-smmu/arm-smmu-qcom.c \
+  > "$OUT/stage/phase203-apps-smmu-qsmmuv500-compat.patch"
+test -s "$OUT/stage/phase203-apps-smmu-qsmmuv500-compat.patch"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase203-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase203-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase203-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase203-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+for marker in \
+  'qcom,qsmmu-v500' \
+  'SMMU parent-probe enter dev=%s driver=%s' \
+  'SMMU parent-dt version=%d model=%d girq=%u skip=%d lvl3=%d' \
+  'SMMU parent-qcom-create scm=%d' \
+  'SMMU parent-qcom-cfg enter groups=%u' \
+  'SMMU parent-reset enter skip=%d groups=%u cbs=%u' \
+  'SMMU parent-domain 3lvl ias=%lu' \
+  'SMMU parent-register rc=%d' \
+  'SMMU parent-probe exit rc=%d legacy=0' \
+  'DCORE suppliers rc=%d status=%d' \
+  'DRMCOMP smmu-match added node=%s' \
+  'BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source "$BASE_OUT/package/boot.img" \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+python3 "$OUT/tools/decode-a52-r199-crc32c-base.py" --self-test | \
+  tee "$OUT/logs/phase203-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r199-crc32c-triple.py" --self-test | \
+  tee "$OUT/logs/phase203-triple-decoder-self-test.log"
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 203 Lagoon Apps SMMU qsmmuv500 compatibility
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 202 hardware result:
+  - qcom,smmu_sde_unsec matched msmdrm_smmu and entered really_probe()
+  - its managed supplier link to 15000000.apps-smmu stayed dormant
+  - the parent Apps SMMU had no driver, causing repeated -EPROBE_DEFER
+
+Exact TouchGrass comparison:
+  - Lagoon Apps SMMU DT compatible is qcom,qsmmu-v500
+  - TouchGrass downstream arm-smmu explicitly matches qcom,qsmmu-v500
+  - pinned GKI arm-smmu did not match qcom,qsmmu-v500
+  - both kernels already have CONFIG_ARM_SMMU=y
+
+Phase 203 changes:
+  - add the missing qcom,qsmmu-v500 OF match to GKI's Qualcomm SMMUv2 path
+  - preserve TouchGrass qcom,skip-init semantics so live bootloader stream and
+    context-bank mappings are not cleared during reset
+  - preserve TouchGrass qcom,use-3-lvl-tables semantics by limiting stage-1
+    AArch64 IAS to 39 bits
+  - trace the parent probe, SCM readiness, hardware configuration, reset,
+    IOMMU registration and bus initialization
+  - preserve the Phase 202 child/device-link trace and Phase 201 dependency
+  - preserve three recorder copies, 32 RS symbols and CRC32C
+
+This is a narrow compatibility port, not a wholesale import of the downstream
+TouchGrass SMMU/TBU driver. No IOMMU bypass is added. DTB, DTBO, ramdisk, panel
+commands, display timing and display power policy remain unchanged.
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib, json
+from pathlib import Path
+root = Path('artifacts/a52xq-apps-smmu-qsmmuv500-compat')
+base = json.loads(Path('artifacts/a52xq-smmu-driver-core-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+base.update({
+    'status': 'a52-apps-smmu-qsmmuv500-compat-audited',
+    'phase': 203,
+    'base_phase': 202,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'phase199_crc32c_rs3_preserved': True,
+    'phase201_smmu_component_dependency_preserved': True,
+    'phase202_driver_core_trace_preserved': True,
+    'functional_change_from_phase202': 'lagoon-apps-smmu-qsmmuv500-minimal-compatibility',
+    'qcom_qsmmuv500_match_added': True,
+    'touchgrass_skip_init_semantics_preserved': True,
+    'touchgrass_3lvl_ias_semantics_preserved': True,
+    'full_touchgrass_tbu_driver_imported': False,
+    'iommu_bypass_added': False,
+    'supplier_dependency_relaxed': False,
+    'dtb_changed': False,
+    'dtbo_changed': False,
+    'panel_commands_changed': False,
+    'display_timing_changed': False,
+    'recorder_copy_count': 3,
+    'recorder_parity_symbols_per_copy': 32,
+    'recorder_crc': 'CRC32C',
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+})
+for key in (
+    'phase199_crc32c_rs3_preserved',
+    'phase201_smmu_component_dependency_preserved',
+    'phase202_driver_core_trace_preserved',
+    'qcom_qsmmuv500_match_added',
+    'touchgrass_skip_init_semantics_preserved',
+    'touchgrass_3lvl_ias_semantics_preserved',
+    'dtb_preserved', 'ramdisk_preserved', 'recovery_dtbo_preserved',
+):
+    assert base[key] is True, key
+assert base['iommu_bypass_added'] is False
+assert base['supplier_dependency_relaxed'] is False
+assert base['full_touchgrass_tbu_driver_imported'] is False
+assert base['recorder_copy_count'] == 3
+assert base['recorder_parity_symbols_per_copy'] == 32
+assert base['recorder_crc'] == 'CRC32C'
+(root / 'final-audit.json').write_text(json.dumps(base, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/203_ci_parent_trace.sh
+++ b/scripts/203_ci_parent_trace.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+python3 - <<'PY'
+from pathlib import Path
+p=Path('scripts/203_ci.sh')
+s=p.read_text()
+start=s.index("for marker in (\n    '{ .compatible = \"qcom,qsmmu-v500\"")
+end=s.index("for marker in (\n    'SMMU parent-qcom-create scm=%d'", start)
+core='''for marker in (\n    '{ .compatible = "qcom,qsmmu-v500", .data = &arm_mmu500 },',\n    'smmu->skip_init = of_property_read_bool',\n    'if (!smmu->skip_init)',\n    'if (smmu->use_3lvl_tables)',\n    'ias = min(ias, 39UL);',\n    'SMMU parent-probe enter dev=%s driver=%s',\n    'SMMU parent-dt rc=%d model=%d skip=%d lvl3=%d',\n    'SMMU parent-impl rc=%d',\n    'SMMU parent-cfg rc=%d groups=%u cbs=%u',\n    'SMMU parent-register rc=%d',\n    'SMMU parent-probe exit rc=%d',\n):\n    assert marker in core, marker\n'''
+s=s[:start]+core+s[end:]
+s=s.replace("for marker in (\n    'SMMU parent-qcom-create scm=%d',\n    'SMMU parent-qcom-cfg enter groups=%u',\n    'SMMU parent-qcom-cfg exit rc=0',\n    'SMMU parent-qcom-create rc=0',\n):", "for marker in (\n    'SMMU parent-qcom scm=%d',\n):")
+s=s.replace("'SMMU parent-dt version=%d model=%d girq=%u skip=%d lvl3=%d'", "'SMMU parent-dt rc=%d model=%d skip=%d lvl3=%d'")
+s=s.replace("'SMMU parent-qcom-create scm=%d'", "'SMMU parent-qcom scm=%d'")
+s=s.replace("  'SMMU parent-qcom-cfg enter groups=%u' \\\n", "")
+s=s.replace("  'SMMU parent-reset enter skip=%d groups=%u cbs=%u' \\\n", "")
+s=s.replace("  'SMMU parent-domain 3lvl ias=%lu' \\\n", "")
+s=s.replace("  'SMMU parent-probe exit rc=%d legacy=0' \\\n", "  'SMMU parent-probe exit rc=%d' \\\n")
+s=s.replace('phase203-apps-smmu-qsmmuv500-compat.patch','phase203-apps-smmu-parent-trace.patch')
+s=s.replace("'status': 'a52-apps-smmu-qsmmuv500-compat-audited'", "'status': 'a52-apps-smmu-parent-trace-audited'")
+s=s.replace("'functional_change_from_phase202': 'lagoon-apps-smmu-qsmmuv500-minimal-compatibility'", "'functional_change_from_phase202': 'none-diagnostic-parent-trace-only'")
+s=s.replace("'qcom_qsmmuv500_match_added': True,", "'qcom_qsmmuv500_match_preexisting': True,\n    'phase203_parent_trace_added': True,")
+s=s.replace("    'qcom_qsmmuv500_match_added',\n", "    'qcom_qsmmuv500_match_preexisting',\n    'phase203_parent_trace_added',\n")
+Path('/tmp/203_ci_runtime.sh').write_text(s)
+PY
+bash -n /tmp/203_ci_runtime.sh
+bash /tmp/203_ci_runtime.sh
+
+OUT="$PWD/artifacts/a52xq-apps-smmu-qsmmuv500-compat"
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 203 Lagoon Apps SMMU parent-probe trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 202 showed that the display context-bank child is deferred because its
+supplier 15000000.apps-smmu has no bound driver.
+
+Post-Phase-202 source verification found that qcom,qsmmu-v500 matching,
+qcom,skip-init preservation, and the 39-bit three-level table behavior already
+exist in the cumulative kernel. Phase 203 therefore changes no SMMU policy.
+
+Phase 203 records the parent probe entry, DT result, Qualcomm SCM readiness,
+implementation selection, hardware configuration, IOMMU registration, and
+probe completion. Phase 202 device-link tracing, the Phase 201 component gate,
+and the R99 three-copy RS32/CRC32C recorder remain unchanged.
+
+No IOMMU bypass or dependency relaxation is added. DTB, DTBO, ramdisk, panel
+commands, display timing, and power policy remain unchanged.
+
+Compile-audited, not hardware validated.
+EOF
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase 202 result

The display SMMU child reaches `really_probe()` but remains deferred because supplier `15000000.apps-smmu` has no bound driver.

## Corrected post-Phase-202 source finding

The cumulative kernel already contains the `qcom,qsmmu-v500` match, `qcom,skip-init` preservation, and the 39-bit three-level table behavior from earlier phases. Therefore Phase 203 does not add or alter SMMU compatibility policy.

## Phase 203

Add filtered diagnostics for the Apps SMMU parent probe: DT parsing, Qualcomm SCM readiness, implementation selection, hardware configuration, IOMMU registration, and probe completion.

The Phase 202 device-link trace, Phase 201 component dependency, and R99 three-copy RS32/CRC32C recorder remain unchanged. No IOMMU bypass, dependency relaxation, DTB, ramdisk, panel, timing, or power-policy change is included.