### PR TITLE
Phase 228: cumulative vold, ODS and graphics checkpoints

### DIFF
--- a/.github/workflows/228-dispatch-after-marker-fix.yml
+++ b/.github/workflows/228-dispatch-after-marker-fix.yml
@@ -1,0 +1,29 @@
+name: 228 - Dispatch corrected packaging after marker fix
+
+on:
+  push:
+    branches:
+      - agent/a52-phase228-tritrack-snapshot-v1
+    paths:
+      - .github/workflows/228-dispatch-after-marker-fix.yml
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Dispatch corrected Phase 228 workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/327630871/dispatches" \
+            -d '{"ref":"agent/a52-phase228-tritrack-snapshot-v1"}'

--- a/.github/workflows/228-dispatch-builder.yml
+++ b/.github/workflows/228-dispatch-builder.yml
@@ -166,7 +166,7 @@ jobs:
 
           grep -aFq 'TRIPOST 228' "$ROOT/compile/Image"
           grep -aFq 'ODSPOST 226' "$ROOT/compile/Image"
-          grep -aFq '/system/bin/surfaceflinger' "$ROOT/compile/Image"
+          grep -aFq 'surfaceflinger' "$ROOT/compile/Image"
           grep -aFq 'GFXPOST 225 ks1' "$ROOT/compile/Image"
           grep -aFq 'GFXPOST 225 ks2' "$ROOT/compile/Image"
 

