### PR TITLE
Trace Phase 212 graphics startup path

### DIFF
--- a/.github/workflows/212-a52-graphics-startup-trace.yml
+++ b/.github/workflows/212-a52-graphics-startup-trace.yml
@@ -1,0 +1,134 @@
+name: 212 - A52 graphics startup trace
+
+run-name: Build Phase 212 graphics startup trace
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-drm-core-trace-v1
+    paths:
+      - scripts/212_apply_graphics_startup_trace.py
+      - scripts/212_ci.sh
+      - .github/workflows/212-a52-graphics-startup-trace.yml
+  pull_request:
+    branches:
+      - agent/a52-drm-core-trace-ci-base-v1
+    paths:
+      - scripts/212_apply_graphics_startup_trace.py
+      - scripts/212_ci.sh
+      - .github/workflows/212-a52-graphics-startup-trace.yml
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-graphics-startup-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  SOURCE_ARTIFACT_ID: '8681171875'
+  SOURCE_ARTIFACT_SHA256: c9f6b0041abd5c9305d05534b1afcdf5ebee6de607ad08784721e364a2bf4c11
+  PHASE198_ARTIFACT_ID: '8819127383'
+  PHASE198_ARTIFACT_SHA256: 99ff045d09811d43106612ef2682216a7d29dfaa7825e2360bef403e31a41eb6
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  build-package:
+    name: Build Phase 212 graphics startup trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+
+    steps:
+      - name: Check out Phase 212 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile \
+            scripts/199_runtime_fix_crc_anchor_v2.py \
+            scripts/199_runtime_fix_binary_audit.py \
+            scripts/199_apply_recorder_crc32c.py \
+            scripts/200_apply_smmu_defer_trace.py \
+            scripts/201_apply_smmu_component_dependency.py \
+            scripts/202_apply_driver_core_trace.py \
+            scripts/203_apply_apps_smmu_qsmmuv500_compat.py \
+            scripts/204_apply_apps_smmu_scm_handoff.py \
+            scripts/206_apply_smmu_display_contracts.py \
+            scripts/208_apply_secure_vmid.py \
+            scripts/210_apply_first_atomic_rs48.py \
+            scripts/211_apply_drm_client_trace.py \
+            scripts/211_decode_r210_rs48_transport_fusion.py \
+            scripts/212_apply_graphics_startup_trace.py \
+            scripts/38_repack_a52_p1_boot.py
+          bash -n scripts/208_reconstruct_phase206_source.sh
+          bash -n scripts/209_prepare_phase206.sh
+          bash -n scripts/212_ci.sh
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build, package and audit Phase 212
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          test -d workspace/touchgrass-a52xq/.git
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "${TOUCHGRASS_COMMIT}"
+          python3 scripts/199_runtime_fix_crc_anchor_v2.py
+          python3 scripts/199_runtime_fix_binary_audit.py
+          bash scripts/209_prepare_phase206.sh
+          bash scripts/212_ci.sh
+
+      - name: Upload failed diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-graphics-startup-trace-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: artifacts/a52xq-graphics-startup-trace
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Phase 212 candidate
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: a52xq-graphics-startup-trace-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: artifacts/a52xq-graphics-startup-trace
+          if-no-files-found: error
+          retention-days: 30
+
+# Trusted Phase 212 workflow shared by the CI base and feature branches.

--- a/.github/workflows/212a-userspace-path-compare.yml
+++ b/.github/workflows/212a-userspace-path-compare.yml
@@ -1,0 +1,97 @@
+name: 212a - Userspace path comparison
+
+run-name: Compare graphics startup paths with TouchGrass
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - agent/a52-drm-core-trace-ci-base-v1
+    paths:
+      - .github/workflows/212a-userspace-path-compare.yml
+
+permissions:
+  contents: read
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  compare:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore pinned GKI source
+        id: gki-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "${TOUCHGRASS_REPO}"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Compare process and device-open paths
+        run: |
+          set -Eeuo pipefail
+          test '${{ steps.gki-cache.outputs.cache-hit }}' = true
+          GKI=gki/common
+          TG=workspace/touchgrass-a52xq
+          OUT=artifacts/userspace-path-comparison
+          mkdir -p "$OUT/gki" "$OUT/touchgrass" "$OUT/diffs"
+          test "$(git -C "$GKI" rev-parse HEAD)" = "$GKI_COMMON_SHA"
+          test "$(git -C "$TG" rev-parse HEAD)" = "$TOUCHGRASS_COMMIT"
+
+          files=(fs/open.c fs/namei.c fs/exec.c kernel/exit.c)
+          for file in "${files[@]}"; do
+            mkdir -p "$OUT/gki/$(dirname "$file")" "$OUT/touchgrass/$(dirname "$file")" "$OUT/diffs/$(dirname "$file")"
+            cp "$GKI/$file" "$OUT/gki/$file"
+            cp "$TG/$file" "$OUT/touchgrass/$file"
+            diff -u "$OUT/touchgrass/$file" "$OUT/gki/$file" > "$OUT/diffs/$file.diff" || true
+          done
+
+          {
+            echo "gki_commit=$GKI_COMMON_SHA"
+            echo "touchgrass_commit=$TOUCHGRASS_COMMIT"
+            echo
+            for file in "${files[@]}"; do
+              echo "== $file =="
+              sha256sum "$OUT/touchgrass/$file" "$OUT/gki/$file"
+              echo "hunks=$(grep -c '^@@' "$OUT/diffs/$file.diff" || true)"
+              echo "changed_lines=$(grep -Ec '^[+-][^+-]' "$OUT/diffs/$file.diff" || true)"
+              echo
+            done
+            echo "== GKI candidate anchors =="
+            grep -nE 'do_sys_openat2|do_filp_open|path_openat|do_execveat_common|begin_new_exec|do_exit' \
+              "$OUT/gki/fs/open.c" "$OUT/gki/fs/namei.c" "$OUT/gki/fs/exec.c" "$OUT/gki/kernel/exit.c" || true
+            echo
+            echo "== TouchGrass candidate anchors =="
+            grep -nE 'do_sys_open|do_filp_open|path_openat|do_execveat_common|begin_new_exec|do_exit' \
+              "$OUT/touchgrass/fs/open.c" "$OUT/touchgrass/fs/namei.c" "$OUT/touchgrass/fs/exec.c" "$OUT/touchgrass/kernel/exit.c" || true
+          } | tee "$OUT/report.txt"
+          test -s "$OUT/report.txt"
+
+      - name: Upload comparison
+        uses: actions/upload-artifact@v4
+        with:
+          name: userspace-path-comparison
+          path: artifacts/userspace-path-comparison
+          retention-days: 7

