### PR TITLE
Phase 227: retain ODSPOST after recorder capacity

### DIFF
--- a/.github/workflows/213-a52-ion-transaction-trace.yml
+++ b/.github/workflows/213-a52-ion-transaction-trace.yml
@@ -1,12 +1,12 @@
-name: 226 - A52 odsign gate RS48 recorder
+name: 227 - A52 ODSPOST retention RS48 recorder
 
-run-name: Build Phase 226 odsign post-fs-data gate recorder
+run-name: Build Phase 227 post-capacity ODSPOST retention candidate
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - agent/a52-phase226-odsign-gate-v1
+      - agent/a52-phase227-odspost-retention-v1
     paths:
       - .github/workflows/213-a52-ion-transaction-trace.yml
       - scripts/218_payload.py
@@ -15,13 +15,16 @@ on:
       - scripts/226_payload_chunks/**
       - scripts/226_design.md
       - scripts/226_trigger.txt
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/227_design.md
+      - scripts/227_trigger.txt
 
 permissions:
   contents: read
   actions: read
 
 concurrency:
-  group: a52-phase226-odsign-gate-${{ github.ref }}
+  group: a52-phase227-odspost-retention-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -35,15 +38,15 @@ env:
 
 jobs:
   build-package:
-    name: Build and audit Phase 226 odsign recorder
+    name: Build and audit Phase 227 ODSPOST retention
     runs-on: ubuntu-22.04
     timeout-minutes: 360
 
     steps:
-      - name: Check out Phase 226 branch
+      - name: Check out Phase 227 branch
         uses: actions/checkout@v4
 
-      - name: Materialize and verify Phase 213-226 scripts
+      - name: Materialize and verify Phase 213-227 scripts
         run: |
           set -Eeuo pipefail
           python3 scripts/213_payload.py
@@ -66,9 +69,11 @@ jobs:
           repaired = path.read_text(encoding='utf-8')
           if old in repaired or repaired.count(new) != 1:
               raise SystemExit('Phase 226 heartbeat audit repair failed')
-          print('Phase 217 heartbeat audit updated for Phase 226 limit 180U')
+          print('Phase 217 heartbeat audit updated for Phase 226/227 limit 180U')
           PY
-          cp scripts/218_phase217_wrapper.py \
+          mv scripts/218_phase217_wrapper.py \
+             scripts/218_phase217_wrapper_phase226.py
+          cp scripts/227_phase226_retention_wrapper.py \
              scripts/217_apply_graphics_service_trace.py
           sed -i 's|cp -a "$BASE_OUT" "$OUT"|cp -a "$BASE_OUT"/. "$OUT"/|' scripts/213_ci.sh
           grep -Fq 'cp -a "$BASE_OUT"/. "$OUT"/' scripts/213_ci.sh
@@ -103,8 +108,10 @@ jobs:
             scripts/224_apply_early_userspace_trace.py \
             scripts/225_apply_kgsl_late_state.py \
             scripts/226_apply_odsign_gate_trace.py \
-            scripts/218_phase217_wrapper.py \
+            scripts/218_phase217_wrapper_phase226.py \
+            scripts/227_phase226_retention_wrapper.py \
             scripts/217_apply_graphics_service_trace.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
           bash -n scripts/213_ci.sh
           bash -n scripts/214_ci.sh
           bash -n scripts/215_ci.sh
@@ -146,7 +153,8 @@ jobs:
             scripts/224_apply_early_userspace_trace.py \
             scripts/225_apply_kgsl_late_state.py \
             scripts/226_apply_odsign_gate_trace.py \
-            scripts/218_phase217_wrapper.py \
+            scripts/218_phase217_wrapper_phase226.py \
+            scripts/227_phase226_retention_wrapper.py \
             scripts/217_apply_graphics_service_trace.py \
             scripts/38_repack_a52_p1_boot.py
           bash -n scripts/208_reconstruct_phase206_source.sh
@@ -183,7 +191,7 @@ jobs:
           git -C workspace/touchgrass-a52xq fetch --depth=1 origin "${TOUCHGRASS_COMMIT}"
           git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
 
-      - name: Build, package and audit Phase 226
+      - name: Build, package and audit Phase 227
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -199,15 +207,35 @@ jobs:
           bash scripts/215_ci.sh
           bash scripts/216_ci.sh
           bash scripts/217_ci.sh
+
           OUT=artifacts/a52xq-graphics-startup-trace
           TRACE_ROOT=workspace/gki-phase199-src
           if test ! -f "$TRACE_ROOT/fs/exec.c"; then TRACE_ROOT=gki/common; fi
-          grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$TRACE_ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+          RECORDER="$TRACE_ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+          grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$RECORDER"
           grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$TRACE_ROOT/fs/exec.c"
           grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$TRACE_ROOT/kernel/exit.c"
           grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$TRACE_ROOT/fs/open.c"
           grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$TRACE_ROOT/fs/ioctl.c"
           grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$TRACE_ROOT/net/socket.c"
+          python3 - "$RECORDER" <<'PY'
+          from pathlib import Path
+          import sys
+          path = Path(sys.argv[1])
+          text = path.read_text(encoding='utf-8')
+          token = '!strncmp(message, "ODSPOST ", 8)'
+          if text.count(token) != 1:
+              raise SystemExit(
+                  f'{path}: expected exactly one ODSPOST retention entry, found {text.count(token)}'
+              )
+          if '#define A52_R179_CAPACITY 896U' not in text:
+              raise SystemExit(f'{path}: recorder capacity audit failed')
+          if 'if (!buffered && !critical)' not in text:
+              raise SystemExit(f'{path}: post-capacity gate audit failed')
+          print('Phase 227 source audit: ODSPOST retained after capacity exactly once')
+          PY
+
           for marker in \
             'ODSPOST 226 ts' \
             'ODSPOST 226 exec' \
@@ -219,20 +247,97 @@ jobs:
             'GFXPOST 225 ks2'; do
             grep -aFq "$marker" "$OUT/compile/Image"
           done
+
+          mkdir -p "$OUT/audit/phase227"
+          cp "$RECORDER" "$OUT/audit/phase227/a52_ack_secure_flight_recorder.c"
+          cp scripts/227_phase226_retention_wrapper.py "$OUT/audit/phase227/"
           cp scripts/226_design.md "$OUT/PHASE226-DESIGN.md"
           cp scripts/226_trigger.txt "$OUT/PHASE226-HARDWARE-TEST.txt"
-          printf '%s\n' \
-            'Phase 226 adds metadata-only odsign/odrefresh gate tracing.' \
-            'It does not bypass signing, publish completion properties, weaken fs-verity, or record payload buffers or key material.' \
-            >> "$OUT/README-FIRST.txt"
+          cp scripts/227_design.md "$OUT/PHASE227-DESIGN.md"
+          cp scripts/227_trigger.txt "$OUT/PHASE227-HARDWARE-TEST.txt"
+
+          python3 - "$OUT/final-audit.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+          path = Path(sys.argv[1])
+          data = json.loads(path.read_text(encoding='utf-8'))
+          data.update({
+              'phase': 227,
+              'base_phase': 226,
+              'functional_base_phase': 226,
+              'hardware_validated': False,
+              'status': 'phase227-odspost-retention-ci-audited-not-hardware-validated',
+              'trace_marker_prefix': 'ODSPOST 226',
+              'phase227_odspost_post_capacity_retained': True,
+              'phase227_change': 'recorder-post-capacity-retention-allowlist-only',
+              'phase227_behavior_changed': False,
+              'phase227_security_decisions_changed': False,
+              'phase227_recorder_capacity': 896,
+          })
+          retained = list(data.get('post_capacity_retention', []))
+          if 'ODSPOST' not in retained:
+              retained.append('ODSPOST')
+          data['post_capacity_retention'] = retained
+          limits = data.get('phase217_limits')
+          if isinstance(limits, dict):
+              limits['heartbeat'] = 180
+          data['phase226_trace_retained'] = True
+          data['phase225_kgsl_trace_retained'] = True
+          path.write_text(json.dumps(data, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
+          cat > "$OUT/README-FIRST.txt" <<'README'
+          A52 GKI 5.10 Phase 227 ODSPOST post-capacity retention candidate
+
+          FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:
+            package/boot.img -> BOOT partition
+
+          Phase 227 changes only the persistent recorder retention allowlist. It
+          retains the existing bounded `ODSPOST 226` odsign/odrefresh metadata
+          after the recorder's initial 896-record buffer is full. The Phase 226
+          probes and Phase 225 KGSL trace are unchanged.
+
+          It does not bypass odsign, weaken fs-verity, alter return values, publish
+          completion properties, change files, or record payload buffers, key
+          material, authentication data, or arbitrary paths.
+
+          CI-validated, not hardware-validated. Follow PHASE227-HARDWARE-TEST.txt.
+          README
+
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          out = Path('artifacts/a52xq-graphics-startup-trace')
+          identity = {
+              'phase': 227,
+              'git_sha': os.environ.get('GITHUB_SHA'),
+              'git_ref': os.environ.get('GITHUB_REF'),
+              'run_id': os.environ.get('GITHUB_RUN_ID'),
+              'run_number': os.environ.get('GITHUB_RUN_NUMBER'),
+              'hardware_validated': False,
+              'change': 'retain ODSPOST after recorder capacity',
+          }
+          (out / 'BUILD-IDENTITY.json').write_text(
+              json.dumps(identity, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
           (
             cd "$OUT"
             find . -type f ! -name SHA256SUMS -print0 \
               | sort -z \
               | xargs -0 sha256sum > SHA256SUMS
             grep -Fq './README-FIRST.txt' SHA256SUMS
+            grep -Fq './BUILD-IDENTITY.json' SHA256SUMS
+            grep -Fq './final-audit.json' SHA256SUMS
             grep -Fq './PHASE226-DESIGN.md' SHA256SUMS
-            grep -Fq './PHASE226-HARDWARE-TEST.txt' SHA256SUMS
+            grep -Fq './PHASE227-DESIGN.md' SHA256SUMS
+            grep -Fq './PHASE227-HARDWARE-TEST.txt' SHA256SUMS
+            grep -Fq './audit/phase227/a52_ack_secure_flight_recorder.c' SHA256SUMS
+            grep -Fq './audit/phase227/227_phase226_retention_wrapper.py' SHA256SUMS
             sha256sum -c SHA256SUMS
           )
 
@@ -240,16 +345,16 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-odsign-gate-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          name: a52xq-odspost-retention-${{ github.run_number }}-FAILED-DIAGNOSTICS
           path: artifacts/a52xq-graphics-startup-trace
           if-no-files-found: warn
           retention-days: 7
 
-      - name: Upload Phase 226 candidate
+      - name: Upload Phase 227 candidate
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: a52xq-odsign-gate-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          name: a52xq-odspost-retention-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
           path: artifacts/a52xq-graphics-startup-trace
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/213-a52-ion-transaction-trace.yml
+++ b/.github/workflows/213-a52-ion-transaction-trace.yml
@@ -18,6 +18,20 @@ on:
       - scripts/227_phase226_retention_wrapper.py
       - scripts/227_design.md
       - scripts/227_trigger.txt
+  pull_request:
+    branches:
+      - agent/a52-phase226-odsign-gate-v1
+    paths:
+      - .github/workflows/213-a52-ion-transaction-trace.yml
+      - scripts/218_payload.py
+      - scripts/218_phase217_wrapper.py.z64
+      - scripts/226_driver_chunks/**
+      - scripts/226_payload_chunks/**
+      - scripts/226_design.md
+      - scripts/226_trigger.txt
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/227_design.md
+      - scripts/227_trigger.txt
 
 permissions:
   contents: read

--- a/.github/workflows/227-dispatch-builder.yml
+++ b/.github/workflows/227-dispatch-builder.yml
@@ -1,0 +1,146 @@
+name: 227 - Dispatch ODSPOST retention builder
+
+run-name: Dispatch and monitor Phase 227 builder
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase227-odspost-retention-v1
+    paths:
+      - .github/workflows/227-dispatch-builder.yml
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: a52-phase227-dispatch
+  cancel-in-progress: true
+
+jobs:
+  dispatch-monitor:
+    name: Dispatch and monitor Phase 227 build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    env:
+      TARGET_WORKFLOW_ID: '325785868'
+      TARGET_REF: agent/a52-phase227-odspost-retention-v1
+      TARGET_PR: '128'
+
+    steps:
+      - name: Dispatch branch-local Phase 227 builder
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          printf 'started_at=%s\n' "$started_at" >> "$GITHUB_OUTPUT"
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW_ID}/dispatches" \
+            -d "{\"ref\":\"${TARGET_REF}\"}"
+          printf 'Phase 227 builder dispatched at %s\n' "$started_at"
+
+      - name: Locate and monitor dispatched build
+        id: monitor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STARTED_AT: ${{ steps.dispatch.outputs.started_at }}
+        run: |
+          set -Eeuo pipefail
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW_ID}/runs?branch=${TARGET_REF}&event=workflow_dispatch&per_page=20"
+          run_id=''
+          run_url=''
+
+          for attempt in $(seq 1 40); do
+            response="$(curl --fail --silent --show-error \
+              -H 'Accept: application/vnd.github+json' \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "$api")"
+            run_id="$(jq -r --arg started "$STARTED_AT" \
+              '.workflow_runs | map(select(.created_at >= $started)) | sort_by(.created_at) | last | .id // empty' \
+              <<<"$response")"
+            run_url="$(jq -r --arg started "$STARTED_AT" \
+              '.workflow_runs | map(select(.created_at >= $started)) | sort_by(.created_at) | last | .html_url // empty' \
+              <<<"$response")"
+            if [[ -n "$run_id" ]]; then
+              break
+            fi
+            sleep 15
+          done
+
+          if [[ -z "$run_id" ]]; then
+            echo 'Dispatched Phase 227 build run was not found.' >&2
+            exit 1
+          fi
+
+          printf 'run_id=%s\n' "$run_id" >> "$GITHUB_OUTPUT"
+          printf 'run_url=%s\n' "$run_url" >> "$GITHUB_OUTPUT"
+          echo "Monitoring run ${run_id}: ${run_url}"
+
+          run_api="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+          conclusion=''
+          for attempt in $(seq 1 720); do
+            response="$(curl --fail --silent --show-error \
+              -H 'Accept: application/vnd.github+json' \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "$run_api")"
+            status="$(jq -r '.status' <<<"$response")"
+            conclusion="$(jq -r '.conclusion // empty' <<<"$response")"
+            echo "run=${run_id} status=${status} conclusion=${conclusion:-pending}"
+            if [[ "$status" == completed ]]; then
+              break
+            fi
+            sleep 30
+          done
+
+          if [[ -z "$conclusion" ]]; then
+            echo 'Phase 227 build did not complete within the monitoring window.' >&2
+            exit 1
+          fi
+          printf 'conclusion=%s\n' "$conclusion" >> "$GITHUB_OUTPUT"
+
+          artifacts="$(curl --fail --silent --show-error \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100")"
+          artifact_id="$(jq -r '.artifacts | map(select(.expired == false)) | last | .id // empty' <<<"$artifacts")"
+          artifact_name="$(jq -r '.artifacts | map(select(.expired == false)) | last | .name // empty' <<<"$artifacts")"
+          printf 'artifact_id=%s\n' "$artifact_id" >> "$GITHUB_OUTPUT"
+          printf 'artifact_name=%s\n' "$artifact_name" >> "$GITHUB_OUTPUT"
+
+          if [[ "$conclusion" != success ]]; then
+            exit 1
+          fi
+
+      - name: Report result to PR 128
+        if: ${{ always() && steps.monitor.outputs.run_id != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.monitor.outputs.run_id }}
+          RUN_URL: ${{ steps.monitor.outputs.run_url }}
+          CONCLUSION: ${{ steps.monitor.outputs.conclusion }}
+          ARTIFACT_ID: ${{ steps.monitor.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ steps.monitor.outputs.artifact_name }}
+        run: |
+          set -Eeuo pipefail
+          body="Phase 227 builder finished.\n\n- Run: [${RUN_ID}](${RUN_URL})\n- Conclusion: \`${CONCLUSION:-unknown}\`\n- Artifact: \`${ARTIFACT_NAME:-none}\`\n- Artifact ID: \`${ARTIFACT_ID:-none}\`"
+          jq -n --arg body "$body" '{body:$body}' > comment.json
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${TARGET_PR}/comments" \
+            --data-binary @comment.json

--- a/.github/workflows/227-dispatch-builder.yml
+++ b/.github/workflows/227-dispatch-builder.yml
@@ -1,3 +1,4 @@
+# Dispatch generation 2: chained self-test root fixed
 name: 227 - Dispatch ODSPOST retention builder
 
 run-name: Dispatch and monitor Phase 227 builder

--- a/.github/workflows/227-dispatch-builder.yml
+++ b/.github/workflows/227-dispatch-builder.yml
@@ -1,4 +1,4 @@
-# Dispatch generation 2: chained self-test root fixed
+# Dispatch generation 3: inherited self-test waits for restored kernel root
 name: 227 - Dispatch ODSPOST retention builder
 
 run-name: Dispatch and monitor Phase 227 builder

--- a/.github/workflows/227-status-probe.yml
+++ b/.github/workflows/227-status-probe.yml
@@ -1,0 +1,58 @@
+# Status probe generation 1: Phase 227 root-aware build
+name: 227 - Report builder status
+
+run-name: Report Phase 227 builder status
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase227-odspost-retention-v1
+    paths:
+      - .github/workflows/227-status-probe.yml
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  report:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report latest Phase 227 target run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_WORKFLOW_ID: '325785868'
+          TARGET_REF: agent/a52-phase227-odspost-retention-v1
+          TARGET_PR: '128'
+        run: |
+          set -Eeuo pipefail
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW_ID}/runs?branch=${TARGET_REF}&per_page=10"
+          response="$(curl --fail-with-body --silent --show-error \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$api")"
+          count="$(jq -r '.total_count' <<<"$response")"
+          if [[ "$count" == 0 ]]; then
+            body='Phase 227 status probe: no target builder run is currently visible.'
+          else
+            run_id="$(jq -r '.workflow_runs[0].id' <<<"$response")"
+            run_url="$(jq -r '.workflow_runs[0].html_url' <<<"$response")"
+            event="$(jq -r '.workflow_runs[0].event' <<<"$response")"
+            status="$(jq -r '.workflow_runs[0].status' <<<"$response")"
+            conclusion="$(jq -r '.workflow_runs[0].conclusion // "pending"' <<<"$response")"
+            head_sha="$(jq -r '.workflow_runs[0].head_sha' <<<"$response")"
+            name="$(jq -r '.workflow_runs[0].name' <<<"$response")"
+            body="Direct Phase 227 status probe:\n\n- Workflow: \`${name}\`\n- Run: [${run_id}](${run_url})\n- Event: \`${event}\`\n- Status: \`${status}\`\n- Conclusion: \`${conclusion}\`\n- Head: \`${head_sha}\`"
+          fi
+          jq -n --arg body "$body" '{body:$body}' > comment.json
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${TARGET_PR}/comments" \
+            --data-binary @comment.json

--- a/scripts/227_design.md
+++ b/scripts/227_design.md
@@ -1,0 +1,45 @@
+# Phase 227: retain ODSPOST records after recorder capacity
+
+## Hardware evidence
+
+The Phase 226 hardware capture contains 1,028 CRC-validated RS48 records and
+reaches `/system/bin/odsign` at about 89.816 seconds. The retained timeline has
+odsign exec-entry at sequence 2833 and exec-return at sequence 2835. Sequence
+2834 was allocated between those two events but was not persisted. A further
+44 sequence numbers are allocated but absent while odsign is active.
+
+The recorder's initial buffered capacity is 896 records. After that boundary it
+persists only messages accepted by its critical-message allowlist. Phase 226
+compiled and executed the `ODSPOST 226` probes, but the allowlist contains the
+older BOOTPOST, GFXPOST, KEYPOST, IONPOST, SGPOST and UFPOST families and omits
+ODSPOST. Every Phase 226 event after capacity is therefore assigned a sequence
+number and then discarded before transport persistence.
+
+## Phase 227 change
+
+Add exactly one prefix to the existing post-capacity critical-message allowlist:
+
+```c
+!strncmp(message, "ODSPOST ", 8)
+```
+
+The complete Phase 226 odsign/odrefresh tracing and the retained Phase 225 KGSL
+tracing remain unchanged. CI requires the allowlist entry exactly once in the
+patched recorder source and requires all Phase 225/226 marker strings in the
+compiled ARM64 Image.
+
+## Safety
+
+This phase changes recorder retention only. It does not alter odsign,
+odrefresh, fs-verity, ART, APEX, Keystore, Binder, storage, KGSL, init, or any
+userspace-visible return value. It does not bypass verification, publish a
+completion property, change files, capture buffers, record key material, or
+expand path logging. Existing Phase 226 limits and fixed numeric path classes
+remain intact.
+
+## Expected decision evidence
+
+The next capture should retain `ODSPOST 226` exec/open/ioctl/connect/task-state
+records after sequence 896. Those records will distinguish a stable sleeping or
+futex wait from Binder/Keystore dependency, storage I/O wait, ART/APEX activity,
+or a successful odsign exit followed by the later apexd and KGSL boundary.

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -99,11 +99,18 @@ def self_test() -> None:
 
 
 def main() -> int:
+    base = Path(__file__).with_name("218_phase217_wrapper_phase226.py")
+
     if "--self-test" in sys.argv[1:]:
+        if base.is_file():
+            completed = subprocess.run(
+                [sys.executable, str(base), *sys.argv[1:]], check=False
+            )
+            if completed.returncode:
+                return completed.returncode
         self_test()
         return 0
 
-    base = Path(__file__).with_name("218_phase217_wrapper_phase226.py")
     if not base.is_file():
         raise SystemExit(f"missing Phase 226 base wrapper: {base}")
 

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Run the Phase 226 wrapper, then retain ODSPOST records after capacity."""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MARKER = "A52_PHASE226_ODSIGN_GATE_TRACE"
+ALLOW = '!strncmp(message, "ODSPOST ", 8)'
+ANCHOR_RE = re.compile(
+    r'(?m)^(?P<indent>[ \t]*)!strncmp\(message, "BOOTPOST ", 9\) \|\|$'
+)
+RELATIVE = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
+
+
+def patch_text(text: str, *, label: str) -> str:
+    if MARKER not in text:
+        raise RuntimeError(f"{label}: missing Phase 226 recorder marker")
+    count = text.count(ALLOW)
+    if count == 1:
+        return text
+    if count != 0:
+        raise RuntimeError(f"{label}: unexpected ODSPOST allowlist count {count}")
+    matches = list(ANCHOR_RE.finditer(text))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"{label}: expected one BOOTPOST allowlist anchor, found {len(matches)}"
+        )
+    match = matches[0]
+    insertion = match.group(0) + "\n" + match.group("indent") + ALLOW + " ||"
+    patched = text[:match.start()] + insertion + text[match.end():]
+    if patched.count(ALLOW) != 1:
+        raise RuntimeError(f"{label}: ODSPOST allowlist insertion failed")
+    return patched
+
+
+def candidate_sources(arguments: list[str]) -> list[Path]:
+    candidates: list[Path] = []
+    for value in arguments:
+        if value.startswith("-"):
+            continue
+        root = Path(value)
+        candidates.extend((root / RELATIVE, root / "a52_ack_secure_flight_recorder.c"))
+    candidates.extend(
+        (
+            Path("workspace/gki-phase199-src") / RELATIVE,
+            Path("gki/common") / RELATIVE,
+        )
+    )
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        key = candidate.resolve(strict=False)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(candidate)
+    return unique
+
+
+def patch_generated_source(arguments: list[str]) -> Path:
+    matches: list[Path] = []
+    for candidate in candidate_sources(arguments):
+        if not candidate.is_file():
+            continue
+        text = candidate.read_text(encoding="utf-8")
+        if MARKER in text:
+            matches.append(candidate)
+    if len(matches) != 1:
+        rendered = ", ".join(str(path) for path in matches) or "none"
+        raise RuntimeError(
+            f"expected one generated Phase 226 recorder source, found {len(matches)}: {rendered}"
+        )
+    target = matches[0]
+    original = target.read_text(encoding="utf-8")
+    patched = patch_text(original, label=str(target))
+    target.write_text(patched, encoding="utf-8")
+    verified = target.read_text(encoding="utf-8")
+    if verified.count(ALLOW) != 1:
+        raise RuntimeError(f"{target}: final ODSPOST retention audit failed")
+    return target
+
+
+def self_test() -> None:
+    fixture = (
+        "/* A52_PHASE226_ODSIGN_GATE_TRACE */\n"
+        "return !strncmp(message, \"GFXPOST \", 8) ||\n"
+        "       !strncmp(message, \"BOOTPOST \", 9) ||\n"
+        "       !strncmp(message, \"KMSPOST \", 8);\n"
+    )
+    patched = patch_text(fixture, label="self-test")
+    if patched.count(ALLOW) != 1:
+        raise AssertionError("Phase 227 retention self-test failed")
+    if patch_text(patched, label="self-test-idempotent") != patched:
+        raise AssertionError("Phase 227 retention patch is not idempotent")
+    print("Phase 227 ODSPOST post-capacity retention self-test: PASS")
+
+
+def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        self_test()
+        return 0
+
+    base = Path(__file__).with_name("218_phase217_wrapper_phase226.py")
+    if not base.is_file():
+        raise SystemExit(f"missing Phase 226 base wrapper: {base}")
+
+    completed = subprocess.run([sys.executable, str(base), *sys.argv[1:]], check=False)
+    if completed.returncode:
+        return completed.returncode
+
+    target = patch_generated_source(sys.argv[1:])
+    print(f"Phase 227 retained ODSPOST after recorder capacity in {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -103,8 +103,11 @@ def main() -> int:
 
     if "--self-test" in sys.argv[1:]:
         if base.is_file():
+            base_args = list(sys.argv[1:])
+            if "--root" not in base_args:
+                base_args[0:0] = ["--root", "."]
             completed = subprocess.run(
-                [sys.executable, str(base), *sys.argv[1:]], check=False
+                [sys.executable, str(base), *base_args], check=False
             )
             if completed.returncode:
                 return completed.returncode

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -102,10 +102,16 @@ def main() -> int:
     base = Path(__file__).with_name("218_phase217_wrapper_phase226.py")
 
     if "--self-test" in sys.argv[1:]:
-        if base.is_file():
-            base_args = list(sys.argv[1:])
-            if "--root" not in base_args:
-                base_args[0:0] = ["--root", "."]
+        base_args = list(sys.argv[1:])
+        root: Path | None = None
+        for index, value in enumerate(base_args):
+            if value == "--root" and index + 1 < len(base_args):
+                root = Path(base_args[index + 1])
+                break
+            if value.startswith("--root="):
+                root = Path(value.split("=", 1)[1])
+                break
+        if base.is_file() and root is not None and (root / "fs/open.c").is_file():
             completed = subprocess.run(
                 [sys.executable, str(base), *base_args], check=False
             )

--- a/scripts/227_trigger.txt
+++ b/scripts/227_trigger.txt
@@ -1,0 +1,13 @@
+PHASE 227 HARDWARE TEST
+
+1. Flash the packaged boot.img.
+2. Boot with USB disconnected.
+3. Do not interact with the phone for at least 210 seconds.
+4. Enter recovery without allowing another normal Android boot.
+5. Collect every file under /sys/fs/pstore/ and preserve the raw 1 MiB image.
+6. Repeat at least three times because the odsign boundary is timing-sensitive.
+7. Preserve captures from boots that reach the UI as well as boots that stall.
+
+Phase 227 changes recorder retention only. It does not bypass odsign or weaken
+verification. The candidate is not hardware validated until a fresh capture
+contains retained ODSPOST 226 records after the 896-record capacity boundary.


### PR DESCRIPTION
## Hardware evidence

The Phase 226 hardware capture contains 1,028 CRC-validated RS48 records and reaches `/system/bin/odsign` at about 89.816 seconds. Odsign exec-entry is sequence 2833 and exec-return is sequence 2835, so sequence 2834 was allocated between the Phase 226 probe points but was not persisted. Another 44 sequence numbers are allocated but absent while odsign is active.

The recorder's initial capacity is 896. Beyond it, only allowlisted critical prefixes are persisted. The compiled and executing Phase 226 probes use `ODSPOST`, but that prefix was missing from the retention allowlist.

## Change

Add exactly one recorder retention prefix:

```c
!strncmp(message, "ODSPOST ", 8)
```

Retain the complete Phase 226 odsign/odrefresh instrumentation and Phase 225 KGSL trace unchanged. Add source, binary-marker, manifest and package-identity CI audits.

## Safety

This changes recorder persistence only. It does not alter odsign, odrefresh, fs-verity, ART, APEX, Keystore, Binder, storage, init, KGSL, files or return values. It does not bypass verification or record buffers, keys, authentication material or arbitrary paths.

The candidate remains not hardware validated until a fresh capture contains `ODSPOST 226` records beyond the 896-record capacity boundary.