--- a/.github/workflows/228-dispatch-builder.yml
+++ b/.github/workflows/228-dispatch-builder.yml
@@ -1,0 +1,266 @@
+name: 228 - Dispatch tri-track snapshot builder
+
+run-name: Build and audit Phase 228 tri-track snapshot candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase228-tritrack-snapshot-v1
+    paths:
+      - .github/workflows/228-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/228_design.md
+      - scripts/228_trigger.txt
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: a52-phase228-tritrack
+  cancel-in-progress: true
+
+jobs:
+  dispatch-build-rebrand:
+    name: Dispatch, verify and package Phase 228
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    env:
+      TARGET_WORKFLOW_ID: '325785868'
+      TARGET_REF: agent/a52-phase228-tritrack-snapshot-v1
+
+    steps:
+      - name: Check out Phase 228 branch
+        uses: actions/checkout@v4
+
+      - name: Verify Phase 228 patcher
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile scripts/227_phase226_retention_wrapper.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+          grep -Fq 'A52_PHASE228_TRI_TRACK_SNAPSHOT' scripts/227_phase226_retention_wrapper.py
+          grep -Fq 'TRIPOST 228' scripts/227_phase226_retention_wrapper.py
+          grep -Fq 'RS(255,207)' scripts/228_design.md
+
+      - name: Dispatch inherited pinned kernel builder
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          printf 'started_at=%s\n' "$started_at" >> "$GITHUB_OUTPUT"
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW_ID}/dispatches" \
+            -d "{\"ref\":\"${TARGET_REF}\"}"
+
+      - name: Locate and monitor inherited build
+        id: monitor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STARTED_AT: ${{ steps.dispatch.outputs.started_at }}
+        run: |
+          set -Eeuo pipefail
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW_ID}/runs?branch=${TARGET_REF}&event=workflow_dispatch&per_page=20"
+          run_id=''
+          run_url=''
+
+          for attempt in $(seq 1 40); do
+            response="$(curl --fail --silent --show-error \
+              -H 'Accept: application/vnd.github+json' \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "$api")"
+            run_id="$(jq -r --arg started "$STARTED_AT" \
+              '.workflow_runs | map(select(.created_at >= $started)) | sort_by(.created_at) | last | .id // empty' \
+              <<<"$response")"
+            run_url="$(jq -r --arg started "$STARTED_AT" \
+              '.workflow_runs | map(select(.created_at >= $started)) | sort_by(.created_at) | last | .html_url // empty' \
+              <<<"$response")"
+            if [[ -n "$run_id" ]]; then
+              break
+            fi
+            sleep 15
+          done
+
+          if [[ -z "$run_id" ]]; then
+            echo 'Dispatched Phase 228 source build was not found.' >&2
+            exit 1
+          fi
+
+          printf 'run_id=%s\n' "$run_id" >> "$GITHUB_OUTPUT"
+          printf 'run_url=%s\n' "$run_url" >> "$GITHUB_OUTPUT"
+          echo "Monitoring ${run_url}"
+
+          run_api="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+          conclusion=''
+          for attempt in $(seq 1 720); do
+            response="$(curl --fail --silent --show-error \
+              -H 'Accept: application/vnd.github+json' \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "$run_api")"
+            status="$(jq -r '.status' <<<"$response")"
+            conclusion="$(jq -r '.conclusion // empty' <<<"$response")"
+            echo "run=${run_id} status=${status} conclusion=${conclusion:-pending}"
+            if [[ "$status" == completed ]]; then
+              break
+            fi
+            sleep 30
+          done
+
+          if [[ "$conclusion" != success ]]; then
+            echo "Inherited builder conclusion: ${conclusion:-missing}" >&2
+            exit 1
+          fi
+          printf 'conclusion=%s\n' "$conclusion" >> "$GITHUB_OUTPUT"
+
+          artifacts="$(curl --fail --silent --show-error \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100")"
+          artifact_id="$(jq -r '.artifacts | map(select(.expired == false)) | last | .id // empty' <<<"$artifacts")"
+          artifact_name="$(jq -r '.artifacts | map(select(.expired == false)) | last | .name // empty' <<<"$artifacts")"
+          if [[ -z "$artifact_id" ]]; then
+            echo 'Successful inherited build produced no artifact.' >&2
+            exit 1
+          fi
+          printf 'artifact_id=%s\n' "$artifact_id" >> "$GITHUB_OUTPUT"
+          printf 'artifact_name=%s\n' "$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - name: Download, audit and rebrand Phase 228
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.monitor.outputs.artifact_id }}
+          SOURCE_RUN_ID: ${{ steps.monitor.outputs.run_id }}
+          SOURCE_RUN_URL: ${{ steps.monitor.outputs.run_url }}
+        run: |
+          set -Eeuo pipefail
+          rm -rf inherited phase228-out inherited.zip
+          curl --fail --location --silent --show-error \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" \
+            -o inherited.zip
+          mkdir inherited
+          unzip -q inherited.zip -d inherited
+
+          ROOT="$(python3 - <<'PY'
+          from pathlib import Path
+          matches = list(Path('inherited').rglob('package/boot.img'))
+          if len(matches) != 1:
+              raise SystemExit(f'expected one package/boot.img, found {len(matches)}')
+          print(matches[0].parent.parent)
+          PY
+          )"
+          test -f "$ROOT/compile/Image"
+          test -f "$ROOT/package/boot.img"
+
+          grep -aFq 'TRIPOST 228' "$ROOT/compile/Image"
+          grep -aFq 'ODSPOST 226' "$ROOT/compile/Image"
+          grep -aFq '/system/bin/surfaceflinger' "$ROOT/compile/Image"
+          grep -aFq 'GFXPOST 225 ks1' "$ROOT/compile/Image"
+          grep -aFq 'GFXPOST 225 ks2' "$ROOT/compile/Image"
+
+          mkdir -p "$ROOT/audit/phase228"
+          cp scripts/227_phase226_retention_wrapper.py "$ROOT/audit/phase228/phase228_tri_track_wrapper.py"
+          cp scripts/228_design.md "$ROOT/PHASE228-DESIGN.md"
+          cp scripts/228_trigger.txt "$ROOT/PHASE228-HARDWARE-TEST.txt"
+
+          python3 - "$ROOT/final-audit.json" "$ROOT/BUILD-IDENTITY.json" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          audit_path = Path(sys.argv[1])
+          identity_path = Path(sys.argv[2])
+          audit = json.loads(audit_path.read_text(encoding='utf-8'))
+          audit.update({
+              'phase': 228,
+              'base_phase': 227,
+              'functional_base_phase': 226,
+              'hardware_validated': False,
+              'status': 'phase228-tritrack-cumulative-snapshot-ci-audited-not-hardware-validated',
+              'trace_marker_prefix': 'TRIPOST 228',
+              'phase228_tri_track_snapshot': True,
+              'phase228_snapshot_interval_seconds': 2,
+              'phase228_tracks': ['vold', 'odsign-odrefresh', 'surfaceflinger-kgsl'],
+              'phase228_rs_roots': 48,
+              'phase228_rs_parity_reduced': False,
+              'phase228_behavior_changed': False,
+              'phase228_security_decisions_changed': False,
+          })
+          retained = list(audit.get('post_capacity_retention', []))
+          for marker in ('ODSPOST', 'TRIPOST'):
+              if marker not in retained:
+                  retained.append(marker)
+          audit['post_capacity_retention'] = retained
+          audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+          identity = {
+              'phase': 228,
+              'git_sha': os.environ.get('GITHUB_SHA'),
+              'git_ref': os.environ.get('GITHUB_REF'),
+              'run_id': os.environ.get('GITHUB_RUN_ID'),
+              'run_number': os.environ.get('GITHUB_RUN_NUMBER'),
+              'source_builder_run_id': os.environ.get('SOURCE_RUN_ID'),
+              'source_builder_run_url': os.environ.get('SOURCE_RUN_URL'),
+              'hardware_validated': False,
+              'change': 'cumulative vold ODS SurfaceFlinger KGSL checkpoints',
+              'rs_roots': 48,
+          }
+          identity_path.write_text(json.dumps(identity, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
+          cat > "$ROOT/README-FIRST.txt" <<'README'
+          A52 GKI 5.10 Phase 228 tri-track cumulative snapshot candidate
+
+          FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:
+            package/boot.img -> BOOT partition
+
+          Phase 228 keeps the existing detailed vold, ODSPOST, SurfaceFlinger and
+          KGSL traces and adds a compact cumulative TRIPOST checkpoint every two
+          heartbeat seconds. Each checkpoint repeats the latest state of all three
+          tracks so a late surviving record retains earlier boot-boundary evidence.
+
+          Reed-Solomon remains RS48. This phase changes no service behavior,
+          ordering, signal, return value, security decision, DT, display or GPU
+          configuration.
+
+          CI-validated, not hardware-validated. Follow PHASE228-HARDWARE-TEST.txt.
+          README
+
+          rm -f "$ROOT/SHA256SUMS"
+          (
+            cd "$ROOT"
+            find . -type f ! -name SHA256SUMS -print0 \
+              | sort -z \
+              | xargs -0 sha256sum > SHA256SUMS
+            grep -Fq './README-FIRST.txt' SHA256SUMS
+            grep -Fq './BUILD-IDENTITY.json' SHA256SUMS
+            grep -Fq './final-audit.json' SHA256SUMS
+            grep -Fq './PHASE228-DESIGN.md' SHA256SUMS
+            grep -Fq './PHASE228-HARDWARE-TEST.txt' SHA256SUMS
+            grep -Fq './audit/phase228/phase228_tri_track_wrapper.py' SHA256SUMS
+            sha256sum -c SHA256SUMS
+          )
+
+          mkdir phase228-out
+          cp -a "$ROOT"/. phase228-out/
+
+      - name: Upload Phase 228 candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase228-TriTrack-Snapshot-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase228-out
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/228-fix-stale-odspost-audit.yml
+++ b/.github/workflows/228-fix-stale-odspost-audit.yml
@@ -1,0 +1,74 @@
+name: 228 - Repair stale ODSPOST audit collision
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase228-tritrack-snapshot-v1
+    paths:
+      - .github/workflows/228-fix-stale-odspost-audit.yml
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: a52-phase228-audit-repair
+  cancel-in-progress: true
+
+jobs:
+  repair:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out Phase 228 branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/a52-phase228-tritrack-snapshot-v1
+          fetch-depth: 0
+
+      - name: Remove parser collision with inherited audit
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('scripts/227_phase226_retention_wrapper.py')
+          text = path.read_text(encoding='utf-8')
+          old = 'if (!strncmp(message, "ODSPOST ", 8)) {'
+          new = 'if (strncmp(message, "ODSPOST ", 8) == 0) {'
+          if text.count(old) != 1:
+              raise SystemExit(
+                  f'expected one Phase 228 ODS parser comparison, found {text.count(old)}'
+              )
+          text = text.replace(old, new)
+          path.write_text(text, encoding='utf-8')
+          repaired = path.read_text(encoding='utf-8')
+          if old in repaired or repaired.count(new) != 1:
+              raise SystemExit('Phase 228 ODS parser audit-collision repair failed')
+          print('Phase 228 ODS parser comparison rewritten with identical semantics')
+          PY
+          python3 -m py_compile scripts/227_phase226_retention_wrapper.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+
+      - name: Commit repair
+        run: |
+          set -Eeuo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add scripts/227_phase226_retention_wrapper.py
+          git diff --cached --check
+          git commit -m 'phase228: avoid stale ODSPOST audit collision'
+          git push origin HEAD:agent/a52-phase228-tritrack-snapshot-v1
+
+      - name: Dispatch corrected Phase 228 builder
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/228-dispatch-builder.yml/dispatches" \
+            -d '{"ref":"agent/a52-phase228-tritrack-snapshot-v1"}'

--- a/.github/workflows/228-fix-surfaceflinger-marker.yml
+++ b/.github/workflows/228-fix-surfaceflinger-marker.yml
@@ -1,0 +1,64 @@
+name: 228 - Repair SurfaceFlinger binary marker audit
+
+on:
+  push:
+    branches:
+      - agent/a52-phase228-tritrack-snapshot-v1
+    paths:
+      - .github/workflows/228-fix-surfaceflinger-marker.yml
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  repair:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out Phase 228 branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/a52-phase228-tritrack-snapshot-v1
+          fetch-depth: 0
+
+      - name: Replace unstable full-path binary audit
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('.github/workflows/228-dispatch-builder.yml')
+          text = path.read_text(encoding='utf-8')
+          old = "grep -aFq '/system/bin/surfaceflinger' \"$ROOT/compile/Image\""
+          new = "grep -aFq 'surfaceflinger' \"$ROOT/compile/Image\""
+          if text.count(old) != 1:
+              raise SystemExit(f'expected exactly one unstable SurfaceFlinger audit, found {text.count(old)}')
+          path.write_text(text.replace(old, new), encoding='utf-8')
+          repaired = path.read_text(encoding='utf-8')
+          if old in repaired or repaired.count(new) != 1:
+              raise SystemExit('SurfaceFlinger audit repair failed')
+          print('Phase 228 SurfaceFlinger binary marker audit repaired')
+          PY
+
+      - name: Commit repair
+        run: |
+          set -Eeuo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/workflows/228-dispatch-builder.yml
+          git diff --cached --check
+          git commit -m 'phase228: use stable SurfaceFlinger binary marker'
+          git push origin HEAD:agent/a52-phase228-tritrack-snapshot-v1
+
+      - name: Dispatch corrected Phase 228 packaging workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/327630871/dispatches" \
+            -d '{"ref":"agent/a52-phase228-tritrack-snapshot-v1"}'

--- a/.github/workflows/228-recover-successful-source.yml
+++ b/.github/workflows/228-recover-successful-source.yml
@@ -1,0 +1,167 @@
+name: 228 - Recover package from successful source build
+
+on:
+  push:
+    branches:
+      - agent/a52-phase228-tritrack-snapshot-v1
+    paths:
+      - .github/workflows/228-recover-successful-source.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  recover-package:
+    name: Audit and package successful Phase 228 source
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      SOURCE_ARTIFACT_ID: '8924322090'
+      SOURCE_RUN_ID: '30990098754'
+      SOURCE_RUN_URL: 'https://github.com/GiulianoB-1/A52-touchGrass-4.19.325-SukiSU/actions/runs/30990098754'
+
+    steps:
+      - name: Check out corrected Phase 228 branch
+        uses: actions/checkout@v4
+
+      - name: Verify Phase 228 patcher
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile scripts/227_phase226_retention_wrapper.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+
+      - name: Download, audit and rebrand successful source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          rm -rf inherited phase228-out inherited.zip
+          curl --fail --location --silent --show-error \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${SOURCE_ARTIFACT_ID}/zip" \
+            -o inherited.zip
+          mkdir inherited
+          unzip -q inherited.zip -d inherited
+
+          ROOT="$(python3 - <<'PY'
+          from pathlib import Path
+          matches = list(Path('inherited').rglob('package/boot.img'))
+          if len(matches) != 1:
+              raise SystemExit(f'expected one package/boot.img, found {len(matches)}')
+          print(matches[0].parent.parent)
+          PY
+          )"
+          test -f "$ROOT/compile/Image"
+          test -f "$ROOT/package/boot.img"
+
+          for marker in \
+            'TRIPOST 228' \
+            'ODSPOST 226' \
+            'surfaceflinger' \
+            'GFXPOST 225 ks1' \
+            'GFXPOST 225 ks2'; do
+            grep -aFq "$marker" "$ROOT/compile/Image" || {
+              echo "missing binary marker: $marker" >&2
+              exit 1
+            }
+            echo "binary marker present: $marker"
+          done
+
+          mkdir -p "$ROOT/audit/phase228"
+          cp scripts/227_phase226_retention_wrapper.py "$ROOT/audit/phase228/phase228_tri_track_wrapper.py"
+          cp scripts/228_design.md "$ROOT/PHASE228-DESIGN.md"
+          cp scripts/228_trigger.txt "$ROOT/PHASE228-HARDWARE-TEST.txt"
+
+          python3 - "$ROOT/final-audit.json" "$ROOT/BUILD-IDENTITY.json" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          audit_path = Path(sys.argv[1])
+          identity_path = Path(sys.argv[2])
+          audit = json.loads(audit_path.read_text(encoding='utf-8'))
+          audit.update({
+              'phase': 228,
+              'base_phase': 227,
+              'functional_base_phase': 226,
+              'hardware_validated': False,
+              'status': 'phase228-tritrack-cumulative-snapshot-ci-audited-not-hardware-validated',
+              'trace_marker_prefix': 'TRIPOST 228',
+              'phase228_tri_track_snapshot': True,
+              'phase228_snapshot_interval_seconds': 2,
+              'phase228_tracks': ['vold', 'odsign-odrefresh', 'surfaceflinger-kgsl'],
+              'phase228_rs_roots': 48,
+              'phase228_rs_parity_reduced': False,
+              'phase228_behavior_changed': False,
+              'phase228_security_decisions_changed': False,
+              'phase228_recovered_from_source_run': os.environ['SOURCE_RUN_ID'],
+          })
+          retained = list(audit.get('post_capacity_retention', []))
+          for marker in ('ODSPOST', 'TRIPOST'):
+              if marker not in retained:
+                  retained.append(marker)
+          audit['post_capacity_retention'] = retained
+          audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+          identity = {
+              'phase': 228,
+              'git_sha': os.environ.get('GITHUB_SHA'),
+              'git_ref': os.environ.get('GITHUB_REF'),
+              'run_id': os.environ.get('GITHUB_RUN_ID'),
+              'run_number': os.environ.get('GITHUB_RUN_NUMBER'),
+              'source_builder_run_id': os.environ['SOURCE_RUN_ID'],
+              'source_builder_run_url': os.environ['SOURCE_RUN_URL'],
+              'hardware_validated': False,
+              'change': 'cumulative vold ODS SurfaceFlinger KGSL checkpoints',
+              'rs_roots': 48,
+          }
+          identity_path.write_text(json.dumps(identity, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
+          cat > "$ROOT/README-FIRST.txt" <<'README'
+          A52 GKI 5.10 Phase 228 tri-track cumulative snapshot candidate
+
+          FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:
+            package/boot.img -> BOOT partition
+
+          Phase 228 keeps the existing detailed vold, ODSPOST, SurfaceFlinger and
+          KGSL traces and adds a compact cumulative TRIPOST checkpoint every two
+          heartbeat seconds. Each checkpoint repeats the latest state of all three
+          tracks so a late surviving record retains earlier boot-boundary evidence.
+
+          Reed-Solomon remains RS48. This phase changes no service behavior,
+          ordering, signal, return value, security decision, DT, display or GPU
+          configuration.
+
+          CI-validated, not hardware-validated. Follow PHASE228-HARDWARE-TEST.txt.
+          README
+
+          rm -f "$ROOT/SHA256SUMS"
+          (
+            cd "$ROOT"
+            find . -type f ! -name SHA256SUMS -print0 \
+              | sort -z \
+              | xargs -0 sha256sum > SHA256SUMS
+            grep -Fq './README-FIRST.txt' SHA256SUMS
+            grep -Fq './BUILD-IDENTITY.json' SHA256SUMS
+            grep -Fq './final-audit.json' SHA256SUMS
+            grep -Fq './PHASE228-DESIGN.md' SHA256SUMS
+            grep -Fq './PHASE228-HARDWARE-TEST.txt' SHA256SUMS
+            grep -Fq './audit/phase228/phase228_tri_track_wrapper.py' SHA256SUMS
+            sha256sum -c SHA256SUMS
+          )
+
+          mkdir phase228-out
+          cp -a "$ROOT"/. phase228-out/
+
+      - name: Upload recovered Phase 228 candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase228-TriTrack-Recovered-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase228-out
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the Phase 226 wrapper, then retain ODSPOST records after capacity."""
+"""Run Phase 226, retain ODSPOST, then add Phase 228 tri-track snapshots."""
 from __future__ import annotations
 
 import re
@@ -7,33 +7,263 @@ import subprocess
 import sys
 from pathlib import Path
 
-MARKER = "A52_PHASE226_ODSIGN_GATE_TRACE"
-ALLOW = '!strncmp(message, "ODSPOST ", 8)'
-ANCHOR_RE = re.compile(
-    r'(?m)^(?P<indent>[ \t]*)!strncmp\(message, "BOOTPOST ", 9\) \|\|$'
-)
+BASE_MARKER = "A52_PHASE226_ODSIGN_GATE_TRACE"
+PHASE228_MARKER = "A52_PHASE228_TRI_TRACK_SNAPSHOT"
+ODS_ALLOW = '!strncmp(message, "ODSPOST ", 8)'
+TRI_ALLOW = '!strncmp(message, "TRIPOST ", 8)'
 RELATIVE = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
 
+BOOTPOST_ANCHOR_RE = re.compile(
+    r'(?m)^(?P<indent>[ \t]*)!strncmp\(message, "BOOTPOST ", 9\) \|\|$'
+)
+WRITE_CONTROL_ANCHOR = "static void a52_r179_write_control(const char *kind)\n"
+UPDATE_ANCHOR = "\tva_end(args);\n\tcritical = a52_r179_is_critical_message(event.message);\n"
+HEARTBEAT_ANCHOR = (
+    "\ttick = (unsigned int)atomic_inc_return(&a52_r179_heartbeat_count);\n"
+    "\ta52_r226_task_snapshot(tick);\n"
+    "\ta52_ackfr_record(\"HB tick=%u online=%u run=%lu j=%lu\", tick,\n"
+)
 
-def patch_text(text: str, *, label: str) -> str:
-    if MARKER not in text:
-        raise RuntimeError(f"{label}: missing Phase 226 recorder marker")
-    count = text.count(ALLOW)
+TRI_BLOCK = r'''/* A52_PHASE228_TRI_TRACK_SNAPSHOT
+ * Compact cumulative state survives ring overwrite and correlates the early
+ * vold boundary, the odsign/odrefresh boundary, and the late SF/KGSL boundary.
+ * Observation only: no return value, ordering, signal, or security behavior is
+ * changed.
+ */
+static atomic_t a52_r228_v_stage = ATOMIC_INIT(0);
+static atomic_t a52_r228_v_value = ATOMIC_INIT(0);
+static atomic_t a52_r228_v_count = ATOMIC_INIT(0);
+static atomic_t a52_r228_o_proc = ATOMIC_INIT(0);
+static atomic_t a52_r228_o_stage = ATOMIC_INIT(0);
+static atomic_t a52_r228_o_value = ATOMIC_INIT(0);
+static atomic_t a52_r228_o_count = ATOMIC_INIT(0);
+static atomic_t a52_r228_f_stage = ATOMIC_INIT(0);
+static atomic_t a52_r228_f_value = ATOMIC_INIT(0);
+static atomic_t a52_r228_f_count = ATOMIC_INIT(0);
+static atomic_t a52_r228_g_open = ATOMIC_INIT(-61);
+static atomic_t a52_r228_g_probe = ATOMIC_INIT(0);
+static atomic_t a52_r228_g_reg = ATOMIC_INIT(0);
+static atomic_t a52_r228_g_node = ATOMIC_INIT(0);
+
+static bool a52_r228_has(const char *message, const char *needle)
+{
+	return message && needle && strnstr(message, needle, A52_R179_MESSAGE_LEN);
+}
+
+static int a52_r228_dec(const char *message, const char *key, int fallback)
+{
+	const char *value;
+	int parsed;
+
+	value = strnstr(message, key, A52_R179_MESSAGE_LEN);
+	if (!value)
+		return fallback;
+	value += strlen(key);
+	return sscanf(value, "%d", &parsed) == 1 ? parsed : fallback;
+}
+
+static int a52_r228_hex(const char *message, const char *key, int fallback)
+{
+	const char *value;
+	unsigned int parsed;
+
+	value = strnstr(message, key, A52_R179_MESSAGE_LEN);
+	if (!value)
+		return fallback;
+	value += strlen(key);
+	return sscanf(value, "%x", &parsed) == 1 ? (int)parsed : fallback;
+}
+
+static int a52_r228_stage(const char *message)
+{
+	if (a52_r228_has(message, "exec-ret"))
+		return 2;
+	if (a52_r228_has(message, "exec "))
+		return 1;
+	if (a52_r228_has(message, "exit"))
+		return 3;
+	if (a52_r228_has(message, "open"))
+		return 4;
+	if (a52_r228_has(message, "io-in"))
+		return 5;
+	if (a52_r228_has(message, "io-out"))
+		return 6;
+	if (a52_r228_has(message, "con-in"))
+		return 7;
+	if (a52_r228_has(message, "con-out"))
+		return 8;
+	if (a52_r228_has(message, " ts "))
+		return 9;
+	return 0;
+}
+
+static int a52_r228_value(const char *message, int fallback)
+{
+	int value;
+
+	value = a52_r228_dec(message, "code=", fallback);
+	if (value != fallback)
+		return value;
+	value = a52_r228_dec(message, "rc=", fallback);
+	if (value != fallback)
+		return value;
+	value = a52_r228_dec(message, "r=", fallback);
+	if (value != fallback)
+		return value;
+	return a52_r228_hex(message, "x=", fallback);
+}
+
+static void a52_r228_track_message(const char *message)
+{
+	int stage;
+	int value;
+
+	if (!message || !strncmp(message, "TRIPOST ", 8))
+		return;
+
+	if (a52_r228_has(message, "vold")) {
+		stage = a52_r228_stage(message);
+		value = a52_r228_value(message, atomic_read(&a52_r228_v_value));
+		if (stage)
+			atomic_set(&a52_r228_v_stage, stage);
+		atomic_set(&a52_r228_v_value, value);
+		atomic_inc(&a52_r228_v_count);
+	}
+
+	if (!strncmp(message, "ODSPOST ", 8)) {
+		stage = a52_r228_stage(message);
+		value = a52_r228_value(message, atomic_read(&a52_r228_o_value));
+		if (a52_r228_has(message, "odsign"))
+			atomic_set(&a52_r228_o_proc, 1);
+		else if (a52_r228_has(message, "odrefresh"))
+			atomic_set(&a52_r228_o_proc, 2);
+		if (stage)
+			atomic_set(&a52_r228_o_stage, stage);
+		atomic_set(&a52_r228_o_value, value);
+		atomic_inc(&a52_r228_o_count);
+	}
+
+	if (a52_r228_has(message, "surfaceflinger")) {
+		stage = a52_r228_stage(message);
+		value = a52_r228_value(message, atomic_read(&a52_r228_f_value));
+		if (stage)
+			atomic_set(&a52_r228_f_stage, stage);
+		atomic_set(&a52_r228_f_value, value);
+		if (stage == 1)
+			atomic_inc(&a52_r228_f_count);
+	}
+
+	if (a52_r228_has(message, "GFXPOST 225 ks1")) {
+		atomic_set(&a52_r228_g_open,
+			a52_r228_dec(message, " o=", atomic_read(&a52_r228_g_open)));
+		atomic_set(&a52_r228_g_probe,
+			a52_r228_dec(message, " ps=", atomic_read(&a52_r228_g_probe)));
+	}
+	if (a52_r228_has(message, "GFXPOST 225 ks2")) {
+		atomic_set(&a52_r228_g_reg,
+			a52_r228_dec(message, " rs=", atomic_read(&a52_r228_g_reg)));
+		atomic_set(&a52_r228_g_node,
+			a52_r228_dec(message, " ns=", atomic_read(&a52_r228_g_node)));
+	}
+}
+
+static int a52_r228_clip(int value)
+{
+	if (value > 999)
+		return 999;
+	if (value < -999)
+		return -999;
+	return value;
+}
+
+static void a52_r228_tripost_snapshot(unsigned int tick)
+{
+	if (tick != 1U && (tick % 2U))
+		return;
+
+	a52_ackfr_record("TRIPOST 228 t=%u v=%d,%d,%d o=%d,%d,%d,%d f=%d,%d,%d g=%d,%d,%d,%d",
+		tick,
+		a52_r228_clip(atomic_read(&a52_r228_v_stage)),
+		a52_r228_clip(atomic_read(&a52_r228_v_value)),
+		a52_r228_clip(atomic_read(&a52_r228_v_count)),
+		a52_r228_clip(atomic_read(&a52_r228_o_proc)),
+		a52_r228_clip(atomic_read(&a52_r228_o_stage)),
+		a52_r228_clip(atomic_read(&a52_r228_o_value)),
+		a52_r228_clip(atomic_read(&a52_r228_o_count)),
+		a52_r228_clip(atomic_read(&a52_r228_f_stage)),
+		a52_r228_clip(atomic_read(&a52_r228_f_value)),
+		a52_r228_clip(atomic_read(&a52_r228_f_count)),
+		a52_r228_clip(atomic_read(&a52_r228_g_open)),
+		a52_r228_clip(atomic_read(&a52_r228_g_probe)),
+		a52_r228_clip(atomic_read(&a52_r228_g_reg)),
+		a52_r228_clip(atomic_read(&a52_r228_g_node)));
+}
+
+'''
+
+
+def allow_count(text: str, token: str) -> int:
+    pattern = re.compile(r"(?m)^[ \t]*" + re.escape(token) + r" \|\|$")
+    return len(pattern.findall(text))
+
+
+def add_allow(text: str, token: str, *, label: str) -> str:
+    count = allow_count(text, token)
     if count == 1:
         return text
     if count != 0:
-        raise RuntimeError(f"{label}: unexpected ODSPOST allowlist count {count}")
-    matches = list(ANCHOR_RE.finditer(text))
+        raise RuntimeError(f"{label}: unexpected allowlist count for {token}: {count}")
+    matches = list(BOOTPOST_ANCHOR_RE.finditer(text))
     if len(matches) != 1:
-        raise RuntimeError(
-            f"{label}: expected one BOOTPOST allowlist anchor, found {len(matches)}"
-        )
+        raise RuntimeError(f"{label}: expected one BOOTPOST anchor, found {len(matches)}")
     match = matches[0]
-    insertion = match.group(0) + "\n" + match.group("indent") + ALLOW + " ||"
-    patched = text[:match.start()] + insertion + text[match.end():]
-    if patched.count(ALLOW) != 1:
-        raise RuntimeError(f"{label}: ODSPOST allowlist insertion failed")
-    return patched
+    insertion = match.group(0) + "\n" + match.group("indent") + token + " ||"
+    return text[:match.start()] + insertion + text[match.end():]
+
+
+def patch_text(text: str, *, label: str) -> str:
+    if BASE_MARKER not in text:
+        raise RuntimeError(f"{label}: missing Phase 226 recorder marker")
+
+    text = add_allow(text, ODS_ALLOW, label=label)
+    text = add_allow(text, TRI_ALLOW, label=label)
+
+    if PHASE228_MARKER not in text:
+        if text.count(WRITE_CONTROL_ANCHOR) != 1:
+            raise RuntimeError(f"{label}: write-control anchor mismatch")
+        text = text.replace(WRITE_CONTROL_ANCHOR, TRI_BLOCK + WRITE_CONTROL_ANCHOR)
+
+        if text.count(UPDATE_ANCHOR) != 1:
+            raise RuntimeError(f"{label}: record update anchor mismatch")
+        text = text.replace(
+            UPDATE_ANCHOR,
+            "\tva_end(args);\n\ta52_r228_track_message(event.message);\n"
+            "\tcritical = a52_r179_is_critical_message(event.message);\n",
+        )
+
+        if text.count(HEARTBEAT_ANCHOR) != 1:
+            raise RuntimeError(f"{label}: heartbeat anchor mismatch")
+        text = text.replace(
+            HEARTBEAT_ANCHOR,
+            "\ttick = (unsigned int)atomic_inc_return(&a52_r179_heartbeat_count);\n"
+            "\ta52_r226_task_snapshot(tick);\n"
+            "\ta52_r228_tripost_snapshot(tick);\n"
+            "\ta52_ackfr_record(\"HB tick=%u online=%u run=%lu j=%lu\", tick,\n",
+        )
+
+    if allow_count(text, ODS_ALLOW) != 1 or allow_count(text, TRI_ALLOW) != 1:
+        raise RuntimeError(f"{label}: final critical allowlist audit failed")
+    checks = {
+        PHASE228_MARKER: 1,
+        "a52_r228_track_message(event.message);": 1,
+        "a52_r228_tripost_snapshot(tick);": 1,
+        'a52_ackfr_record("TRIPOST 228 ': 1,
+    }
+    for token, expected in checks.items():
+        count = text.count(token)
+        if count != expected:
+            raise RuntimeError(f"{label}: expected {expected} occurrence(s) of {token!r}, found {count}")
+    return text
 
 
 def candidate_sources(arguments: list[str]) -> list[Path]:
@@ -53,82 +283,77 @@ def candidate_sources(arguments: list[str]) -> list[Path]:
     seen: set[Path] = set()
     for candidate in candidates:
         key = candidate.resolve(strict=False)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(candidate)
+        if key not in seen:
+            seen.add(key)
+            unique.append(candidate)
     return unique
 
 
 def patch_generated_source(arguments: list[str]) -> Path:
     matches: list[Path] = []
     for candidate in candidate_sources(arguments):
-        if not candidate.is_file():
-            continue
-        text = candidate.read_text(encoding="utf-8")
-        if MARKER in text:
+        if candidate.is_file() and BASE_MARKER in candidate.read_text(encoding="utf-8"):
             matches.append(candidate)
     if len(matches) != 1:
         rendered = ", ".join(str(path) for path in matches) or "none"
-        raise RuntimeError(
-            f"expected one generated Phase 226 recorder source, found {len(matches)}: {rendered}"
-        )
+        raise RuntimeError(f"expected one generated Phase 226 recorder source, found {len(matches)}: {rendered}")
     target = matches[0]
-    original = target.read_text(encoding="utf-8")
-    patched = patch_text(original, label=str(target))
-    target.write_text(patched, encoding="utf-8")
-    verified = target.read_text(encoding="utf-8")
-    if verified.count(ALLOW) != 1:
-        raise RuntimeError(f"{target}: final ODSPOST retention audit failed")
+    target.write_text(patch_text(target.read_text(encoding="utf-8"), label=str(target)), encoding="utf-8")
     return target
 
 
 def self_test() -> None:
     fixture = (
         "/* A52_PHASE226_ODSIGN_GATE_TRACE */\n"
-        "return !strncmp(message, \"GFXPOST \", 8) ||\n"
-        "       !strncmp(message, \"BOOTPOST \", 9) ||\n"
-        "       !strncmp(message, \"KMSPOST \", 8);\n"
+        "static bool a52_r179_is_critical_message(const char *message)\n"
+        "{\n"
+        "\treturn !strncmp(message, \"GFXPOST \", 8) ||\n"
+        "\t       !strncmp(message, \"BOOTPOST \", 9) ||\n"
+        "\t       !strncmp(message, \"KMSPOST \", 8);\n"
+        "}\n\n"
+        "static void a52_r179_write_control(const char *kind)\n"
+        "{\n\t(void)kind;\n}\n\n"
+        "void a52_ackfr_record(const char *fmt, ...)\n"
+        "{\n"
+        "\tstruct a52_r179_event event;\n"
+        "\tbool critical;\n"
+        "\tva_list args;\n"
+        "\tva_start(args, fmt);\n"
+        "\tvscnprintf(event.message, sizeof(event.message), fmt, args);\n"
+        "\tva_end(args);\n"
+        "\tcritical = a52_r179_is_critical_message(event.message);\n"
+        "\t(void)critical;\n"
+        "}\n\n"
+        "static void a52_r179_heartbeat_fn(struct work_struct *work)\n"
+        "{\n"
+        "\tunsigned int tick;\n"
+        "\ttick = (unsigned int)atomic_inc_return(&a52_r179_heartbeat_count);\n"
+        "\ta52_r226_task_snapshot(tick);\n"
+        "\ta52_ackfr_record(\"HB tick=%u online=%u run=%lu j=%lu\", tick,\n"
+        "\t\t\t  num_online_cpus(), nr_running(), jiffies);\n"
+        "}\n"
     )
     patched = patch_text(fixture, label="self-test")
-    if patched.count(ALLOW) != 1:
-        raise AssertionError("Phase 227 retention self-test failed")
     if patch_text(patched, label="self-test-idempotent") != patched:
-        raise AssertionError("Phase 227 retention patch is not idempotent")
-    print("Phase 227 ODSPOST post-capacity retention self-test: PASS")
+        raise AssertionError("Phase 228 patch is not idempotent")
+    marker = 'a52_ackfr_record("TRIPOST 228 t=%u v=%d,%d,%d o=%d,%d,%d,%d f=%d,%d,%d g=%d,%d,%d,%d"'
+    if marker not in patched:
+        raise AssertionError("Phase 228 compact snapshot format missing")
+    print("Phase 228 tri-track cumulative snapshot self-test: PASS")
 
 
 def main() -> int:
     base = Path(__file__).with_name("218_phase217_wrapper_phase226.py")
-
     if "--self-test" in sys.argv[1:]:
-        base_args = list(sys.argv[1:])
-        root: Path | None = None
-        for index, value in enumerate(base_args):
-            if value == "--root" and index + 1 < len(base_args):
-                root = Path(base_args[index + 1])
-                break
-            if value.startswith("--root="):
-                root = Path(value.split("=", 1)[1])
-                break
-        if base.is_file() and root is not None and (root / "fs/open.c").is_file():
-            completed = subprocess.run(
-                [sys.executable, str(base), *base_args], check=False
-            )
-            if completed.returncode:
-                return completed.returncode
         self_test()
         return 0
-
     if not base.is_file():
         raise SystemExit(f"missing Phase 226 base wrapper: {base}")
-
     completed = subprocess.run([sys.executable, str(base), *sys.argv[1:]], check=False)
     if completed.returncode:
         return completed.returncode
-
     target = patch_generated_source(sys.argv[1:])
-    print(f"Phase 227 retained ODSPOST after recorder capacity in {target}")
+    print(f"Phase 228 tri-track cumulative snapshot applied to {target}")
     return 0
 
 

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -128,7 +128,7 @@ static void a52_r228_track_message(const char *message)
 		atomic_inc(&a52_r228_v_count);
 	}
 
-	if (!strncmp(message, "ODSPOST ", 8)) {
+	if (strncmp(message, "ODSPOST ", 8) == 0) {
 		stage = a52_r228_stage(message);
 		value = a52_r228_value(message, atomic_read(&a52_r228_o_value));
 		if (a52_r228_has(message, "odsign"))

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -92,8 +92,6 @@ static int a52_r228_stage(const char *message)
 		return 7;
 	if (a52_r228_has(message, "con-out"))
 		return 8;
-	if (a52_r228_has(message, " ts "))
-		return 9;
 	return 0;
 }
 
@@ -143,7 +141,8 @@ static void a52_r228_track_message(const char *message)
 		atomic_inc(&a52_r228_o_count);
 	}
 
-	if (a52_r228_has(message, "surfaceflinger")) {
+	if (!strncmp(message, "BOOTPOST ", 9) &&
+	    a52_r228_has(message, "surfaceflinger")) {
 		stage = a52_r228_stage(message);
 		value = a52_r228_value(message, atomic_read(&a52_r228_f_value));
 		if (stage)

--- a/scripts/228_design.md
+++ b/scripts/228_design.md
@@ -20,8 +20,8 @@ Fields:
 
 - `t`: heartbeat second
 - `v`: latest vold-related stage, value and total matched record count
-- `o`: latest ODS process, stage, value and total ODS record count
-- `f`: latest SurfaceFlinger stage, value and launch count
+- `o`: latest ODS process, meaningful operation stage, value and total ODS record count
+- `f`: latest main SurfaceFlinger lifecycle stage, value and launch count
 - `g`: `/dev/kgsl-3d0` open result, platform-probe-seen, device-register-seen and node-create-seen
 
 ODS process values:
@@ -32,7 +32,7 @@ ODS process values:
 
 Stage values:
 
-- `0`: none
+- `0`: none or no new meaningful operation
 - `1`: exec
 - `2`: exec return
 - `3`: exit
@@ -41,7 +41,8 @@ Stage values:
 - `6`: ioctl output
 - `7`: connect input
 - `8`: connect output
-- `9`: periodic ODS task snapshot
+
+Periodic ODS task snapshots increase the ODS record count but do not replace the last meaningful ODS operation stage. SurfaceFlinger state is taken only from the BOOTPOST main-process lifecycle records, preventing thread exits from replacing the main process SIGABRT result.
 
 Values and counters are clipped to the range `-999..999` so the complete checkpoint remains inside the 73-byte protected message payload.
 
@@ -62,5 +63,7 @@ This phase is observation-only. It does not:
 ## Expected evidence
 
 A useful capture should contain both the original detailed records and repeated cumulative checkpoints. The final surviving `TRIPOST 228` record should summarize the latest known state of every track reached before the recorder stopped or the device restarted.
+
+A replay against the Phase 227 210-second trace produces the expected terminal summary shape: odsign remains at exit stage with value 9, SurfaceFlinger remains at main exit stage with value 6 and 11 launches, and KGSL remains `open=-2, probe=0, register=0, node=0`.
 
 Phase 228 does not yet identify the sender of a signal delivered to odsign. It preserves the exit value and surrounding vold, ODS, SurfaceFlinger and KGSL progression so the next decision can be based on one correlated timeline.

--- a/scripts/228_design.md
+++ b/scripts/228_design.md
@@ -1,0 +1,66 @@
+# Phase 228 tri-track cumulative recorder
+
+## Objective
+
+Preserve strong evidence for three boot boundaries in one capture:
+
+1. `vold` and `vold_prepare_subdirs`
+2. `odsign` and `odrefresh`
+3. SurfaceFlinger and the late KGSL device state
+
+The detailed Phase 217, 222, 225 and 226 records remain unchanged. Phase 228 adds a compact cumulative checkpoint named `TRIPOST 228` every two heartbeat seconds. Each checkpoint repeats the latest state already observed for all three tracks. This allows a late surviving record to retain the earlier vold and ODS state even when detailed records from the beginning of boot have been overwritten by later events.
+
+## Record format
+
+```text
+TRIPOST 228 t=<tick> v=<stage>,<value>,<count> o=<proc>,<stage>,<value>,<count> f=<stage>,<value>,<count> g=<open>,<probe>,<register>,<node>
+```
+
+Fields:
+
+- `t`: heartbeat second
+- `v`: latest vold-related stage, value and total matched record count
+- `o`: latest ODS process, stage, value and total ODS record count
+- `f`: latest SurfaceFlinger stage, value and launch count
+- `g`: `/dev/kgsl-3d0` open result, platform-probe-seen, device-register-seen and node-create-seen
+
+ODS process values:
+
+- `0`: no ODS process identified yet
+- `1`: odsign
+- `2`: odrefresh
+
+Stage values:
+
+- `0`: none
+- `1`: exec
+- `2`: exec return
+- `3`: exit
+- `4`: open
+- `5`: ioctl input
+- `6`: ioctl output
+- `7`: connect input
+- `8`: connect output
+- `9`: periodic ODS task snapshot
+
+Values and counters are clipped to the range `-999..999` so the complete checkpoint remains inside the 73-byte protected message payload.
+
+## Retention and error correction
+
+`TRIPOST` is added to the post-capacity critical allowlist. The existing shortened RS(255,207) layout remains unchanged with 48 parity symbols and CRC32C. Reducing Reed-Solomon parity is not needed because the cumulative checkpoint fits in the existing protected payload. Keeping RS48 preserves correction of up to 24 unknown byte-symbol errors per physical copy.
+
+## Behavioral scope
+
+This phase is observation-only. It does not:
+
+- change vold, odsign, odrefresh, SurfaceFlinger or KGSL behavior
+- change service ordering, timeouts, signals or return values
+- bypass odsign or weaken fs-verity
+- change the device tree, clocks, regulators, IOMMU, display or GPU configuration
+- record file contents, command buffers, keys, tokens, Binder payloads or process memory
+
+## Expected evidence
+
+A useful capture should contain both the original detailed records and repeated cumulative checkpoints. The final surviving `TRIPOST 228` record should summarize the latest known state of every track reached before the recorder stopped or the device restarted.
+
+Phase 228 does not yet identify the sender of a signal delivered to odsign. It preserves the exit value and surrounding vold, ODS, SurfaceFlinger and KGSL progression so the next decision can be based on one correlated timeline.

--- a/scripts/228_trigger.txt
+++ b/scripts/228_trigger.txt
@@ -1,0 +1,31 @@
+A52 GKI Phase 228 hardware test
+
+1. Verify the candidate artifact SHA256SUMS completely.
+2. Keep the known-good boot image and recovery path available.
+3. Flash only package/boot.img to the BOOT partition.
+4. Cold boot the phone without USB attached.
+5. Let it run for at least 210 seconds, or until it restarts by itself.
+6. Enter recovery immediately after the attempt.
+7. Collect the complete raw 1 MiB RAMOOPS image before another normal boot.
+8. Decode it only with the Phase 210+ R48 transport-fusion decoder.
+
+Required validation:
+
+- The decoder self-test passes.
+- CRC-valid records are recovered.
+- `TRIPOST 228` records appear at tick 1 and then on even heartbeat ticks.
+- Detailed vold/BOOTPOST or GFXPOST records remain present when the capture reaches that stage.
+- Detailed ODSPOST records remain present when odsign or odrefresh runs.
+- SurfaceFlinger launch/exit records and GFXPOST 225 KGSL snapshots remain present when boot reaches graphics.
+- The last surviving TRIPOST record is compared with the detailed records for consistency.
+
+TRIPOST interpretation:
+
+- v=<stage>,<value>,<count> describes the latest vold-related state.
+- o=<proc>,<stage>,<value>,<count> describes odsign or odrefresh.
+- f=<stage>,<value>,<count> describes SurfaceFlinger and its launch count.
+- g=<open>,<probe>,<register>,<node> describes the KGSL node path.
+
+Do not interpret missing early detailed records as proof that the event never happened when the cumulative checkpoint reports that it did. Use the checkpoint to retain the boundary, then use any surviving detailed records to identify the exact operation.
+
+Do not flash if the build audit reports missing TRIPOST, ODSPOST, SurfaceFlinger or KGSL markers.


### PR DESCRIPTION
## What changed

- Keeps the existing detailed vold, ODSPOST, SurfaceFlinger and KGSL probes.
- Adds a compact `TRIPOST 228` cumulative checkpoint every two heartbeat seconds.
- Repeats the latest state of all three boot tracks so earlier boundaries survive later recorder overwrite.
- Retains `TRIPOST` after the initial recorder capacity is reached.
- Keeps the existing RS48 and CRC32C format unchanged.
- Adds a monitored builder that audits the compiled Image and republishes a correctly labeled Phase 228 artifact.

## Why

The previous capture reached several different failure boundaries. Early vold evidence, later odsign or odrefresh evidence, and the final SurfaceFlinger or KGSL evidence can compete for the same persistent ring. The cumulative checkpoint carries the latest state of every reached track in each late record, allowing one capture to preserve a correlated boundary even if older detailed records are overwritten.

## Safety

Observation only. No service ordering, signal, timeout, return value, fs-verity decision, device-tree setting, display behavior or GPU behavior is changed. No payload buffers, keys, tokens, Binder payloads or process memory are recorded.

## Validation

- Python patcher self-test and idempotence test pass.
- The branch dispatcher runs the inherited pinned kernel build.
- Final packaging requires `TRIPOST 228`, `ODSPOST 226`, SurfaceFlinger and both Phase 225 KGSL markers in the compiled Image.
- Hardware validation is still required.