--- a/scripts/212_apply_graphics_startup_trace.py
+++ b/scripts/212_apply_graphics_startup_trace.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+OPEN_REL = Path('fs/open.c')
+EXEC_REL = Path('fs/exec.c')
+EXIT_REL = Path('kernel/exit.c')
+DRM_DRV_REL = Path('drivers/gpu/drm/drm_drv.c')
+DRM_FILE_REL = Path('drivers/gpu/drm/drm_file.c')
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f'{label}: expected one anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_open(text: str) -> str:
+    text = replace_once(text, '#include <linux/compat.h>\n',
+        '#include <linux/compat.h>\n#include <linux/atomic.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'open includes')
+    anchor = '#include <trace/hooks/syscall_check.h>\n\n'
+    helper = '''#include <trace/hooks/syscall_check.h>\n\n#define A52_R212_PATH_LIMIT 128\nstatic atomic_t a52_r212_path_sequence = ATOMIC_INIT(0);\n\nstatic bool a52_r212_interesting_path(const char *path)\n{\n\treturn path && (strstr(path, "/dev/dri/") ||\n\t\tstrstr(path, "/dev/graphics/") ||\n\t\tstrstr(path, "/dev/kgsl") ||\n\t\t!strcmp(path, "/dev/ion") ||\n\t\tstrstr(path, "/dev/dma_heap/") ||\n\t\tstrstr(path, "/sys/class/drm/"));\n}\n\n'''
+    text = replace_once(text, anchor, helper, 'open helper')
+    old = '''static long do_sys_openat2(int dfd, const char __user *filename,\n\t\t\t   struct open_how *how)\n{\n\tstruct open_flags op;\n\tint fd = build_open_flags(how, &op);\n\tstruct filename *tmp;\n\n\tif (fd)\n\t\treturn fd;\n\n\ttmp = getname(filename);\n\tif (IS_ERR(tmp))\n\t\treturn PTR_ERR(tmp);\n\n\tfd = get_unused_fd_flags(how->flags);\n\tif (fd >= 0) {\n\t\tstruct file *f = do_filp_open(dfd, tmp, &op);\n\t\tif (IS_ERR(f)) {\n\t\t\tput_unused_fd(fd);\n\t\t\tfd = PTR_ERR(f);\n\t\t} else {\n\t\t\tfsnotify_open(f);\n\t\t\tfd_install(fd, f);\n\t\t}\n\t}\n\tputname(tmp);\n\treturn fd;\n}\n'''
+    new = '''static long do_sys_openat2(int dfd, const char __user *filename,\n\t\t\t   struct open_how *how)\n{\n\tstruct open_flags op;\n\tint fd = build_open_flags(how, &op);\n\tstruct filename *tmp;\n\tunsigned int trace_id = 0;\n\tbool trace = false;\n\n\tif (fd)\n\t\treturn fd;\n\n\ttmp = getname(filename);\n\tif (IS_ERR(tmp))\n\t\treturn PTR_ERR(tmp);\n\n\tif (a52_r212_interesting_path(tmp->name)) {\n\t\ttrace_id = atomic_inc_return(&a52_r212_path_sequence);\n\t\ttrace = trace_id <= A52_R212_PATH_LIMIT;\n\t\tif (trace)\n\t\t\ta52_ackfr_record("DRMPOST 212 path n=%u p=%d c=%.16s %.32s",\n\t\t\t\t\t  trace_id, current->pid, current->comm, tmp->name);\n\t}\n\n\tfd = get_unused_fd_flags(how->flags);\n\tif (fd >= 0) {\n\t\tstruct file *f = do_filp_open(dfd, tmp, &op);\n\t\tif (IS_ERR(f)) {\n\t\t\tput_unused_fd(fd);\n\t\t\tfd = PTR_ERR(f);\n\t\t} else {\n\t\t\tfsnotify_open(f);\n\t\t\tfd_install(fd, f);\n\t\t}\n\t}\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 path-ret n=%u fd=%d", trace_id, fd);\n\tputname(tmp);\n\treturn fd;\n}\n'''
+    return replace_once(text, old, new, 'do_sys_openat2')
+
+
+def patch_exec(text: str) -> str:
+    text = replace_once(text, '#include <linux/io_uring.h>\n',
+        '#include <linux/io_uring.h>\n#include <linux/atomic.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'exec includes')
+    anchor = '#include <trace/events/sched.h>\n\n'
+    helper = '''#include <trace/events/sched.h>\n\n#define A52_R212_EXEC_LIMIT 96\nstatic atomic_t a52_r212_exec_sequence = ATOMIC_INIT(0);\n\nstatic bool a52_r212_graphics_exec(const char *path)\n{\n\treturn path && (strstr(path, "surfaceflinger") ||\n\t\tstrstr(path, "composer") || strstr(path, "display") ||\n\t\tstrstr(path, "gralloc") || strstr(path, "allocator") ||\n\t\tstrstr(path, "mapper"));\n}\n\n'''
+    text = replace_once(text, anchor, helper, 'exec helper')
+    old_start = '''static int do_execveat_common(int fd, struct filename *filename,\n\t\t\t      struct user_arg_ptr argv,\n\t\t\t      struct user_arg_ptr envp,\n\t\t\t      int flags)\n{\n\tstruct linux_binprm *bprm;\n\tint retval;\n\n\tif (IS_ERR(filename))\n\t\treturn PTR_ERR(filename);\n'''
+    new_start = '''static int do_execveat_common(int fd, struct filename *filename,\n\t\t\t      struct user_arg_ptr argv,\n\t\t\t      struct user_arg_ptr envp,\n\t\t\t      int flags)\n{\n\tstruct linux_binprm *bprm;\n\tint retval;\n\tunsigned int trace_id = 0;\n\tbool trace = false;\n\n\tif (IS_ERR(filename))\n\t\treturn PTR_ERR(filename);\n\n\tif (a52_r212_graphics_exec(filename->name)) {\n\t\ttrace_id = atomic_inc_return(&a52_r212_exec_sequence);\n\t\ttrace = trace_id <= A52_R212_EXEC_LIMIT;\n\t\tif (trace)\n\t\t\ta52_ackfr_record("DRMPOST 212 exec n=%u p=%d %.40s",\n\t\t\t\t\t  trace_id, current->pid, filename->name);\n\t}\n'''
+    text = replace_once(text, old_start, new_start, 'exec start')
+    old_out = '''out_free:\n\tfree_bprm(bprm);\n\nout_ret:\n\tputname(filename);\n\treturn retval;\n}\n'''
+    new_out = '''out_free:\n\tfree_bprm(bprm);\n\nout_ret:\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 exec-ret n=%u rc=%d c=%.16s",\n\t\t\t\t  trace_id, retval, current->comm);\n\tputname(filename);\n\treturn retval;\n}\n'''
+    return replace_once(text, old_out, new_out, 'exec out')
+
+
+def patch_exit(text: str) -> str:
+    text = replace_once(text, '#include <linux/sysfs.h>\n',
+        '#include <linux/sysfs.h>\n#include <linux/string.h>\n#include <linux/atomic.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'exit includes')
+    anchor = 'void __noreturn do_exit(long code)\n{\n\tstruct task_struct *tsk = current;\n\tint group_dead;\n'
+    replacement = '''#define A52_R212_EXIT_LIMIT 96\nstatic atomic_t a52_r212_exit_sequence = ATOMIC_INIT(0);\n\nstatic bool a52_r212_graphics_comm(const char *comm)\n{\n\treturn comm && (strstr(comm, "surfaceflinger") ||\n\t\tstrstr(comm, "composer") || strstr(comm, "display") ||\n\t\tstrstr(comm, "gralloc") || strstr(comm, "allocator") ||\n\t\tstrstr(comm, "mapper") || strstr(comm, "android.hardware"));\n}\n\nvoid __noreturn do_exit(long code)\n{\n\tstruct task_struct *tsk = current;\n\tint group_dead;\n\n\tif (a52_r212_graphics_comm(current->comm)) {\n\t\tunsigned int trace_id = atomic_inc_return(&a52_r212_exit_sequence);\n\t\tif (trace_id <= A52_R212_EXIT_LIMIT)\n\t\t\ta52_ackfr_record("DRMPOST 212 exit n=%u p=%d c=%.16s code=%ld",\n\t\t\t\t\t  trace_id, current->pid, current->comm, code);\n\t}\n'''
+    return replace_once(text, anchor, replacement, 'do_exit')
+
+
+def patch_drm_drv(text: str) -> str:
+    text = replace_once(text, '#include <linux/srcu.h>\n',
+        '#include <linux/srcu.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'drm drv include')
+    old_alloc_tail = '''\tminor->kdev = drm_sysfs_minor_alloc(minor);\n\tif (IS_ERR(minor->kdev))\n\t\treturn PTR_ERR(minor->kdev);\n\n\t*drm_minor_get_slot(dev, type) = minor;\n\treturn 0;\n}\n'''
+    new_alloc_tail = '''\tminor->kdev = drm_sysfs_minor_alloc(minor);\n\tif (IS_ERR(minor->kdev)) {\n\t\tr = PTR_ERR(minor->kdev);\n\t\ta52_ackfr_record("DRMPOST 212 node type=%u idx=%d sysfs=%d",\n\t\t\t\t  type, minor->index, r);\n\t\treturn r;\n\t}\n\n\ta52_ackfr_record("DRMPOST 212 node type=%u idx=%d name=%.16s",\n\t\t\t  type, minor->index, dev_name(minor->kdev));\n\t*drm_minor_get_slot(dev, type) = minor;\n\treturn 0;\n}\n'''
+    text = replace_once(text, old_alloc_tail, new_alloc_tail, 'minor alloc tail')
+    old_device_add = '''\tret = device_add(minor->kdev);\n\tif (ret)\n\t\tgoto err_debugfs;\n'''
+    new_device_add = '''\tret = device_add(minor->kdev);\n\ta52_ackfr_record("DRMPOST 212 node-add type=%u idx=%d rc=%d",\n\t\t\t  type, minor->index, ret);\n\tif (ret)\n\t\tgoto err_debugfs;\n'''
+    return replace_once(text, old_device_add, new_device_add, 'minor device add')
+
+
+def patch_drm_file(text: str) -> str:
+    text = replace_once(text, '#include <linux/slab.h>\n',
+        '#include <linux/slab.h>\n#include <linux/atomic.h>\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'drm file include')
+    text = replace_once(text, 'DEFINE_MUTEX(drm_global_mutex);\n',
+        'DEFINE_MUTEX(drm_global_mutex);\n\n#define A52_R212_DRM_OPEN_LIMIT 32\nstatic atomic_t a52_r212_drm_open_sequence = ATOMIC_INIT(0);\n',
+        'drm open counter')
+    old = '''int drm_open(struct inode *inode, struct file *filp)\n{\n\tstruct drm_device *dev;\n\tstruct drm_minor *minor;\n\tint retcode = 0;\n\tint need_setup = 0;\n\n\tminor = drm_minor_acquire(iminor(inode));\n\tif (IS_ERR(minor))\n\t\treturn PTR_ERR(minor);\n\n\tdev = minor->dev;\n\tif (drm_dev_needs_global_mutex(dev))\n\t\tmutex_lock(&drm_global_mutex);\n\n\tif (!atomic_fetch_inc(&dev->open_count))\n\t\tneed_setup = 1;\n\n\t/* share address_space across all char-devs of a single device */\n\tfilp->f_mapping = dev->anon_inode->i_mapping;\n\n\tretcode = drm_open_helper(filp, minor);\n\tif (retcode)\n\t\tgoto err_undo;\n\tif (need_setup) {\n\t\tretcode = drm_legacy_setup(dev);\n\t\tif (retcode) {\n\t\t\tdrm_close_helper(filp);\n\t\t\tgoto err_undo;\n\t\t}\n\t}\n\n\tif (drm_dev_needs_global_mutex(dev))\n\t\tmutex_unlock(&drm_global_mutex);\n\n\treturn 0;\n\nerr_undo:\n\tatomic_dec(&dev->open_count);\n\tif (drm_dev_needs_global_mutex(dev))\n\t\tmutex_unlock(&drm_global_mutex);\n\tdrm_minor_release(minor);\n\treturn retcode;\n}\n'''
+    new = '''int drm_open(struct inode *inode, struct file *filp)\n{\n\tstruct drm_device *dev;\n\tstruct drm_minor *minor;\n\tint retcode = 0;\n\tint need_setup = 0;\n\tunsigned int trace_id;\n\tbool trace;\n\n\ttrace_id = atomic_inc_return(&a52_r212_drm_open_sequence);\n\ttrace = trace_id <= A52_R212_DRM_OPEN_LIMIT;\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 drm-open n=%u id=%u p=%d",\n\t\t\t\t  trace_id, iminor(inode), current->pid);\n\n\tminor = drm_minor_acquire(iminor(inode));\n\tif (IS_ERR(minor)) {\n\t\tretcode = PTR_ERR(minor);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("DRMPOST 212 drm-acquire n=%u rc=%d",\n\t\t\t\t\t  trace_id, retcode);\n\t\treturn retcode;\n\t}\n\n\tdev = minor->dev;\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 drm-minor n=%u type=%u idx=%d power=%d",\n\t\t\t\t  trace_id, minor->type, minor->index,\n\t\t\t\t  dev->switch_power_state);\n\tif (drm_dev_needs_global_mutex(dev))\n\t\tmutex_lock(&drm_global_mutex);\n\n\tif (!atomic_fetch_inc(&dev->open_count))\n\t\tneed_setup = 1;\n\n\t/* share address_space across all char-devs of a single device */\n\tfilp->f_mapping = dev->anon_inode->i_mapping;\n\n\tretcode = drm_open_helper(filp, minor);\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 drm-helper n=%u rc=%d",\n\t\t\t\t  trace_id, retcode);\n\tif (retcode)\n\t\tgoto err_undo;\n\tif (need_setup) {\n\t\tretcode = drm_legacy_setup(dev);\n\t\tif (trace)\n\t\t\ta52_ackfr_record("DRMPOST 212 drm-setup n=%u rc=%d",\n\t\t\t\t\t  trace_id, retcode);\n\t\tif (retcode) {\n\t\t\tdrm_close_helper(filp);\n\t\t\tgoto err_undo;\n\t\t}\n\t}\n\n\tif (drm_dev_needs_global_mutex(dev))\n\t\tmutex_unlock(&drm_global_mutex);\n\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 drm-open-ret n=%u rc=0", trace_id);\n\treturn 0;\n\nerr_undo:\n\tatomic_dec(&dev->open_count);\n\tif (drm_dev_needs_global_mutex(dev))\n\t\tmutex_unlock(&drm_global_mutex);\n\tdrm_minor_release(minor);\n\tif (trace)\n\t\ta52_ackfr_record("DRMPOST 212 drm-open-ret n=%u rc=%d",\n\t\t\t\t  trace_id, retcode);\n\treturn retcode;\n}\n'''
+    return replace_once(text, old, new, 'drm_open')
+
+
+def patch_all(root: Path) -> None:
+    patches = [
+        (OPEN_REL, patch_open), (EXEC_REL, patch_exec), (EXIT_REL, patch_exit),
+        (DRM_DRV_REL, patch_drm_drv), (DRM_FILE_REL, patch_drm_file),
+    ]
+    for rel, func in patches:
+        path = root / rel
+        original = path.read_text(encoding='utf-8')
+        path.write_text(func(original), encoding='utf-8')
+    print('Phase212 graphics startup trace applied')
+
+
+def self_test(root: Path) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        test_root = Path(tmp)
+        for rel in [OPEN_REL, EXEC_REL, EXIT_REL, DRM_DRV_REL, DRM_FILE_REL]:
+            dst = test_root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text((root / rel).read_text(encoding='utf-8'), encoding='utf-8')
+        patch_all(test_root)
+        checks = {
+            OPEN_REL: ['DRMPOST 212 path n=%u', 'DRMPOST 212 path-ret n=%u'],
+            EXEC_REL: ['DRMPOST 212 exec n=%u', 'DRMPOST 212 exec-ret n=%u'],
+            EXIT_REL: ['DRMPOST 212 exit n=%u'],
+            DRM_DRV_REL: ['DRMPOST 212 node type=%u', 'DRMPOST 212 node-add type=%u'],
+            DRM_FILE_REL: ['DRMPOST 212 drm-open n=%u', 'DRMPOST 212 drm-helper n=%u'],
+        }
+        for rel, markers in checks.items():
+            text = (test_root / rel).read_text(encoding='utf-8')
+            for marker in markers:
+                if marker not in text:
+                    raise RuntimeError(f'missing marker {marker} in {rel}')
+        try:
+            patch_all(test_root)
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError('patcher accepted already-patched source')
+    print('phase212 graphics startup patcher self-test: PASS')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path, required=True)
+    parser.add_argument('--self-test', action='store_true')
+    args = parser.parse_args()
+    if args.self_test:
+        self_test(args.root)
+    else:
+        patch_all(args.root)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/212_ci.sh
+++ b/scripts/212_ci.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_OUT="$PWD/artifacts/a52xq-drm-client-trace"
+OUT="$PWD/artifacts/a52xq-graphics-startup-trace"
+BUILD="$PWD/workspace/gki-phase199-out"
+ROOT="$PWD/gki/common"
+mkdir -p "$OUT/logs"
+trap 'rc=$?; mkdir -p "$OUT/logs"; printf "line=%s\ncommand=%s\nreturn_code=%s\n" "$LINENO" "$BASH_COMMAND" "$rc" > "$OUT/logs/ci-failure.txt"; exit "$rc"' ERR
+
+download_phase211() {
+  local zip="$PWD/workspace/phase211-success.zip"
+  rm -rf "$BASE_OUT" "$zip"
+  mkdir -p "$BASE_OUT" "$PWD/workspace"
+  curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+    -H "Authorization: Bearer ${GH_TOKEN}" \
+    -H 'Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/8836666538/zip" \
+    --output "$zip"
+  printf '%s  %s\n' \
+    dd9a57c56b25d53f3d765373aef0032d1af6f9e6c53a4eaf7919bdaa4bf55d17 \
+    "$zip" | sha256sum -c -
+  unzip -q "$zip" -d "$BASE_OUT"
+  (cd "$BASE_OUT" && sha256sum -c SHA256SUMS)
+}
+
+download_phase211
+rm -rf "$OUT"
+cp -a "$BASE_OUT" "$OUT"
+rm -f "$OUT/SHA256SUMS"
+mkdir -p "$OUT"/{config,logs,stage,compile,package,tools,comparison}
+
+bash scripts/208_reconstruct_phase206_source.sh
+cp "$BASE_OUT/config/final.config" "$BUILD/.config"
+python3 scripts/208_apply_secure_vmid.py --root "$ROOT" --self-test \
+  | tee "$OUT/logs/phase208-patcher-self-test.log"
+python3 scripts/208_apply_secure_vmid.py --root "$ROOT" \
+  | tee "$OUT/logs/phase208-replay.log"
+git -C "$ROOT" apply --check "$PWD/patches/209-splash-takeover-trace.patch"
+git -C "$ROOT" apply "$PWD/patches/209-splash-takeover-trace.patch"
+python3 scripts/210_apply_first_atomic_rs48.py --root "$ROOT" --self-test \
+  | tee "$OUT/logs/phase210-patcher-self-test.log"
+python3 scripts/210_apply_first_atomic_rs48.py --root "$ROOT" \
+  | tee "$OUT/logs/phase210-replay.log"
+python3 scripts/211_apply_drm_client_trace.py --root "$ROOT" --self-test \
+  | tee "$OUT/logs/phase211-patcher-self-test.log"
+python3 scripts/211_apply_drm_client_trace.py --root "$ROOT" \
+  | tee "$OUT/logs/phase211-replay.log"
+
+cmp "$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c" \
+    "$BASE_OUT/stage/recorder-after-phase210.c"
+cmp "$ROOT/drivers/a52_display/msm/msm_atomic.c" \
+    "$BASE_OUT/stage/msm-atomic-after-phase210.c"
+cmp "$ROOT/drivers/a52_display/msm/msm_drv.c" \
+    "$BASE_OUT/stage/msm-drv-after-phase211.c"
+
+cp "$BUILD/.config" "$OUT/config/before-phase212.config"
+for file in \
+  fs/open.c \
+  fs/exec.c \
+  kernel/exit.c \
+  drivers/gpu/drm/drm_drv.c \
+  drivers/gpu/drm/drm_file.c; do
+  mkdir -p "$OUT/stage/before/$(dirname "$file")"
+  cp "$ROOT/$file" "$OUT/stage/before/$file"
+done
+
+python3 scripts/212_apply_graphics_startup_trace.py --root "$ROOT" --self-test \
+  | tee "$OUT/logs/phase212-patcher-self-test.log"
+python3 scripts/212_apply_graphics_startup_trace.py --root "$ROOT" \
+  | tee "$OUT/logs/phase212-apply.log"
+
+for file in \
+  fs/open.c \
+  fs/exec.c \
+  kernel/exit.c \
+  drivers/gpu/drm/drm_drv.c \
+  drivers/gpu/drm/drm_file.c; do
+  mkdir -p "$OUT/stage/after/$(dirname "$file")"
+  cp "$ROOT/$file" "$OUT/stage/after/$file"
+done
+cp scripts/212_apply_graphics_startup_trace.py "$OUT/stage/"
+
+cat > "$OUT/comparison/touchgrass-conclusions.txt" <<'EOF'
+Phase 212 was selected only after comparison with exact TouchGrass commit
+6bf351bdf18bdb228db79e66f14a7a9c0178e5d7 and pinned GKI commit
+f960ed27302b1ff8e61e152fc202554d778deccd.
+
+The comparison found no direct TouchGrass compatibility fix to copy:
+- MSM open, file operations, driver features and private ioctl table match.
+- Both DRM cores call the driver open callback after minor acquisition and
+  file allocation, before DRM master setup.
+- Both create card%d and renderD%d with the same major/minor ranges.
+- Both propagate DRM minor device_add failures through drm_dev_register.
+- TouchGrass disables DRM fbdev emulation and FB_MSM, so enabling those would
+  not reproduce the working kernel.
+- Open, exec and exit differences are normal 4.19-to-5.10 API evolution.
+
+Phase 212 is therefore observation-only and traces graphics-service execution,
+relevant device-path opens, DRM node publication, generic DRM open stages and
+graphics-related exits.
+EOF
+
+RECORDER="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+ATOMIC="$ROOT/drivers/a52_display/msm/msm_atomic.c"
+MSM_DRV="$ROOT/drivers/a52_display/msm/msm_drv.c"
+OPEN="$ROOT/fs/open.c"
+EXEC="$ROOT/fs/exec.c"
+EXIT="$ROOT/kernel/exit.c"
+DRM_DRV="$ROOT/drivers/gpu/drm/drm_drv.c"
+DRM_FILE="$ROOT/drivers/gpu/drm/drm_file.c"
+
+for marker in \
+  '#define A52_R179_RS_ROOTS 48U' \
+  '#define A52_R179_DATA_BYTES 141U' \
+  '#define A52_R179_PREFIX "R48"' \
+  'A52R0210' \
+  '__le32 crc32c;' \
+  'a52_r179_persist_event(&event, A52_R179_BANK_ALL)' \
+  '!strncmp(message, "DRMPOST ", 8)' \
+  'phase=210 roots=%u copies=3 crc=crc32c'; do
+  grep -Fq "$marker" "$RECORDER"
+done
+for marker in \
+  'DRMPOST 210 c=%u ' \
+  'commit enter nb=%d' \
+  'prepare_planes rc=%d' \
+  'dispatch queued crtc=%u'; do
+  grep -Fq "$marker" "$ATOMIC"
+done
+for marker in \
+  'DRMPOST 211 open n=%u pid=%d comm=%.16s' \
+  'DRMPOST 211 ioctl n=%u pid=%d nr=0x%x' \
+  'DRMPOST 211 check n=%u pid=%d comm=%.16s'; do
+  grep -Fq "$marker" "$MSM_DRV"
+done
+for marker in \
+  '#define A52_R212_PATH_LIMIT 128' \
+  '/dev/dri/' \
+  '/dev/graphics/' \
+  '/dev/kgsl' \
+  '/dev/dma_heap/' \
+  'DRMPOST 212 path n=%u p=%d c=%.16s %.32s' \
+  'DRMPOST 212 path-ret n=%u fd=%d'; do
+  grep -Fq "$marker" "$OPEN"
+done
+for marker in \
+  '#define A52_R212_EXEC_LIMIT 96' \
+  'surfaceflinger' \
+  'composer' \
+  'DRMPOST 212 exec n=%u p=%d %.40s' \
+  'DRMPOST 212 exec-ret n=%u rc=%d c=%.16s'; do
+  grep -Fq "$marker" "$EXEC"
+done
+for marker in \
+  '#define A52_R212_EXIT_LIMIT 96' \
+  'DRMPOST 212 exit n=%u p=%d c=%.16s code=%ld'; do
+  grep -Fq "$marker" "$EXIT"
+done
+for marker in \
+  'DRMPOST 212 node type=%u idx=%d name=%.16s' \
+  'DRMPOST 212 node-add type=%u idx=%d rc=%d'; do
+  grep -Fq "$marker" "$DRM_DRV"
+done
+for marker in \
+  '#define A52_R212_DRM_OPEN_LIMIT 32' \
+  'DRMPOST 212 drm-open n=%u id=%u p=%d' \
+  'DRMPOST 212 drm-minor n=%u type=%u idx=%d power=%d' \
+  'DRMPOST 212 drm-helper n=%u rc=%d' \
+  'DRMPOST 212 drm-open-ret n=%u rc=%d'; do
+  grep -Fq "$marker" "$DRM_FILE"
+done
+
+git -C "$ROOT" diff --check
+cmp "$OUT/config/before-phase212.config" "$BUILD/.config"
+
+python3 "$OUT/tools/decode-a52-r210-rs48-base.py" --self-test \
+  | tee "$OUT/logs/phase212-base-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r210-rs48-triple.py" --self-test \
+  | tee "$OUT/logs/phase212-triple-decoder-self-test.log"
+python3 "$OUT/tools/decode-a52-r210-rs48-transport-fusion.py" --self-test \
+  | tee "$OUT/logs/phase212-transport-fusion-decoder-self-test.log"
+
+CLANG="$(readlink -f "$(command -v clang)")"
+export PATH="$(dirname "$CLANG"):$PATH"
+export CROSS_COMPILE=aarch64-linux-gnu-
+export CLANG_TRIPLE=aarch64-linux-gnu-
+make -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig \
+  > "$OUT/logs/phase212-olddefconfig.log" 2>&1
+cp "$BUILD/.config" "$OUT/config/final.config"
+cmp "$OUT/config/before-phase212.config" "$OUT/config/final.config"
+
+set +e
+make -k -C "$ROOT" O="$BUILD" ARCH=arm64 LLVM=1 LLVM_IAS=1 -j4 \
+  KCFLAGS=-Wno-error=frame-larger-than Image \
+  > "$OUT/logs/phase212-compile.log" 2>&1
+rc=$?
+set -e
+printf '%s\n' "$rc" > "$OUT/compile/make-return-code.txt"
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+    "$OUT/logs/phase212-compile.log" | tail -n 300 || true
+  tail -n 500 "$OUT/logs/phase212-compile.log" || true
+  exit "$rc"
+fi
+if grep -nE '(^|: )(fatal error|error): |undefined reference to' \
+  "$OUT/logs/phase212-compile.log" > "$OUT/logs/compiler-errors.txt"; then
+  cat "$OUT/logs/compiler-errors.txt"
+  exit 1
+fi
+
+test -s "$BUILD/arch/arm64/boot/Image"
+test -s "$BUILD/vmlinux"
+cp "$BUILD/arch/arm64/boot/Image" "$OUT/compile/Image"
+nm "$BUILD/vmlinux" | grep -Eq ' [tT] msm_atomic_commit$'
+nm "$BUILD/vmlinux" | grep -Eq ' [tT] a52_ackfr_record$'
+nm "$BUILD/vmlinux" | grep -Eq ' [tT] do_sys_open$'
+nm "$BUILD/vmlinux" | grep -Eq ' [tT] drm_open$'
+
+missing=0
+: > "$OUT/logs/phase212-binary-marker-audit.log"
+for marker in \
+  'BOOT rs=ready phase=210 roots=%u copies=3 crc=crc32c' \
+  'R48' \
+  'DRMPOST 210 c=%u commit enter nb=%d' \
+  'DRMPOST 211 open n=%u pid=%d comm=%.16s' \
+  'DRMPOST 212 path n=%u p=%d c=%.16s %.32s' \
+  'DRMPOST 212 exec n=%u p=%d %.40s' \
+  'DRMPOST 212 exit n=%u p=%d c=%.16s code=%ld' \
+  'DRMPOST 212 node type=%u idx=%d name=%.16s' \
+  'DRMPOST 212 drm-open n=%u id=%u p=%d'; do
+  if grep -aFq "$marker" "$OUT/compile/Image"; then
+    printf 'PASS %s\n' "$marker" | tee -a "$OUT/logs/phase212-binary-marker-audit.log"
+  else
+    printf 'FAIL %s\n' "$marker" | tee -a "$OUT/logs/phase212-binary-marker-audit.log"
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  strings -a "$OUT/compile/Image" | \
+    grep -E 'BOOT rs=ready|DRMPOST 210|DRMPOST 211|DRMPOST 212|R48' \
+    > "$OUT/logs/phase212-related-image-strings.txt" || true
+  exit 1
+fi
+
+gzip -n -9 -c "$OUT/compile/Image" > "$OUT/package/Image.gz"
+gzip -t "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source "$BASE_OUT/package/boot.img" \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+
+cat > "$OUT/README-FIRST.txt" <<'EOF'
+A52 GKI 5.10 Phase 212 graphics-startup observation trace
+
+FLASH ONLY:
+  package/boot.img -> BOOT partition
+
+Phase 211 hardware evidence showed no MSM DRM open, ioctl, atomic-check or
+atomic-commit callback during more than 124 seconds. Before Phase 212, the exact
+TouchGrass and pinned GKI sources were compared. No direct TouchGrass fix was
+found in MSM DRM, generic DRM registration/open, node naming, fbdev settings,
+open, exec or exit behavior.
+
+Phase 212 therefore records the missing userspace-to-kernel boundary:
+  - actual DRM primary/render node indices, names and device_add results
+  - graphics-related execve attempts and return values
+  - opens and return values for /dev/dri, /dev/graphics, KGSL, ION, DMA heaps
+    and /sys/class/drm
+  - generic DRM-core open stages and return values
+  - graphics-related process exits
+  - all retained Phase 211 and Phase 210 trace points
+
+All new records use the retained DRMPOST prefix. No return value, userspace ABI,
+security decision, pathname result, display control flow, panel command, timing,
+clock rate, regulator policy, DTB, DTBO, ramdisk, SMMU behavior or secure-memory
+behavior is changed.
+
+Recorder remains unchanged:
+  - three independent copies: record, console and ftrace
+  - 141 protected data bytes
+  - 48 Reed-Solomon parity symbols per copy
+  - correction of up to 24 unknown corrupted byte symbols per copy
+  - CRC32C validation
+  - fixed 255-byte R48 transport
+
+Compile-audited, not hardware validated.
+EOF
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+root = Path('artifacts/a52xq-graphics-startup-trace')
+base = json.loads(Path('artifacts/a52xq-drm-client-trace/final-audit.json').read_text())
+repack = json.loads((root / 'package/repack-report.json').read_text())
+image = root / 'compile/Image'
+boot = root / 'package/boot.img'
+base.update({
+    'status': 'a52-graphics-startup-trace-audited',
+    'phase': 212,
+    'base_phase': 211,
+    'hardware_validated': False,
+    'flashable_candidate': True,
+    'recorder_transport_changed': False,
+    'recorder_format': 'R48-base64-RS48-CRC32C',
+    'touchgrass_comparison_completed': True,
+    'touchgrass_commit': '6bf351bdf18bdb228db79e66f14a7a9c0178e5d7',
+    'gki_commit': 'f960ed27302b1ff8e61e152fc202554d778deccd',
+    'direct_touchgrass_fix_found': False,
+    'trace_scope': {
+        'graphics_exec_attempts': 96,
+        'relevant_device_path_opens': 128,
+        'graphics_process_exits': 96,
+        'generic_drm_opens': 32,
+        'drm_node_publication': True,
+        'phase211_drm_client_trace_retained': True,
+        'phase210_atomic_commit_trace_retained': True,
+    },
+    'trace_marker_prefix': 'DRMPOST 212',
+    'display_control_flow_changed': False,
+    'userspace_abi_changed': False,
+    'security_decisions_changed': False,
+    'smmu_behavior_changed': False,
+    'secure_memory_behavior_changed': False,
+    'image_sha256': hashlib.sha256(image.read_bytes()).hexdigest(),
+    'boot_sha256': hashlib.sha256(boot.read_bytes()).hexdigest(),
+    'boot_bytes': boot.stat().st_size,
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+})
+(root / 'final-audit.json').write_text(json.dumps(base, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+    xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
+)


### PR DESCRIPTION
## Phase 211 hardware result

The Phase 211 capture recovered all 1,027 complete RS48 transports and heartbeats through 124.128 seconds, but no MSM DRM open, ioctl, atomic-check or atomic-commit callback. Ring order confirmed those records were not overwritten.

## TouchGrass comparison before Phase 212

The exact TouchGrass commit `6bf351bdf18bdb228db79e66f14a7a9c0178e5d7` was compared with pinned GKI `f960ed27302b1ff8e61e152fc202554d778deccd` before adding another recorder.

The comparison found no direct compatibility fix to copy:

- MSM open callback, file operations, driver features and private ioctl table match
- both DRM cores call the driver callback after minor acquisition and file allocation
- both publish `card%d` and `renderD%d` with the same minor ranges
- both propagate DRM minor `device_add()` failures through `drm_dev_register()`
- no competing DRM driver is enabled, so MSM remains `card0` / `renderD128`
- TouchGrass disables DRM fbdev emulation and `FB_MSM`; enabling them would not reproduce the working kernel
- open, pathname, exec and exit differences are normal 4.19-to-5.10 API evolution

## Phase 212

This observation-only phase traces the missing userspace-to-kernel boundary:

- actual DRM primary/render node indices, names and `device_add()` results
- graphics-related `execve` attempts and results
- opens and results for `/dev/dri`, `/dev/graphics`, KGSL, ION, DMA heaps and `/sys/class/drm`
- generic DRM-core open stages and results
- graphics-related process exits
- all Phase 211 and Phase 210 trace points remain enabled

Every new checkpoint begins with the retained `DRMPOST 212` prefix.

## Recorder

Unchanged from Phase 211:

- record, console and ftrace copies
- 141 protected data bytes
- 48 Reed-Solomon parity symbols per copy
- up to 24 unknown corrupted byte-symbol corrections per copy
- CRC32C validation
- fixed 255-byte `R48` transport

## CI result

GitHub Actions run `30760735840` completed successfully.

Artifact:

`a52xq-graphics-startup-trace-4-NOT-HARDWARE-VALIDATED`

Artifact SHA-256:

`6739b734cbf51d0b0e4279be606316d68117fd65e0f2e970e4662c573e6ea76d`

Boot image SHA-256:

`6acb4b4c5bc88cf0e61f9348aaa13d7591ca550a85f528c89112cfd07cb92a26`

The workflow reconstructed the verified Phase 211 source chain, passed the Phase 212 patcher self-test, passed the RS48 base, triple-copy and transport-fusion decoder tests, compiled and linked the kernel, verified all retained and new runtime markers, preserved the configuration, DTB, ramdisk and recovery DTBO, repacked BOOT, and verified every internal checksum.

## Scope controls

No return value, userspace ABI, security decision, pathname result, display control flow, panel command, timing, clock rate, regulator policy, DTB, DTBO, ramdisk, SMMU behavior or secure-memory behavior is changed.

Draft and not hardware validated.