### PR TITLE
Trace Phase 210 first atomic commits with RS48

### DIFF
--- a/.github/workflows/210-a52-first-atomic-rs48.yml
+++ b/.github/workflows/210-a52-first-atomic-rs48.yml
@@ -1,0 +1,124 @@
+name: 210 - A52 first atomic recorder RS48
+
+run-name: Build Phase 210 first atomic recorder RS48
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-first-atomic-rs48-v1
+    paths:
+      - scripts/210_apply_first_atomic_rs48.py
+      - scripts/210_make_rs48_decoders.py
+      - scripts/210_ci.sh
+      - .github/workflows/210-a52-first-atomic-rs48.yml
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-first-atomic-rs48-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 210 first atomic recorder RS48
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+
+    steps:
+      - name: Check out Phase 210 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_runtime_fix_binary_audit.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/200_apply_smmu_defer_trace.py \
+            scripts/201_apply_smmu_component_dependency.py \
+            scripts/202_apply_driver_core_trace.py \
+            scripts/203_apply_apps_smmu_qsmmuv500_compat.py \
+            scripts/204_apply_apps_smmu_scm_handoff.py \
+            scripts/206_apply_smmu_display_contracts.py \
+            scripts/208_apply_secure_vmid.py \
+            scripts/210_apply_first_atomic_rs48.py \
+            scripts/210_make_rs48_decoders.py \
+            scripts/38_repack_a52_p1_boot.py
+          bash -n scripts/208_reconstruct_phase206_source.sh
+          bash -n scripts/209_prepare_phase206.sh
+          bash -n scripts/210_ci.sh
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 210
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_runtime_fix_binary_audit.py
+          bash scripts/209_prepare_phase206.sh
+          bash scripts/210_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-first-atomic-rs48-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-first-atomic-rs48
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 210 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-first-atomic-rs48-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-first-atomic-rs48
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/210-a52-first-atomic-rs48.yml
+++ b/.github/workflows/210-a52-first-atomic-rs48.yml
@@ -122,3 +122,5 @@ jobs:
           path: artifacts/a52xq-first-atomic-rs48
           if-no-files-found: error
           retention-days: 30
+
+# Push-trigger synchronization commit.

--- a/.github/workflows/210-a52-first-atomic-rs48.yml
+++ b/.github/workflows/210-a52-first-atomic-rs48.yml
@@ -12,6 +12,14 @@ on:
       - scripts/210_make_rs48_decoders.py
       - scripts/210_ci.sh
       - .github/workflows/210-a52-first-atomic-rs48.yml
+  pull_request:
+    branches:
+      - agent/a52-first-atomic-rs48-ci-base-v1
+    paths:
+      - scripts/210_apply_first_atomic_rs48.py
+      - scripts/210_make_rs48_decoders.py
+      - scripts/210_ci.sh
+      - .github/workflows/210-a52-first-atomic-rs48.yml
 
 permissions:
   contents: read
@@ -123,4 +131,4 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-# Push-trigger synchronization commit.
+# Trusted Phase 210 workflow shared by the CI base and feature branches.

--- a/scripts/210_apply_first_atomic_rs48.py
+++ b/scripts/210_apply_first_atomic_rs48.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+RECORDER_REL = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+ATOMIC_REL = Path('drivers/a52_display/msm/msm_atomic.c')
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f'{label}: expected one anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def replace_once_after(text: str, start_marker: str, old: str, new: str, label: str) -> str:
+    start = text.find(start_marker)
+    if start < 0:
+        raise RuntimeError(f'{label}: start marker missing')
+    pos = text.find(old, start)
+    if pos < 0:
+        raise RuntimeError(f'{label}: anchor missing after start marker')
+    return text[:pos] + new + text[pos + len(old):]
+
+
+def patch_recorder(text: str) -> str:
+    replacements = [
+        ('A52 GKI 5.10 display takeover recorder, phase 199.',
+         'A52 GKI 5.10 first-atomic recorder, phase 210.'),
+        ('#define pr_fmt(fmt) "A52R199: " fmt',
+         '#define pr_fmt(fmt) "A52R210: " fmt'),
+        ('#define A52_R179_COMMIT 0x5a52c199U',
+         '#define A52_R179_COMMIT 0x5a52c210U'),
+        ('#define A52_R179_VERSION 2U',
+         '#define A52_R179_VERSION 3U'),
+        ('#define A52_R179_RS_ROOTS 32U',
+         '#define A52_R179_RS_ROOTS 48U'),
+        ('#define A52_R179_DATA_BYTES 157U',
+         '#define A52_R179_DATA_BYTES 141U'),
+        ('#define A52_R179_PREFIX "R99"',
+         '#define A52_R179_PREFIX "R48"'),
+        ('#define A52_R179_PREFIX_BYTES 3U',
+         '#define A52_R179_PREFIX_BYTES 3U\n#define A52_R210_PACKED_MESSAGE_LEN 73U'),
+        ('\tchar message[A52_R179_MESSAGE_LEN - 1];',
+         '\tchar message[A52_R210_PACKED_MESSAGE_LEN];'),
+        ('\tmemcpy(data->magic, "A52R0199", sizeof(data->magic));',
+         '\tmemcpy(data->magic, "A52R0210", sizeof(data->magic));'),
+        ('a52_ackfr_record("BOOT rs=ready phase=199 roots=%u copies=3 crc=crc32c",',
+         'a52_ackfr_record("BOOT rs=ready phase=210 roots=%u copies=3 crc=crc32c",'),
+    ]
+    for old, new in replacements:
+        text = replace_once(text, old, new, old)
+    required = [
+        '#define A52_R179_BANK_CONSOLE BIT(0)',
+        '#define A52_R179_BANK_FTRACE BIT(1)',
+        '#define A52_R179_BANK_RECORD BIT(2)',
+        'a52_r179_persist_event(&event, A52_R179_BANK_ALL)',
+        '!strncmp(message, "DRMPOST ", 8)',
+        '__le32 crc32c;',
+    ]
+    for marker in required:
+        if marker not in text:
+            raise RuntimeError(f'recorder invariant missing: {marker}')
+    return text
+
+
+def patch_atomic(text: str) -> str:
+    text = replace_once(
+        text,
+        '#include "sde_trace.h"\n',
+        '#include "sde_trace.h"\n#include <linux/atomic.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'atomic includes',
+    )
+    text = replace_once(
+        text,
+        '#define MULTIPLE_CONN_DETECTED(x) (x > 1)\n',
+        '''#define MULTIPLE_CONN_DETECTED(x) (x > 1)\n\n#define A52_R210_TRACE_LIMIT 8\n\nstatic atomic_t a52_r210_commit_sequence = ATOMIC_INIT(0);\n\n#define A52_R210_REC_ID(enabled, id, fmt, ...) \\\n\tdo { \\\n\t\tif (enabled) \\\n\t\t\ta52_ackfr_record("DRMPOST 210 c=%u " fmt, \\\n\t\t\t\t\t  (unsigned int)(id), ##__VA_ARGS__); \\\n\t} while (0)\n\n#define A52_R210_REC(commit, fmt, ...) \\\n\tA52_R210_REC_ID((commit)->a52_trace, (commit)->a52_trace_id, \\\n\t\t\t  fmt, ##__VA_ARGS__)\n''',
+        'trace macro block',
+    )
+    text = replace_once(
+        text,
+        '\tbool nonblock;\n\tstruct kthread_work commit_work;\n',
+        '\tbool nonblock;\n\tbool a52_trace;\n\tu32 a52_trace_id;\n\tstruct kthread_work commit_work;\n',
+        'commit trace fields',
+    )
+
+    text = replace_once(
+        text,
+        '#endif\n\n\tdrm_atomic_helper_wait_for_fences(dev, state, false);\n\n\tkms->funcs->prepare_commit(kms, state);\n\n\tmsm_atomic_helper_commit_modeset_disables(dev, state);\n\n\tdrm_atomic_helper_commit_planes(dev, state,\n\t\t\t\tDRM_PLANE_COMMIT_ACTIVE_ONLY);\n\n\tmsm_atomic_helper_commit_modeset_enables(dev, state);\n',
+        '''#endif\n\n\tA52_R210_REC(c, "complete enter");\n\tA52_R210_REC(c, "fences wait enter");\n\tdrm_atomic_helper_wait_for_fences(dev, state, false);\n\tA52_R210_REC(c, "fences wait exit");\n\n\tA52_R210_REC(c, "prepare_commit enter");\n\tkms->funcs->prepare_commit(kms, state);\n\tA52_R210_REC(c, "prepare_commit exit");\n\n\tA52_R210_REC(c, "modeset_disable enter");\n\tmsm_atomic_helper_commit_modeset_disables(dev, state);\n\tA52_R210_REC(c, "modeset_disable exit");\n\n\tA52_R210_REC(c, "planes enter");\n\tdrm_atomic_helper_commit_planes(dev, state,\n\t\t\t\tDRM_PLANE_COMMIT_ACTIVE_ONLY);\n\tA52_R210_REC(c, "planes exit");\n\n\tA52_R210_REC(c, "modeset_enable enter");\n\tmsm_atomic_helper_commit_modeset_enables(dev, state);\n\tA52_R210_REC(c, "modeset_enable exit");\n''',
+        'complete commit early stages',
+    )
+    old_wait = '\tmsm_atomic_wait_for_commit_done(dev, state);\n'
+    if text.count(old_wait) < 1:
+        raise RuntimeError('wait commit done anchor missing')
+    text = text.replace(old_wait, '\tA52_R210_REC(c, "wait_done enter");\n\tmsm_atomic_wait_for_commit_done(dev, state);\n\tA52_R210_REC(c, "wait_done exit");\n', 1)
+    text = replace_once(
+        text,
+        '\tdrm_atomic_helper_cleanup_planes(dev, state);\n\n\tkms->funcs->complete_commit(kms, state);\n\n\tdrm_atomic_state_put(state);\n\n\tcommit_destroy(c);\n',
+        '''\tA52_R210_REC(c, "cleanup enter");\n\tdrm_atomic_helper_cleanup_planes(dev, state);\n\tA52_R210_REC(c, "cleanup exit");\n\n\tA52_R210_REC(c, "complete_cb enter");\n\tkms->funcs->complete_commit(kms, state);\n\tA52_R210_REC(c, "complete_cb exit");\n\n\tdrm_atomic_state_put(state);\n\n\tA52_R210_REC(c, "complete exit");\n\tcommit_destroy(c);\n''',
+        'complete commit tail',
+    )
+
+    text = replace_once(
+        text,
+        '\tint ret = -ECANCELED, i = 0, j = 0;\n\tbool nonblock;\n\n\t/* cache since work will kfree commit in non-blocking case */\n\tnonblock = commit->nonblock;\n',
+        '''\tint ret = -ECANCELED, i = 0, j = 0;\n\tbool nonblock;\n\tbool a52_trace;\n\tu32 a52_trace_id;\n\n\t/* cache since work may free commit in the non-blocking case */\n\tnonblock = commit->nonblock;\n\ta52_trace = commit->a52_trace;\n\ta52_trace_id = commit->a52_trace_id;\n\tA52_R210_REC_ID(a52_trace, a52_trace_id, "dispatch enter nb=%d",\n\t\t\t  nonblock);\n''',
+        'dispatch locals',
+    )
+    text = replace_once(
+        text,
+        '\t\t\t\t\tret = 0;\n',
+        '\t\t\t\t\tret = 0;\n\t\t\t\t\tA52_R210_REC_ID(a52_trace, a52_trace_id,\n\t\t\t\t\t\t\t  "dispatch queued crtc=%u",\n\t\t\t\t\t\t\t  crtc->base.id);\n',
+        'dispatch queued',
+    )
+    text = replace_once_after(
+        text,
+        'static void msm_atomic_commit_dispatch',
+        '\tif (ret) {\n',
+        '\tA52_R210_REC_ID(a52_trace, a52_trace_id, "dispatch result rc=%d", ret);\n\tif (ret) {\n',
+        'dispatch result',
+    )
+    text = replace_once(
+        text,
+        '\t\tcomplete_commit(commit);\n\t} else if (!nonblock) {\n\t\tkthread_flush_work(&commit->commit_work);\n\t}\n',
+        '''\t\tA52_R210_REC_ID(a52_trace, a52_trace_id, "dispatch fallback");\n\t\tcomplete_commit(commit);\n\t} else if (!nonblock) {\n\t\tA52_R210_REC_ID(a52_trace, a52_trace_id, "dispatch flush enter");\n\t\tkthread_flush_work(&commit->commit_work);\n\t\tA52_R210_REC_ID(a52_trace, a52_trace_id, "dispatch flush exit");\n\t}\n''',
+        'dispatch fallback/flush',
+    )
+
+    text = replace_once(
+        text,
+        '\tint i, ret;\n',
+        '\tint i, ret;\n\tint a52_trace_index;\n\tbool a52_trace;\n',
+        'atomic trace declarations',
+    )
+    text = replace_once(
+        text,
+        '#endif\n\n\tif (!priv || priv->shutdown_in_progress) {\n',
+        '''#endif\n\n\ta52_trace_index = atomic_inc_return(&a52_r210_commit_sequence);\n\ta52_trace = a52_trace_index <= A52_R210_TRACE_LIMIT;\n\tA52_R210_REC_ID(a52_trace, a52_trace_index,\n\t\t\t  "commit enter nb=%d", nonblock);\n\n\tif (!priv || priv->shutdown_in_progress) {\n\t\tA52_R210_REC_ID(a52_trace, a52_trace_index,\n\t\t\t\t  "commit reject priv=%d shutdown=%d",\n\t\t\t\t  !priv, priv ? priv->shutdown_in_progress : -1);\n''',
+        'atomic entry',
+    )
+    text = replace_once(
+        text,
+        '\tret = drm_atomic_helper_prepare_planes(dev, state);\n\tif (ret) {\n',
+        '\tret = drm_atomic_helper_prepare_planes(dev, state);\n\tA52_R210_REC_ID(a52_trace, a52_trace_index, "prepare_planes rc=%d", ret);\n\tif (ret) {\n',
+        'prepare planes',
+    )
+    text = replace_once(
+        text,
+        '\tc = commit_init(state, nonblock);\n\tif (!c) {\n',
+        '''\tc = commit_init(state, nonblock);\n\tif (c) {\n\t\tc->a52_trace = a52_trace;\n\t\tc->a52_trace_id = (u32)a52_trace_index;\n\t}\n\tA52_R210_REC_ID(a52_trace, a52_trace_index, "commit_init ok=%d", !!c);\n\tif (!c) {\n''',
+        'commit init',
+    )
+    text = replace_once(
+        text,
+        '\t/* Protection for prepare_fence callback */\nretry:\n',
+        '\tA52_R210_REC(c, "masks crtc=0x%x plane=0x%x",\n\t\t\tc->crtc_mask, c->plane_mask);\n\n\t/* Protection for prepare_fence callback */\nretry:\n\tA52_R210_REC(c, "conn_lock enter");\n',
+        'mask and lock entry',
+    )
+    text = replace_once(
+        text,
+        '\tret = drm_modeset_lock(&state->dev->mode_config.connection_mutex,\n\t\tstate->acquire_ctx);\n\n\tif (ret == -EDEADLK) {\n',
+        '''\tret = drm_modeset_lock(&state->dev->mode_config.connection_mutex,\n\t\tstate->acquire_ctx);\n\tA52_R210_REC(c, "conn_lock rc=%d", ret);\n\n\tif (ret == -EDEADLK) {\n''',
+        'lock result',
+    )
+    text = replace_once(
+        text,
+        '\t/* Start Atomic */\n\tspin_lock(&priv->pending_crtcs_event.lock);\n',
+        '\t/* Start Atomic */\n\tA52_R210_REC(c, "pending wait enter pc=0x%x pp=0x%x",\n\t\t\tpriv->pending_crtcs, priv->pending_planes);\n\tspin_lock(&priv->pending_crtcs_event.lock);\n',
+        'pending wait entry',
+    )
+    text = replace_once(
+        text,
+        '\tspin_unlock(&priv->pending_crtcs_event.lock);\n\n\tif (ret)\n',
+        '\tspin_unlock(&priv->pending_crtcs_event.lock);\n\tA52_R210_REC(c, "pending wait exit rc=%d", ret);\n\n\tif (ret)\n',
+        'pending wait exit',
+    )
+    text = replace_once(
+        text,
+        '\tWARN_ON(drm_atomic_helper_swap_state(state, false) < 0);\n',
+        '\tA52_R210_REC(c, "swap_state enter");\n\tWARN_ON(drm_atomic_helper_swap_state(state, false) < 0);\n\tA52_R210_REC(c, "swap_state exit");\n',
+        'swap state',
+    )
+    text = replace_once(
+        text,
+        '\tif (priv && priv->kms && priv->kms->funcs &&\n\t\t\tpriv->kms->funcs->prepare_fence)\n\t\tpriv->kms->funcs->prepare_fence(priv->kms, state);\n',
+        '''\tif (priv && priv->kms && priv->kms->funcs &&\n\t\t\tpriv->kms->funcs->prepare_fence) {\n\t\tA52_R210_REC(c, "prepare_fence enter");\n\t\tpriv->kms->funcs->prepare_fence(priv->kms, state);\n\t\tA52_R210_REC(c, "prepare_fence exit");\n\t}\n''',
+        'prepare fence',
+    )
+    text = replace_once(
+        text,
+        '\tdrm_atomic_state_get(state);\n\tmsm_atomic_commit_dispatch(dev, state, c);\n\n\tSDE_ATRACE_END("atomic_commit");\n\n\treturn 0;\n',
+        '''\tdrm_atomic_state_get(state);\n\tA52_R210_REC(c, "dispatch call");\n\tmsm_atomic_commit_dispatch(dev, state, c);\n\n\tSDE_ATRACE_END("atomic_commit");\n\tA52_R210_REC_ID(a52_trace, a52_trace_index, "commit return rc=0");\n\n\treturn 0;\n''',
+        'dispatch call and return',
+    )
+    text = replace_once(
+        text,
+        'err_free:\n\tkfree(c);\nerror:\n\tdrm_atomic_helper_cleanup_planes(dev, state);\n',
+        '''err_free:\n\tA52_R210_REC_ID(a52_trace, a52_trace_index, "commit err_free rc=%d", ret);\n\tkfree(c);\nerror:\n\tA52_R210_REC_ID(a52_trace, a52_trace_index, "commit error rc=%d", ret);\n\tdrm_atomic_helper_cleanup_planes(dev, state);\n''',
+        'atomic error paths',
+    )
+
+    required = [
+        'DRMPOST 210 c=%u',
+        'fences wait enter',
+        'pending wait enter',
+        'dispatch queued crtc=%u',
+        'commit return rc=0',
+    ]
+    for marker in required:
+        if marker not in text:
+            raise RuntimeError(f'atomic marker missing: {marker}')
+    return text
+
+
+def apply(root: Path) -> None:
+    recorder = root / RECORDER_REL
+    atomic = root / ATOMIC_REL
+    if not recorder.is_file() or not atomic.is_file():
+        raise RuntimeError('required source files are missing')
+    recorder.write_text(patch_recorder(recorder.read_text()), encoding='utf-8')
+    atomic.write_text(patch_atomic(atomic.read_text()), encoding='utf-8')
+
+
+def self_test(root: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix='a52-r210-') as tmp:
+        tmp_root = Path(tmp)
+        (tmp_root / RECORDER_REL).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_root / ATOMIC_REL).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_root / RECORDER_REL).write_text((root / RECORDER_REL).read_text(), encoding='utf-8')
+        (tmp_root / ATOMIC_REL).write_text((root / ATOMIC_REL).read_text(), encoding='utf-8')
+        apply(tmp_root)
+        rec = (tmp_root / RECORDER_REL).read_text()
+        atom = (tmp_root / ATOMIC_REL).read_text()
+        assert '#define A52_R179_RS_ROOTS 48U' in rec
+        assert '#define A52_R179_DATA_BYTES 141U' in rec
+        assert '#define A52_R179_PREFIX "R48"' in rec
+        assert 'char message[A52_R210_PACKED_MESSAGE_LEN];' in rec
+        assert 'DRMPOST 210 c=%u' in atom
+        print('phase210 RS48 and first-atomic patcher self-test: PASS')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path, required=True)
+    parser.add_argument('--self-test', action='store_true')
+    args = parser.parse_args()
+    if args.self_test:
+        self_test(args.root)
+    else:
+        apply(args.root)
+        print('Phase210 RS48 recorder and first-atomic trace applied')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/210_ci.sh
+++ b/scripts/210_ci.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-splash-takeover-trace"
+OUT="$PWD/artifacts/a52xq-first-atomic-rs48"
+BUILD="$PWD/workspace/gki-phase199-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+download_phase209() {
+  local zip="$PWD/workspace/phase209-success.zip"
+  rm -rf "$BASE_OUT" "$zip"
+  mkdir -p "$BASE_OUT" "$PWD/workspace"
+  curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+    -H "Authorization: Bearer ${GH_TOKEN}" \
+    -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/8833147831/zip" \
+    --output "$zip"
+  printf '%s  %s\n' \
+    31060a6f567843dc30e509cace7cfccc4c6d3f320f4e5dea1d4ea4e5bae4331b \
+    "$zip" | sha256sum -c -
+  unzip -q "$zip" -d "$BASE_OUT"
+  (cd "$BASE_OUT" && sha256sum -c SHA256SUMS)
+}
+
+download_phase209
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools}
+
+bash scripts/208_reconstruct_phase206_source.sh
+cp "$BASE_OUT/config/final.config" "$BUILD/.config"
+python3 scripts/208_apply_secure_vmid.py --root "$ROOT" --self-test \
+  | tee "$OUT/logs/phase208-patcher-self-test.log"
+python3 scripts/208_apply_secure_vmid.py --root "$ROOT" \
+  | tee "$OUT/logs/phase208-replay.log"
+git -C "$ROOT" apply --check "$PWD/patches/209-splash-takeover-trace.patch"
+git -C "$ROOT" apply "$PWD/patches/209-splash-takeover-trace.patch"
+
+cmp "$ROOT/drivers/a52_display/msm/sde/sde_kms.c" \
+    "$BASE_OUT/stage/sde-kms-after-phase209.c"
+cmp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+    "$BASE_OUT/stage/recorder-after-phase209.c"
+
+cp "$BUILD/.config" "$OUT/config/before-phase210.config"
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-before-phase210.c"
+cp "$ROOT/drivers/a52_display/msm/msm_atomic.c" \
+  "$OUT/stage/msm-atomic-before-phase210.c"
+
+python3 scripts/210_apply_first_atomic_rs48.py --root "$ROOT" --self-test \
+  | tee "$OUT/logs/phase210-patcher-self-test.log"
+python3 scripts/210_apply_first_atomic_rs48.py --root "$ROOT" \
+  | tee "$OUT/logs/phase210-apply.log"
+
+cp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+  "$OUT/stage/recorder-after-phase210.c"
+cp "$ROOT/drivers/a52_display/msm/msm_atomic.c" \
+  "$OUT/stage/msm-atomic-after-phase210.c"
+cp scripts/210_apply_first_atomic_rs48.py "$OUT/stage/"
+
+RECORDER="$OUT/stage/recorder-after-phase210.c"
+ATOMIC="$OUT/stage/msm-atomic-after-phase210.c"
+for marker in \
+  '#define A52_R179_BANK_CONSOLE BIT(0)' \
+  '#define A52_R179_BANK_FTRACE BIT(1)' \
+  '#define A52_R179_BANK_RECORD BIT(2)' \
+  '#define A52_R179_BANK_ALL' \
+  '#define A52_R179_RS_ROOTS 48U' \
+  '#define A52_R179_DATA_BYTES 141U' \
+  '#define A52_R179_CODE_BYTES (A52_R179_DATA_BYTES + A52_R179_RS_ROOTS)' \
+  '#define A52_R179_TEXT_BYTES 255U' \
+  '#define A52_R179_PREFIX "R48"' \
+  '#define A52_R210_PACKED_MESSAGE_LEN 73U' \
+  'A52R0210' \
+  '__le32 crc32c;' \
+  'a52_r199_crc32c' \
+  'a52_r179_persist_event(&event, A52_R179_BANK_ALL)' \
+  '!strncmp(message, "DRMPOST ", 8)' \
+  'phase=210 roots=%u copies=3 crc=crc32c'; do
+  grep -Fq "$marker" "$RECORDER"
+done
+
+for marker in \
+  'DRMPOST 210 c=%u ' \
+  'commit enter nb=%d' \
+  'prepare_planes rc=%d' \
+  'pending wait enter pc=0x%x pp=0x%x' \
+  'swap_state enter' \
+  'prepare_fence enter' \
+  'dispatch queued crtc=%u' \
+  'fences wait enter' \
+  'modeset_enable enter' \
+  'wait_done enter' \
+  'complete exit'; do
+  grep -Fq "$marker" "$ATOMIC"
+done
+
+git -C "$ROOT" diff --check
+cmp "$OUT/config/before-phase210.config" "$BUILD/.config"
+
+python3 scripts/210_make_rs48_decoders.py \
+  --source "$BASE_OUT/tools" --output "$OUT/tools" \
+  | tee "$OUT/logs/phase210-decoder-generation.log"
+python3 "$OUT/tools/decode-a52-r210-rs48-base.py" --self-test \
+  | tee "$OUT/logs/phase210-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r210-rs48-triple.py" --self-test \
+  | tee "$OUT/logs/phase210-triple-decoder-self-test.log"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+  > "$OUT/logs/phase210-olddefconfig.log" 2>&1
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase210.config" "$OUT/config/final.config"
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase210-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase210-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase210-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase210-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+test -s "$BUILD/vmlinux"
+nm "$BUILD/vmlinux" | grep -Eq ' [tT] msm_atomic_commit$'
+nm "$BUILD/vmlinux" | grep -Eq ' [tT] a52_ackfr_record$'
+for marker in \
+  'BOOT rs=ready phase=210 roots=%u copies=3 crc=crc32c' \
+  'R48' \
+  'A52R0210' \
+  'DRMPOST 210 c=%u commit enter nb=%d' \
+  'DRMPOST 210 c=%u fences wait enter' \
+  'DRMPOST 210 c=%u dispatch queued crtc=%u'; do
+  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+done
+
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source "$BASE_OUT/package/boot.img" \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 210 first-userspace-atomic recorder with RS48
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 210 preserves the Phase 209 display and secure-VMID behavior. It traces
+only the first eight msm_atomic_commit transactions, including plane
+preparation, pending-state waits, state swap, fence preparation, dispatch,
+complete_commit fence waits, plane/modeset stages and CRTC completion waits.
+All Phase 210 checkpoints begin with the retained DRMPOST prefix.
+
+Recorder format:
+  - three independent copies: record, console and ftrace
+  - 141 protected data bytes per copy
+  - 48 Reed-Solomon parity symbols per copy
+  - correction of up to 24 unknown corrupted byte symbols per copy
+  - CRC32C validation in every record
+  - R48 Base64 transport, 255 bytes per copy
+
+No display return value, userspace ABI, panel command, display timing, clock
+rate, regulator policy, DTB, DTBO, ramdisk, SMMU behavior or secure-memory
+behavior is changed. Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-first-atomic-rs48')
+base = json.loads(Path('artifacts/a52xq-splash-takeover-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+base.update({
+    'status': 'a52-first-atomic-rs48-audited',
+    'phase': 210,
+    'base_phase': 209,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'recorder_transport_changed': True,
+    'recorder_format': 'R48-base64-RS48-CRC32C',
+    'recorder_copy_count': 3,
+    'recorder_banks': ['record', 'console', 'ftrace'],
+    'recorder_data_bytes': 141,
+    'recorder_parity_symbols_per_copy': 48,
+    'recorder_max_unknown_symbol_corrections_per_copy': 24,
+    'recorder_crc': 'CRC32C',
+    'recorder_transport_bytes': 255,
+    'recorder_prefix': 'R48',
+    'trace_scope': 'first eight msm_atomic_commit transactions',
+    'trace_marker_prefix': 'DRMPOST 210',
+    'display_control_flow_changed': False,
+    'userspace_abi_changed': False,
+    'smmu_behavior_changed': False,
+    'secure_memory_behavior_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+})
+(root / 'final-audit.json').write_text(json.dumps(base, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)

--- a/scripts/210_ci.sh
+++ b/scripts/210_ci.sh
@@ -143,12 +143,13 @@ cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
 nm "$BUILD/vmlinux" | grep -Eq ' [tT] msm_atomic_commit$'
 nm "$BUILD/vmlinux" | grep -Eq ' [tT] a52_ackfr_record$'
 
+# The recorder magic is source-audited above. Clang may lower its memcpy into
+# immediate stores, so only runtime-visible strings are required in the Image.
 missing=0
 : > "$OUT/logs/phase210-binary-marker-audit.log"
 for marker in \
   'BOOT rs=ready phase=210 roots=%u copies=3 crc=crc32c' \
   'R48' \
-  'A52R0210' \
   'DRMPOST 210 c=%u commit enter nb=%d' \
   'DRMPOST 210 c=%u fences wait enter' \
   'DRMPOST 210 c=%u dispatch queued crtc=%u'; do

--- a/scripts/210_ci.sh
+++ b/scripts/210_ci.sh
@@ -139,8 +139,12 @@ fi
 
 test -s "$BUILD/arch/arm64/boot/Image"
 test -s "$BUILD/vmlinux"
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
 nm "$BUILD/vmlinux" | grep -Eq ' [tT] msm_atomic_commit$'
 nm "$BUILD/vmlinux" | grep -Eq ' [tT] a52_ackfr_record$'
+
+missing=0
+: > "$OUT/logs/phase210-binary-marker-audit.log"
 for marker in \
   'BOOT rs=ready phase=210 roots=%u copies=3 crc=crc32c' \
   'R48' \
@@ -148,10 +152,20 @@ for marker in \
   'DRMPOST 210 c=%u commit enter nb=%d' \
   'DRMPOST 210 c=%u fences wait enter' \
   'DRMPOST 210 c=%u dispatch queued crtc=%u'; do
-  grep -aFq "$marker" "$BUILD/arch/arm64/boot/Image"
+  if grep -aFq "$marker" "$OUT/compile/Image"; then
+    printf 'PASS %s\n' "$marker" | tee -a "$OUT/logs/phase210-binary-marker-audit.log"
+  else
+    printf 'FAIL %s\n' "$marker" | tee -a "$OUT/logs/phase210-binary-marker-audit.log"
+    missing=1
+  fi
 done
+if [ "$missing" -ne 0 ]; then
+  strings -a "$OUT/compile/Image" | \
+    grep -E 'A52R|BOOT rs=ready|DRMPOST 210|R48' \
+    > "$OUT/logs/phase210-related-image-strings.txt" || true
+  exit 1
+fi
 
-cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
 gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
 gzip -t "$OUT/package/Image.gz"
 python3 scripts/38_repack_a52_p1_boot.py \

--- a/scripts/210_make_rs48_decoders.py
+++ b/scripts/210_make_rs48_decoders.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f'{label}: expected one anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def build(source: Path, output: Path) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    core = (source / 'decode-a52-r179-rs-recorder.py').read_text()
+    base = (source / 'decode-a52-r199-crc32c-base.py').read_text()
+    triple = (source / 'decode-a52-r199-crc32c-triple.py').read_text()
+
+    core_repl = [
+        ('Decode the A52 phase-179 Reed-Solomon mirrored display recorder.',
+         'RS core adapted for the A52 Phase 210 R48 recorder.'),
+        ('b"R79" + base64(RS(157 data bytes + 32 parity bytes))',
+         'b"R48" + base64(RS(141 data bytes + 48 parity bytes))'),
+        ('PHASE = 179', 'PHASE = 210'),
+        ('PREFIX = b"R79"', 'PREFIX = b"R48"'),
+        ('DATA_BYTES = 157', 'DATA_BYTES = 141'),
+        ('PARITY_BYTES = 32', 'PARITY_BYTES = 48'),
+        ('MAGIC = b"A52R0179"', 'MAGIC = b"A52R0210"'),
+        ('VERSION = 1', 'VERSION = 3'),
+        ('COMMIT = 0x5A52C179', 'COMMIT = 0x5A52C210'),
+    ]
+    for old, new in core_repl:
+        core = replace_once(core, old, new, f'core {old}')
+    core_name = 'decode-a52-r210-rs48-core.py'
+    (output / core_name).write_text(core)
+
+    base_repl = [
+        ('Phase 199 CRC32C format adapter for the Phase 179 RS decoder core.',
+         'Phase 210 CRC32C adapter for the 48-parity RS decoder core.'),
+        ('decode-a52-r179-rs-recorder.py', core_name),
+        ('a52_r179_core_for_r199', 'a52_r210_rs48_core'),
+        ('PHASE = 199', 'PHASE = 210'),
+        ('PREFIX = b"R99"', 'PREFIX = b"R48"'),
+        ('MAGIC = b"A52R0199"', 'MAGIC = b"A52R0210"'),
+        ('VERSION = 2', 'VERSION = 3'),
+        ('COMMIT = 0x5A52C199', 'COMMIT = 0x5A52C210'),
+        ('RECORD_STRUCT = struct.Struct("<8sHHQQIIIHH16s89sII")',
+         'RECORD_STRUCT = struct.Struct("<8sHHQQIIIHH16s73sII")'),
+        ('message.encode("utf-8")[:89]', 'message.encode("utf-8")[:73]'),
+        ('message_bytes.ljust(89, b"\\0")', 'message_bytes.ljust(73, b"\\0")'),
+        ('rng = random.Random(0xA52199)', 'rng = random.Random(0xA52210)'),
+        ('for errors in (0, 1, 5, 16):', 'for errors in (0, 1, 8, 24):'),
+        ('phase199 CRC32C decoder self-test: PASS',
+         'phase210 RS48 CRC32C decoder self-test: PASS'),
+        ('Test the Phase 199 CRC32C RS decoder core',
+         'Test the Phase 210 RS48 CRC32C decoder core'),
+    ]
+    for old, new in base_repl:
+        base = replace_once(base, old, new, f'base {old}')
+    base_name = 'decode-a52-r210-rs48-base.py'
+    (output / base_name).write_text(base)
+
+    triple_repl = [
+        ('Decode the A52 Phase 199 triple-copy RS + CRC32C recorder.',
+         'Decode the A52 Phase 210 triple-copy RS48 + CRC32C recorder.'),
+        ('PHASE = 199', 'PHASE = 210'),
+        ('decode-a52-r199-crc32c-base.py', base_name),
+        ('a52_r199_crc32c_base', 'a52_r210_rs48_base'),
+        ('missing Phase 199 base decoder', 'missing Phase 210 RS48 base decoder'),
+        ('"status": "a52-r199-crc32c-rs-triple-decoded"',
+         '"status": "a52-r210-crc32c-rs48-triple-decoded"'),
+        ('BASE.encode_record_for_test(199, "DRMPOST triple-copy CRC self-test")',
+         'BASE.encode_record_for_test(210, "DRMPOST triple-copy CRC self-test")'),
+        ('rng = random.Random(0xA52199)', 'rng = random.Random(0xA52210)'),
+        ('selected = nonzero_positions[:60]', 'selected = nonzero_positions[:90]'),
+        ('selected[bank_index * 20 : (bank_index + 1) * 20]',
+         'selected[bank_index * 30 : (bank_index + 1) * 30]'),
+        ('record.seq == 199', 'record.seq == 210'),
+        ('phase199 triple-copy RS + CRC32C decoder self-test: PASS',
+         'phase210 triple-copy RS48 + CRC32C decoder self-test: PASS'),
+        ('Decode A52 Phase 199 triple-copy Reed-Solomon and CRC32C records',
+         'Decode A52 Phase 210 triple-copy RS48 and CRC32C records'),
+        ('Path("decoded-a52-r199")', 'Path("decoded-a52-r210-rs48")'),
+    ]
+    for old, new in triple_repl:
+        triple = replace_once(triple, old, new, f'triple {old}')
+    triple_name = 'decode-a52-r210-rs48-triple.py'
+    (output / triple_name).write_text(triple)
+
+    print(f'created {core_name}, {base_name}, {triple_name}')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--source', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    build(args.source, args.output)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Hardware finding

Phase 209 proves DRM registration, continuous-splash configuration, panel callback, plane update, late init and kernel heartbeats all complete. Android userspace runs, but no retained `sde_crtc_commit_kickoff` record appears during the captured interval.

## Phase 210

This change traces only the first eight `msm_atomic_commit` transactions through:

- plane preparation
- commit allocation and CRTC/plane masks
- connection mutex acquisition
- pending CRTC/plane wait
- atomic state swap
- output-fence preparation
- display-thread dispatch
- complete-commit fence wait
- prepare, disable, plane, enable and CRTC-completion stages

Every new checkpoint uses the retained `DRMPOST` prefix.

## Recorder upgrade

The protected recorder changes from 32 to 48 Reed-Solomon parity symbols per copy:

- three independent copies: record, console and ftrace
- 141 protected data bytes
- 48 RS parity symbols
- correction of up to 24 unknown corrupted byte symbols per copy
- CRC32C validation
- fixed 189-byte codeword and 255-byte `R48` Base64 transport

The artifact includes matching RS48 base and triple-copy decoders with self-tests.

## CI result

GitHub Actions run `30755513077` completed successfully.

Artifact:

`a52xq-first-atomic-rs48-8-NOT-HARDWARE-VALIDATED`

Artifact digest:

`sha256:3b33b63ce3d2382f45ec6bfe11406e205da34d88710a4be6aa80bb4914d79266`

Boot image digest:

`sha256:383958f6abc97a58e228d41e0420ac538f34d176a5b24985783ed02e87f4acd4`

The build reconstructed the full Phase 209 source chain, applied the Phase 210 patch, compiled and linked the kernel, passed the RS48 base and triple-copy decoder self-tests, verified the runtime recorder and atomic trace strings, preserved the DTB and ramdisk, repacked BOOT, and verified all packaged checksums.

## Scope controls

No display return value, panel command, timing, clock rate, regulator policy, DTB, DTBO, ramdisk, SMMU behavior, secure-memory behavior or userspace ABI is changed.

Draft and not hardware validated.