### PR TITLE
Phase 230: trace KGSL driver-core and supplier boundary

### DIFF
--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -4,6 +4,18 @@ run-name: Build and audit Phase 230 KGSL driver-core supplier candidate
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase230-kgsl-drivercore-supplier-v1
+    paths:
+      - .github/workflows/230-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/229_phase228_kgsl_wrapper.py
+      - scripts/230_patcher_parts/**
+      - scripts/230_package.py
+      - scripts/230_package_parts/**
+      - scripts/230_design.md
+      - scripts/230_trigger.txt
 
 permissions:
   actions: write

--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -1,0 +1,68 @@
+name: 230 - A52 KGSL driver-core supplier recorder
+
+run-name: Build and audit Phase 230 KGSL driver-core supplier candidate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: a52-phase230-kgsl-drivercore-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-package:
+    name: Build, compare and package Phase 230
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 230 branch
+        uses: actions/checkout@v4
+
+      - name: Verify Phase 230 source
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile \
+            scripts/228_phase227_tritrack_wrapper.py \
+            scripts/229_phase228_kgsl_wrapper.py \
+            scripts/227_phase226_retention_wrapper.py \
+            scripts/230_package.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+          grep -RFq 'A52_PHASE230_KGSL_DRIVERCORE_PATH' scripts/230_patcher_parts
+          grep -RFq 'KGBPOST 230' scripts/230_patcher_parts
+          grep -RFq 'device_links_check_suppliers' scripts/230_patcher_parts
+          grep -Fq 'RS(255,207)' scripts/230_design.md
+          grep -Fq 'KGPPOST 229' scripts/230_design.md
+          grep -Fq 'vold, odsign/odrefresh' scripts/230_design.md
+          grep -Fq '6bf351bdf18bdb228db79e66f14a7a9c0178e5d7' scripts/230_design.md
+
+      - name: Dispatch inherited builder and package Phase 230
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          python3 scripts/230_package.py
+          test -f phase230-out/package/boot.img
+          test -f phase230-out/compile/Image
+          test -f phase230-out/comparison/phase230-gpu-dt-touchgrass.json
+          test -f phase230-out/comparison/phase230-drivercore-touchgrass.json
+          grep -aFq 'KGBPOST 230' phase230-out/compile/Image
+          grep -aFq 'KGPPOST 229' phase230-out/compile/Image
+          grep -aFq 'TRIPOST 228' phase230-out/compile/Image
+          grep -aFq 'ODSPOST 226' phase230-out/compile/Image
+          (
+            cd phase230-out
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Upload Phase 230 candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase230-KGSL-DriverCore-Supplier-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase230-out
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -4,18 +4,6 @@ run-name: Build and audit Phase 230 KGSL driver-core supplier candidate
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - agent/a52-phase230-kgsl-drivercore-supplier-v1
-    paths:
-      - .github/workflows/230-dispatch-builder.yml
-      - scripts/227_phase226_retention_wrapper.py
-      - scripts/229_phase228_kgsl_wrapper.py
-      - scripts/230_patcher_parts/**
-      - scripts/230_package.py
-      - scripts/230_package_parts/**
-      - scripts/230_design.md
-      - scripts/230_trigger.txt
 
 permissions:
   actions: write

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-"""Load the checked-in, readable Phase 229 implementation fragments."""
+"""Load the checked-in, readable Phase 230 implementation fragments."""
 from __future__ import annotations
-
 from pathlib import Path
-
-payload_dir = Path(__file__).resolve().parent / "229_patcher_parts"
+payload_dir = Path(__file__).resolve().parent / "230_patcher_parts"
 parts = sorted(payload_dir.glob("*.pyfrag"))
 if not parts:
-    raise SystemExit(f"missing Phase 229 patcher source fragments: {payload_dir}")
+    raise SystemExit(f"missing Phase 230 patcher source fragments: {payload_dir}")
 source = "".join(part.read_text(encoding="utf-8") for part in parts)
-exec(compile(source, str(payload_dir / "phase229_impl.py"), "exec"), globals(), globals())
+exec(compile(source, str(payload_dir / "phase230_impl.py"), "exec"), globals(), globals())

--- a/scripts/229_phase228_kgsl_wrapper.py
+++ b/scripts/229_phase228_kgsl_wrapper.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Load the checked-in, readable Phase 229 implementation fragments."""
+from __future__ import annotations
+from pathlib import Path
+payload_dir = Path(__file__).resolve().parent / "229_patcher_parts"
+parts = sorted(payload_dir.glob("*.pyfrag"))
+if not parts:
+    raise SystemExit(f"missing Phase 229 patcher source fragments: {payload_dir}")
+source = "".join(part.read_text(encoding="utf-8") for part in parts)
+exec(compile(source, str(payload_dir / "phase229_impl.py"), "exec"), globals(), globals())

--- a/scripts/230_design.md
+++ b/scripts/230_design.md
@@ -1,0 +1,84 @@
+# Phase 230: KGSL driver-core and supplier-boundary recorder
+
+## Evidence entering this phase
+
+Phase 229 hardware data reported the same state from the first surviving GPU
+snapshot through shutdown:
+
+- the live `qcom,kgsl-3d0` node exists
+- the node is enabled
+- its `platform_device` exists
+- the device is not bound
+- both KGSL platform-driver registrations return zero
+- `adreno_probe()` is never entered
+
+Therefore Phase 230 observes the driver-core path between successful driver
+registration and the Adreno callback. It does not attempt to force a bind.
+
+## TouchGrass comparison
+
+The inherited build compares the generated Phase 229 source with:
+
+- repository: `micr0softstore/samsung_android_kernel_a52xq`
+- commit: `6bf351bdf18bdb228db79e66f14a7a9c0178e5d7`
+
+The artifact includes:
+
+- every DTS/DTSI node containing `qcom,kgsl-3d0`
+- the direct properties and phandle-reference set for those nodes
+- focused diffs for `platform_match()`, `__device_attach_driver()`,
+  `__driver_attach()`, `driver_probe_device()`, `really_probe()` and
+  `device_links_check_suppliers()`
+
+This extends the Phase 229 comparison beyond `drivers/gpu/msm` into the DT and
+driver-core code that can prevent the callback from running.
+
+## Runtime trace
+
+`KGBPOST 230` is retained after recorder capacity and is emitted only for the
+GPU consumer and the Adreno driver identified by its OF table. Each checkpoint
+is one-shot, so repeated deferred-probe attempts cannot flood RAMOOPS.
+
+The records distinguish:
+
+- final platform-match result, direct OF result, `driver_override` presence and
+  ID-table presence
+- driver-centric versus device-centric attach traversal
+- entry and return from `driver_probe_device()`
+- entry to `really_probe()` and global probe deferral state
+- firmware-node supplier waiting
+- the first blocking managed supplier device, link state, flags and supplier
+  state
+- supplier-check result and deferred-probe reason
+- pinctrl, DMA configuration, driver sysfs and PM-domain activation results
+- entry and return of the platform bus probe callback
+
+The existing Phase 229 delayed `KGPPOST 229` snapshots remain active through
+approximately 220 seconds and show whether the device eventually binds.
+
+## Preserved evidence
+
+Phase 230 retains unchanged:
+
+- `KGPPOST 229`
+- `TRIPOST 228` including vold, odsign/odrefresh, SurfaceFlinger and KGSL state
+- detailed `ODSPOST 226`
+- `GFXPOST 225 ks1` and `GFXPOST 225 ks2`
+- RS(255,207), 48 parity symbols, CRC32C and transport-fusion decoding
+
+## Safety and non-goals
+
+Phase 230 does not:
+
+- modify DT data or a device/driver name
+- change `platform_match()` or supplier-check return values
+- clear `driver_override`
+- remove, add or relax a device link
+- force, retry or manually invoke `adreno_probe()`
+- change asynchronous-probe selection
+- alter pinctrl, DMA, IOMMU, clocks, regulators, power domains or firmware
+- create `/dev/kgsl-3d0`
+- change vold, odsign, odrefresh, SurfaceFlinger or reboot behavior
+- reduce Reed-Solomon parity
+
+The candidate is CI-audited and must still be hardware-validated.

--- a/scripts/230_package.py
+++ b/scripts/230_package.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Load the checked-in, readable Phase 230 packaging fragments."""
+from __future__ import annotations
+from pathlib import Path
+payload_dir = Path(__file__).resolve().parent / "230_package_parts"
+parts = sorted(payload_dir.glob("*.pyfrag"))
+if not parts:
+    raise SystemExit(f"missing Phase 230 package source fragments: {payload_dir}")
+source = "".join(part.read_text(encoding="utf-8") for part in parts)
+exec(compile(source, str(payload_dir / "phase230_package_impl.py"), "exec"), globals(), globals())

--- a/scripts/230_package_parts/00.pyfrag
+++ b/scripts/230_package_parts/00.pyfrag
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["GH_TOKEN"]
+REF = "agent/a52-phase230-kgsl-drivercore-supplier-v1"
+WORKFLOW_ID = 325785868
+API = f"https://api.github.com/repos/{REPO}"
+
+
+def request(url: str, *, method: str = "GET", data: dict | None = None) -> bytes:
+    body = None if data is None else json.dumps(data).encode()
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=120) as response:
+        return response.read()
+
+
+def get_json(url: str) -> dict:
+    return json.loads(request(url))
+
+
+def dispatch_and_wait() -> tuple[int, str, int]:
+    started = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    request(f"{API}/actions/workflows/{WORKFLOW_ID}/dispatches", method="POST", data={"ref": REF})
+    run = None
+    for _ in range(40):
+        data = get_json(f"{API}/actions/workflows/{WORKFLOW_ID}/runs?branch={REF}&event=workflow_dispatch&per_page=20")
+        candidates = [row for row in data.get("workflow_runs", []) if row.get("created_at", "") >= started]
+        if candidates:
+            run = sorted(candidates, key=lambda row: row["created_at"])[-1]
+            break
+        time.sleep(15)
+    if not run:
+        raise RuntimeError("dispatched inherited Phase 230 source build was not found")
+    run_id = int(run["id"])
+    print(f"Monitoring {run['html_url']}", flush=True)
+    for _ in range(720):
+        run = get_json(f"{API}/actions/runs/{run_id}")
+        print(f"run={run_id} status={run['status']} conclusion={run.get('conclusion') or 'pending'}", flush=True)
+        if run["status"] == "completed":
+            break
+        time.sleep(30)
+    if run.get("conclusion") != "success":
+        raise RuntimeError(f"inherited builder conclusion: {run.get('conclusion')}")
+    artifacts = get_json(f"{API}/actions/runs/{run_id}/artifacts?per_page=100").get("artifacts", [])
+    artifacts = [artifact for artifact in artifacts if not artifact.get("expired")]
+    if not artifacts:
+        raise RuntimeError("successful inherited build produced no artifact")
+    artifact = artifacts[-1]
+    return run_id, run["html_url"], int(artifact["id"])
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def download_artifact(artifact_id: int, dest: Path) -> None:
+    api_url = f"{API}/actions/artifacts/{artifact_id}/zip"
+    req = urllib.request.Request(api_url, method="GET")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        opener.open(req, timeout=120)
+        raise RuntimeError("artifact download unexpectedly returned without redirect")
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (301, 302, 303, 307, 308):
+            raise
+        location = exc.headers.get("Location")
+        if not location:
+            raise RuntimeError("artifact redirect did not include Location") from exc
+    with urllib.request.urlopen(location, timeout=120) as response:
+        dest.write_bytes(response.read())
+
+

--- a/scripts/230_package_parts/01.pyfrag
+++ b/scripts/230_package_parts/01.pyfrag
@@ -1,0 +1,38 @@
+def select_source() -> tuple[int, str, int]:
+    artifact = os.environ.get("PHASE230_SOURCE_ARTIFACT_ID")
+    run = os.environ.get("PHASE230_SOURCE_RUN_ID")
+    if artifact and run:
+        run_id = int(run)
+        return run_id, f"https://github.com/{REPO}/actions/runs/{run_id}", int(artifact)
+    if artifact or run:
+        raise RuntimeError("both PHASE230_SOURCE_ARTIFACT_ID and PHASE230_SOURCE_RUN_ID are required")
+    return dispatch_and_wait()
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def locate_root(base: Path) -> Path:
+    matches = list(base.rglob("package/boot.img"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one package/boot.img, found {len(matches)}")
+    return matches[0].parent.parent
+
+
+def verify_markers(image: Path) -> None:
+    data = image.read_bytes()
+    markers = (
+        b"KGBPOST 230", b"KGPPOST 229", b"TRIPOST 228", b"ODSPOST 226",
+        b"GFXPOST 225 ks1", b"GFXPOST 225 ks2",
+    )
+    for marker in markers:
+        if marker not in data:
+            raise RuntimeError(f"missing binary marker: {marker.decode()}")
+        print(f"binary marker present: {marker.decode()}")
+
+

--- a/scripts/230_package_parts/02.pyfrag
+++ b/scripts/230_package_parts/02.pyfrag
@@ -1,0 +1,101 @@
+def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
+    verify_markers(root / "compile/Image")
+    comparison_names = (
+        "phase230-gpu-dt-touchgrass.json",
+        "phase230-gpu-dt-touchgrass.txt",
+        "phase230-drivercore-touchgrass.json",
+        "phase230-drivercore-touchgrass.txt",
+    )
+    for name in comparison_names:
+        if not (root / "comparison" / name).is_file():
+            raise RuntimeError(f"missing Phase 230 comparison output: {name}")
+
+    stage_names = (
+        "drivers-base-platform.c-after-phase230.c",
+        "drivers-base-dd.c-after-phase230.c",
+        "drivers-base-core.c-after-phase230.c",
+        "drivers-a52_secure-a52_ack_secure_flight_recorder.c-after-phase230.c",
+    )
+    for name in stage_names:
+        if not (root / "stage" / name).is_file():
+            raise RuntimeError(f"missing Phase 230 staged source: {name}")
+
+    audit_dir = root / "audit/phase230"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2("scripts/227_phase226_retention_wrapper.py", audit_dir / "phase230_loader.py")
+    shutil.copy2("scripts/229_phase228_kgsl_wrapper.py", audit_dir / "phase229_base_loader.py")
+    shutil.copy2("scripts/228_phase227_tritrack_wrapper.py", audit_dir / "phase228_tri_track_wrapper.py")
+    shutil.copy2("scripts/230_package.py", audit_dir / "phase230_package.py")
+    shutil.copytree("scripts/230_patcher_parts", audit_dir / "patcher_parts", dirs_exist_ok=True)
+    shutil.copytree("scripts/229_patcher_parts", audit_dir / "phase229_patcher_parts", dirs_exist_ok=True)
+    shutil.copy2("scripts/230_design.md", root / "PHASE230-DESIGN.md")
+    shutil.copy2("scripts/230_trigger.txt", root / "PHASE230-HARDWARE-TEST.txt")
+
+    audit_path = root / "final-audit.json"
+    audit = json.loads(audit_path.read_text())
+    audit.update({
+        "phase": 230,
+        "base_phase": 229,
+        "functional_base_phase": 229,
+        "hardware_validated": False,
+        "status": "phase230-kgsl-drivercore-supplier-ci-audited-not-hardware-validated",
+        "trace_marker_prefix": "KGBPOST 230",
+        "phase229_kgppost_retained": True,
+        "phase228_tri_track_retained": True,
+        "phase226_odspost_retained": True,
+        "phase230_touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "phase230_one_shot_runtime_checkpoints": True,
+        "phase230_behavior_changed": False,
+        "phase230_binding_decisions_changed": False,
+        "phase230_supplier_links_changed": False,
+        "phase230_security_decisions_changed": False,
+        "phase230_rs_roots": 48,
+    })
+    retained = list(audit.get("post_capacity_retention", []))
+    for marker in ("ODSPOST", "TRIPOST", "KGPPOST", "KGBPOST"):
+        if marker not in retained:
+            retained.append(marker)
+    audit["post_capacity_retention"] = retained
+    audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n")
+
+    identity = {
+        "phase": 230,
+        "git_sha": os.environ.get("GITHUB_SHA"),
+        "git_ref": os.environ.get("GITHUB_REF"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_number": os.environ.get("GITHUB_RUN_NUMBER"),
+        "source_builder_run_id": str(source_run_id),
+        "source_builder_run_url": source_run_url,
+        "touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "hardware_validated": False,
+        "change": "KGSL platform-match, attach, supplier and pre-probe read-only trace",
+        "rs_roots": 48,
+    }
+    (root / "BUILD-IDENTITY.json").write_text(json.dumps(identity, indent=2, sort_keys=True) + "\n")
+    (root / "README-FIRST.txt").write_text(
+        "A52 GKI 5.10 Phase 230 KGSL driver-core and supplier-boundary candidate\n\n"
+        "FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:\n"
+        "  package/boot.img -> BOOT partition\n\n"
+        "Phase 230 preserves Phase 229, including KGPPOST 229, vold, odsign/\n"
+        "odrefresh, SurfaceFlinger and KGSL recording. It adds bounded one-shot\n"
+        "read-only checkpoints across platform matching, attach traversal,\n"
+        "supplier checks and the pre-callback stages of really_probe().\n\n"
+        "The artifact also compares the GPU DT dependency graph and relevant\n"
+        "driver-core functions with pinned TouchGrass commit 6bf351b.\n\n"
+        "No DT, match result, supplier link, probe result, service, security,\n"
+        "GPU power or firmware behavior is changed. Reed-Solomon remains RS48.\n\n"
+        "CI-validated, not hardware-validated. Follow PHASE230-HARDWARE-TEST.txt.\n"
+    )
+
+    sums = root / "SHA256SUMS"
+    if sums.exists():
+        sums.unlink()
+    files = sorted(path for path in root.rglob("*") if path.is_file() and path.name != "SHA256SUMS")
+    sums.write_text("".join(f"{sha256(path)}  ./{path.relative_to(root)}\n" for path in files))
+
+    out = Path("phase230-out")
+    if out.exists():
+        shutil.rmtree(out)
+    shutil.copytree(root, out)
+    return out
+

--- a/scripts/230_package_parts/03.pyfrag
+++ b/scripts/230_package_parts/03.pyfrag
@@ -1,0 +1,23 @@
+def main() -> int:
+    run_id, run_url, artifact_id = select_source()
+    work = Path("phase230-work")
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir()
+    zip_path = work / "inherited.zip"
+    download_artifact(artifact_id, zip_path)
+    extract = work / "inherited"
+    extract.mkdir()
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extractall(extract)
+    root = locate_root(extract)
+    package(root, run_id, run_url)
+    print(f"Phase 230 package prepared from source run {run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, urllib.error.URLError, zipfile.BadZipFile) as exc:
+        print(f"Phase 230 packaging failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/230_patcher_parts/00.pyfrag
+++ b/scripts/230_patcher_parts/00.pyfrag
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Run Phase 229, compare the GPU DT/driver core with TouchGrass, and trace the pre-probe boundary."""
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BASE_MARKER = "A52_PHASE229_KGSL_PLATFORM_PATH"
+PHASE230_MARKER = "A52_PHASE230_KGSL_DRIVERCORE_PATH"
+GPU_COMPAT = "qcom,kgsl-3d0"
+PLATFORM_REL = Path("drivers/base/platform.c")
+DD_REL = Path("drivers/base/dd.c")
+CORE_REL = Path("drivers/base/core.c")
+RECORDER_REL = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
+ADRENO_REL = Path("drivers/gpu/msm/adreno.c")
+KGB_ALLOW = '!strncmp(message, "KGBPOST ", 8)'
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def candidate_roots(arguments: list[str]) -> list[Path]:
+    roots: list[Path] = []
+    for value in arguments:
+        if value.startswith("-"):
+            continue
+        p = Path(value)
+        roots.extend((p, p.parent))
+    roots.extend((Path("workspace/gki-phase199-src"), Path("gki/common")))
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        key = root.resolve(strict=False)
+        if key not in seen:
+            seen.add(key)
+            out.append(root)
+    return out
+
+
+def locate_root(arguments: list[str]) -> Path:
+    matches: list[Path] = []
+    for root in candidate_roots(arguments):
+        paths = [root / rel for rel in (PLATFORM_REL, DD_REL, CORE_REL, RECORDER_REL, ADRENO_REL)]
+        if all(path.is_file() for path in paths):
+            recorder = paths[3].read_text(encoding="utf-8")
+            adreno = paths[4].read_text(encoding="utf-8")
+            if '!strncmp(message, "KGPPOST ", 8)' in recorder and BASE_MARKER in adreno:
+                matches.append(root)
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in matches:
+        key = root.resolve()
+        if key not in seen:
+            seen.add(key)
+            unique.append(root)
+    if len(unique) != 1:
+        rendered = ", ".join(str(p) for p in unique) or "none"
+        raise RuntimeError(f"expected one generated Phase 229 source root, found {len(unique)}: {rendered}")
+    return unique[0]
+
+
+def allow_count(text: str, token: str) -> int:
+    return len(re.findall(r"(?m)^[ \t]*" + re.escape(token) + r" \|\|$", text))
+
+
+def patch_recorder(text: str, label: str) -> str:
+    if '!strncmp(message, "KGPPOST ", 8)' not in text:
+        raise RuntimeError(f"{label}: missing Phase 229 KGPPOST retention entry")
+    count = allow_count(text, KGB_ALLOW)
+    if count == 0:
+        anchor = re.compile(r'(?m)^(?P<i>[ \t]*)!strncmp\(message, "KGPPOST ", 8\) \|\|$')
+        matches = list(anchor.finditer(text))
+        if len(matches) != 1:
+            raise RuntimeError(f"{label}: expected one KGPPOST allowlist anchor, found {len(matches)}")
+        match = matches[0]
+        replacement = match.group(0) + "\n" + match.group("i") + KGB_ALLOW + " ||"
+        text = text[:match.start()] + replacement + text[match.end():]
+    elif count != 1:
+        raise RuntimeError(f"{label}: KGBPOST allowlist count is {count}")
+    if allow_count(text, KGB_ALLOW) != 1:
+        raise RuntimeError(f"{label}: final KGBPOST allowlist audit failed")
+    return text
+
+
+PLATFORM_HELPER = r'''/* A52_PHASE230_KGSL_DRIVERCORE_PATH
+ * Read-only trace of the qcom,kgsl-3d0 platform match. No match result,
+ * driver override, probe ordering, dependency or return value is changed.
+ */
+static atomic_t a52_r230_platform_logged = ATOMIC_INIT(0);
+
+static bool a52_r230_gpu_device(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,kgsl-3d0");
+}
+
+static bool a52_r230_adreno_driver(const struct device_driver *drv)
+{
+	const struct of_device_id *id;
+
+	if (!drv || !drv->of_match_table)
+		return false;
+	for (id = drv->of_match_table;
+	     id->name[0] || id->type[0] || id->compatible[0]; id++)
+		if (!strcmp(id->compatible, "qcom,kgsl-3d0"))
+			return true;
+	return false;
+}
+
+'''
+
+
+def patch_platform(text: str, label: str) -> str:
+    if PHASE230_MARKER in text:
+        return text
+    anchor = "static int platform_match(struct device *dev, struct device_driver *drv)\n"
+    if text.count(anchor) != 1:
+        raise RuntimeError(f"{label}: platform_match anchor mismatch")
+    text = text.replace(anchor, PLATFORM_HELPER + anchor)
+    tail = (
+        "\telse\n"
+        "\t\tret = strcmp(pdev->name, drv->name) == 0;\n\n"
+        "\tif (dev->of_node &&\n"
+    )
+    if text.count(tail) != 1:
+        raise RuntimeError(f"{label}: platform_match result anchor mismatch")
+    replacement = (
+        "\telse\n"
+        "\t\tret = strcmp(pdev->name, drv->name) == 0;\n\n"
+        "\tif (a52_r230_gpu_device(dev) && a52_r230_adreno_driver(drv) &&\n"
+        "\t    atomic_cmpxchg(&a52_r230_platform_logged, 0, 1) == 0)\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 M r=%d of=%d ov=%d id=%d n=%.16s\",\n"
+        "\t\t\tret, of_driver_match_device(dev, drv) ? 1 : 0,\n"
+        "\t\t\tpdev->driver_override ? 1 : 0, pdrv->id_table ? 1 : 0,\n"
+        "\t\t\tdrv->name ? drv->name : \"-\");\n\n"
+        "\tif (dev->of_node &&\n"
+    )
+    text = text.replace(tail, replacement)
+    expected = {PHASE230_MARKER: 1, "KGBPOST 230 M": 1, "a52_r230_adreno_driver": 2}
+    for token, count in expected.items():
+        if text.count(token) != count:
+            raise RuntimeError(f"{label}: expected {count} {token!r}, found {text.count(token)}")
+    return text
+
+

--- a/scripts/230_patcher_parts/01.pyfrag
+++ b/scripts/230_patcher_parts/01.pyfrag
@@ -1,0 +1,245 @@
+DD_HELPER = r'''/* A52_PHASE230_KGSL_DRIVERCORE_PATH
+ * Read-only checkpoints from match/attach through the actual probe callback.
+ */
+static atomic_t a52_r230_dd_seen = ATOMIC_INIT(0);
+
+static bool a52_r230_dd_once(unsigned int bit)
+{
+	int old, new;
+
+	do {
+		old = atomic_read(&a52_r230_dd_seen);
+		if (old & BIT(bit))
+			return false;
+		new = old | BIT(bit);
+	} while (atomic_cmpxchg(&a52_r230_dd_seen, old, new) != old);
+	return true;
+}
+
+static bool a52_r230_gpu_pair(const struct device *dev,
+			      const struct device_driver *drv)
+{
+	const struct of_device_id *id;
+
+	if (!dev || !dev->of_node ||
+	    !of_device_is_compatible(dev->of_node, "qcom,kgsl-3d0") ||
+	    !drv || !drv->of_match_table)
+		return false;
+	for (id = drv->of_match_table;
+	     id->name[0] || id->type[0] || id->compatible[0]; id++)
+		if (!strcmp(id->compatible, "qcom,kgsl-3d0"))
+			return true;
+	return false;
+}
+
+'''
+
+
+def patch_dd(text: str, label: str) -> str:
+    if PHASE230_MARKER in text:
+        return text
+    helper_anchor = (
+        "static bool a52_smmu_unsec_trace_dev(const struct device *dev)\n"
+        "{\n"
+        "\treturn dev && dev->of_node &&\n"
+        "\t\tof_device_is_compatible(dev->of_node, \"qcom,smmu_sde_unsec\");\n"
+        "}\n\n"
+    )
+    if text.count(helper_anchor) != 1:
+        raise RuntimeError(f"{label}: dd helper anchor mismatch")
+    text = text.replace(helper_anchor, helper_anchor + "\n" + DD_HELPER)
+
+    attach_anchor = "\tret = driver_match_device(drv, dev);\n\tif (a52_smmu_unsec_trace_dev(dev) &&\n"
+    if text.count(attach_anchor) != 1:
+        raise RuntimeError(f"{label}: device-attach match anchor mismatch")
+    text = text.replace(
+        attach_anchor,
+        "\tret = driver_match_device(drv, dev);\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(0))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 UA m=%d ck=%d wa=%d\",\n"
+        "\t\t\tret, data->check_async, data->want_async);\n"
+        "\tif (a52_smmu_unsec_trace_dev(dev) &&\n",
+    )
+
+    driver_attach_anchor = (
+        "\tret = driver_match_device(drv, dev);\n"
+        "\tif (a52_rscc_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"RSCCCORE match path=driver-attach dev=%s drv=%s rc=%d\",\n"
+    )
+    if text.count(driver_attach_anchor) != 1:
+        raise RuntimeError(f"{label}: driver-attach match anchor mismatch")
+    text = text.replace(
+        driver_attach_anchor,
+        "\tret = driver_match_device(drv, dev);\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(1))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 DA m=%d dead=%d bound=%d\",\n"
+        "\t\t\tret, dev->p ? dev->p->dead : -1, dev->driver ? 1 : 0);\n"
+        "\tif (a52_rscc_probe_device(dev))\n"
+        "\t\ta52_ackfr_record(\"RSCCCORE match path=driver-attach dev=%s drv=%s rc=%d\",\n",
+    )
+
+    probe_start = "int driver_probe_device(struct device_driver *drv, struct device *dev)\n{\n\tint ret = 0;\n\n"
+    if text.count(probe_start) != 1:
+        raise RuntimeError(f"{label}: driver_probe_device start mismatch")
+    text = text.replace(
+        probe_start,
+        probe_start
+        + "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(2))\n"
+        + "\t\ta52_ackfr_record(\"KGBPOST 230 DP in reg=%d par=%d\",\n"
+        + "\t\t\tdevice_is_registered(dev), dev->parent ? 1 : 0);\n\n",
+    )
+    probe_after = (
+        "\telse\n"
+        "\t\tret = really_probe(dev, drv);\n"
+        "\tpm_request_idle(dev);\n"
+    )
+    if text.count(probe_after) != 1:
+        raise RuntimeError(f"{label}: driver_probe_device return anchor mismatch")
+    text = text.replace(
+        probe_after,
+        "\telse\n"
+        "\t\tret = really_probe(dev, drv);\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(3))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 DP out r=%d b=%d\",\n"
+        "\t\t\tret, dev->driver ? 1 : 0);\n"
+        "\tpm_request_idle(dev);\n",
+    )
+
+    really_decl = (
+        "\tbool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&\n"
+        "\t\t\t   !drv->suppress_bind_attrs;\n\n"
+    )
+    if text.count(really_decl) != 1:
+        raise RuntimeError(f"{label}: really_probe declaration anchor mismatch")
+    text = text.replace(
+        really_decl,
+        really_decl
+        + "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(4))\n"
+        + "\t\ta52_ackfr_record(\"KGBPOST 230 R in all=%d st=%d\",\n"
+        + "\t\t\tdefer_all_probes, dev->links.status);\n\n",
+    )
+
+    suppliers_anchor = "\tret = device_links_check_suppliers(dev);\n\tif (a52_smmu_unsec_trace_dev(dev))\n"
+    if text.count(suppliers_anchor) != 1:
+        raise RuntimeError(f"{label}: supplier return anchor mismatch")
+    text = text.replace(
+        suppliers_anchor,
+        "\tret = device_links_check_suppliers(dev);\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(5)) {\n"
+        "\t\tconst char *reason = dev->p && dev->p->deferred_probe_reason ?\n"
+        "\t\t\tdev->p->deferred_probe_reason : \"-\";\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 R sup=%d st=%d why=%.24s\",\n"
+        "\t\t\tret, dev->links.status, reason);\n"
+        "\t}\n"
+        "\tif (a52_smmu_unsec_trace_dev(dev))\n",
+    )
+
+    pin_anchor = "\tret = pinctrl_bind_pins(dev);\n\tif (a52_rscc_probe_device(dev))\n"
+    if text.count(pin_anchor) != 1:
+        raise RuntimeError(f"{label}: pinctrl anchor mismatch")
+    text = text.replace(
+        pin_anchor,
+        "\tret = pinctrl_bind_pins(dev);\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(6))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 R pin=%d\", ret);\n"
+        "\tif (a52_rscc_probe_device(dev))\n",
+    )
+
+    dma_to_sysfs = (
+        "\t} else if (a52_run40_preprobe_target(dev)) {\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t}\n\n"
+        "\tret = driver_sysfs_add(dev);\n"
+    )
+    if text.count(dma_to_sysfs) != 1:
+        raise RuntimeError(f"{label}: dma/sysfs anchor mismatch")
+    text = text.replace(
+        dma_to_sysfs,
+        "\t} else if (a52_run40_preprobe_target(dev)) {\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t}\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(7))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 R dma=%d rc=%d\",\n"
+        "\t\t\tdev->bus->dma_configure ? 1 : 0, ret);\n\n"
+        "\tret = driver_sysfs_add(dev);\n",
+    )
+
+    sysfs_anchor = "\tret = driver_sysfs_add(dev);\n\tif (a52_rscc_probe_device(dev))\n"
+    if text.count(sysfs_anchor) != 1:
+        raise RuntimeError(f"{label}: sysfs anchor mismatch")
+    text = text.replace(
+        sysfs_anchor,
+        "\tret = driver_sysfs_add(dev);\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(8))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 R sys=%d\", ret);\n"
+        "\tif (a52_rscc_probe_device(dev))\n",
+    )
+
+    pm_to_bus = (
+        "\t} else if (a52_run40_preprobe_target(dev)) {\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t}\n\n"
+        "\tif (dev->bus->probe) {\n"
+    )
+    if text.count(pm_to_bus) != 1:
+        raise RuntimeError(f"{label}: pm/bus anchor mismatch")
+    text = text.replace(
+        pm_to_bus,
+        "\t} else if (a52_run40_preprobe_target(dev)) {\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t\tdo { } while (0);\n"
+        "\t}\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(9))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 R pm=%d rc=%d\",\n"
+        "\t\t\tdev->pm_domain && dev->pm_domain->activate ? 1 : 0, ret);\n\n"
+        "\tif (dev->bus->probe) {\n",
+    )
+
+    bus_call = "\t\tret = dev->bus->probe(dev);\n\t\tif (a52_smmu_unsec_trace_dev(dev))\n"
+    if text.count(bus_call) != 1:
+        raise RuntimeError(f"{label}: bus probe call anchor mismatch")
+    text = text.replace(
+        bus_call,
+        "\t\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(10))\n"
+        "\t\t\ta52_ackfr_record(\"KGBPOST 230 R cb-in bus=1\");\n"
+        "\t\tret = dev->bus->probe(dev);\n"
+        "\t\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(11))\n"
+        "\t\t\ta52_ackfr_record(\"KGBPOST 230 R cb-out=%d\", ret);\n"
+        "\t\tif (a52_smmu_unsec_trace_dev(dev))\n",
+    )
+
+    done_anchor = "done:\n\tif (a52_smmu_unsec_trace_dev(dev))\n"
+    if text.count(done_anchor) != 1:
+        raise RuntimeError(f"{label}: really_probe done anchor mismatch")
+    text = text.replace(
+        done_anchor,
+        "done:\n"
+        "\tif (a52_r230_gpu_pair(dev, drv) && a52_r230_dd_once(12))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 R done=%d b=%d\",\n"
+        "\t\t\tret, dev->driver ? 1 : 0);\n"
+        "\tif (a52_smmu_unsec_trace_dev(dev))\n",
+    )
+
+    expected = {
+        PHASE230_MARKER: 1,
+        "KGBPOST 230 UA": 1,
+        "KGBPOST 230 DA": 1,
+        "KGBPOST 230 DP in": 1,
+        "KGBPOST 230 DP out": 1,
+        "KGBPOST 230 R sup": 1,
+        "KGBPOST 230 R cb-in": 1,
+        "KGBPOST 230 R cb-out": 1,
+    }
+    for token, count in expected.items():
+        if text.count(token) != count:
+            raise RuntimeError(f"{label}: expected {count} {token!r}, found {text.count(token)}")
+    return text
+
+

--- a/scripts/230_patcher_parts/02.pyfrag
+++ b/scripts/230_patcher_parts/02.pyfrag
@@ -1,0 +1,218 @@
+CORE_HELPER = r'''/* A52_PHASE230_KGSL_DRIVERCORE_PATH
+ * Read-only supplier diagnostics for the qcom,kgsl-3d0 consumer.
+ */
+static atomic_t a52_r230_core_seen = ATOMIC_INIT(0);
+
+static bool a52_r230_core_once(unsigned int bit)
+{
+	int old, new;
+
+	do {
+		old = atomic_read(&a52_r230_core_seen);
+		if (old & BIT(bit))
+			return false;
+		new = old | BIT(bit);
+	} while (atomic_cmpxchg(&a52_r230_core_seen, old, new) != old);
+	return true;
+}
+
+static bool a52_r230_gpu_consumer(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,kgsl-3d0");
+}
+
+'''
+
+
+def patch_core(text: str, label: str) -> str:
+    if PHASE230_MARKER in text:
+        return text
+    helper_anchor = (
+        "static bool a52_smmu_unsec_trace_dev(const struct device *dev)\n"
+        "{\n"
+        "\treturn dev && dev->of_node &&\n"
+        "\t\tof_device_is_compatible(dev->of_node, \"qcom,smmu_sde_unsec\");\n"
+        "}\n\n"
+    )
+    if text.count(helper_anchor) != 1:
+        raise RuntimeError(f"{label}: core helper anchor mismatch")
+    text = text.replace(helper_anchor, helper_anchor + "\n" + CORE_HELPER)
+
+    start_anchor = "\tstruct device_link *link;\n\tint ret = 0;\n\n\tif (a52_smmu_unsec_trace_dev(dev))\n"
+    if text.count(start_anchor) != 1:
+        raise RuntimeError(f"{label}: supplier check start mismatch")
+    text = text.replace(
+        start_anchor,
+        "\tstruct device_link *link;\n\tint ret = 0;\n\n"
+        "\tif (a52_r230_gpu_consumer(dev) && a52_r230_core_once(0))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 S in st=%d perm=%d fw=%d\",\n"
+        "\t\t\tdev->links.status, fw_devlink_is_permissive(),\n"
+        "\t\t\tdev->fwnode && !list_empty(&dev->fwnode->suppliers));\n\n"
+        "\tif (a52_smmu_unsec_trace_dev(dev))\n",
+    )
+
+    fw_anchor = (
+        "\t\tdev_dbg(dev, \"probe deferral - wait for supplier %pfwP\\n\",\n"
+        "\t\t\tlist_first_entry(&dev->fwnode->suppliers,\n"
+        "\t\t\tstruct fwnode_link,\n"
+        "\t\t\tc_hook)->supplier);\n"
+    )
+    if text.count(fw_anchor) != 1:
+        raise RuntimeError(f"{label}: fwnode supplier anchor mismatch")
+    text = text.replace(
+        fw_anchor,
+        fw_anchor
+        + "\t\tif (a52_r230_gpu_consumer(dev) && a52_r230_core_once(1))\n"
+        + "\t\t\ta52_ackfr_record(\"KGBPOST 230 S fw=%pfwP\",\n"
+        + "\t\t\t\tlist_first_entry(&dev->fwnode->suppliers,\n"
+        + "\t\t\t\tstruct fwnode_link, c_hook)->supplier);\n",
+    )
+
+    blocked_anchor = (
+        "\t\tif (link->status != DL_STATE_AVAILABLE &&\n"
+        "\t\t    !(link->flags & DL_FLAG_SYNC_STATE_ONLY)) {\n"
+        "\t\t\tdevice_links_missing_supplier(dev);\n"
+    )
+    if text.count(blocked_anchor) != 1:
+        raise RuntimeError(f"{label}: managed supplier anchor mismatch")
+    text = text.replace(
+        blocked_anchor,
+        "\t\tif (link->status != DL_STATE_AVAILABLE &&\n"
+        "\t\t    !(link->flags & DL_FLAG_SYNC_STATE_ONLY)) {\n"
+        "\t\t\tif (a52_r230_gpu_consumer(dev) && a52_r230_core_once(2))\n"
+        "\t\t\t\ta52_ackfr_record(\"KGBPOST 230 S dl=%.22s ls=%d f=%x ss=%d\",\n"
+        "\t\t\t\t\tdev_name(link->supplier), link->status, link->flags,\n"
+        "\t\t\t\t\tlink->supplier->links.status);\n"
+        "\t\t\tdevice_links_missing_supplier(dev);\n",
+    )
+
+    exit_anchor = (
+        "\tdevice_links_write_unlock();\n"
+        "\tif (a52_smmu_unsec_trace_dev(dev))\n"
+    )
+    if text.count(exit_anchor) != 1:
+        raise RuntimeError(f"{label}: supplier exit anchor mismatch")
+    text = text.replace(
+        exit_anchor,
+        "\tdevice_links_write_unlock();\n"
+        "\tif (a52_r230_gpu_consumer(dev) && a52_r230_core_once(3))\n"
+        "\t\ta52_ackfr_record(\"KGBPOST 230 S out=%d st=%d\", ret,\n"
+        "\t\t\tdev->links.status);\n"
+        "\tif (a52_smmu_unsec_trace_dev(dev))\n",
+    )
+    for token in (PHASE230_MARKER, "KGBPOST 230 S fw", "KGBPOST 230 S dl", "KGBPOST 230 S out"):
+        if text.count(token) != 1:
+            raise RuntimeError(f"{label}: expected exactly one {token!r}")
+    return text
+
+
+def strip_dts_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//.*", "", text)
+
+
+def gpu_node_blocks(path: Path) -> list[dict[str, object]]:
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    clean = strip_dts_comments(raw)
+    lines = clean.splitlines()
+    stack: list[tuple[int, int]] = []
+    matches: list[tuple[int, int]] = []
+    depth = 0
+    for idx, line in enumerate(lines):
+        opens = line.count("{")
+        closes = line.count("}")
+        for _ in range(opens):
+            stack.append((idx, depth))
+            depth += 1
+        if GPU_COMPAT in line and stack:
+            matches.append(stack[-1])
+        for _ in range(closes):
+            depth = max(depth - 1, 0)
+            if stack:
+                start, start_depth = stack[-1]
+                if start_depth >= depth:
+                    stack.pop()
+    out: list[dict[str, object]] = []
+    for start, start_depth in matches:
+        depth = 0
+        end = start
+        started = False
+        for idx in range(start, len(lines)):
+            line = lines[idx]
+            depth += line.count("{")
+            if line.count("{"):
+                started = True
+            depth -= line.count("}")
+            end = idx
+            if started and depth <= 0:
+                break
+        block = "\n".join(lines[start:end + 1]).strip() + "\n"
+        refs = sorted(set(re.findall(r"&([A-Za-z_][A-Za-z0-9_]*)", block)))
+        props = sorted(set(re.findall(r"(?m)^\s*([A-Za-z0-9,#._+\-]+)\s*=", block)))
+        out.append({
+            "path": str(path),
+            "start_line": start + 1,
+            "end_line": end + 1,
+            "sha256": hashlib.sha256(block.encode()).hexdigest(),
+            "references": refs,
+            "properties": props,
+            "block": block,
+        })
+    unique: list[dict[str, object]] = []
+    seen: set[tuple[int, int]] = set()
+    for row in out:
+        key = (int(row["start_line"]), int(row["end_line"]))
+        if key not in seen:
+            seen.add(key)
+            unique.append(row)
+    return unique
+
+
+def find_gpu_nodes(tree: Path) -> list[dict[str, object]]:
+    base = tree / "arch/arm64/boot/dts"
+    if not base.is_dir():
+        return []
+    rows: list[dict[str, object]] = []
+    for path in sorted(base.rglob("*.dts*")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if GPU_COMPAT not in text:
+            continue
+        for row in gpu_node_blocks(path):
+            row["path"] = str(path.relative_to(tree))
+            rows.append(row)
+    return rows
+
+
+def extract_function(text: str, name: str) -> str | None:
+    match = re.search(r"(?m)^(?:static\s+)?(?:[\w\s*]+)\b" + re.escape(name) + r"\s*\([^;]*\)\s*\{", text)
+    if not match:
+        return None
+    brace = text.find("{", match.start())
+    depth = 0
+    in_string = False
+    escape = False
+    for idx in range(brace, len(text)):
+        ch = text[idx]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[match.start():idx + 1] + "\n"
+    return None
+
+

--- a/scripts/230_patcher_parts/03.pyfrag
+++ b/scripts/230_patcher_parts/03.pyfrag
@@ -1,0 +1,182 @@
+def compare_driver_core(root: Path, touchgrass: Path) -> tuple[dict[str, object], str]:
+    pairs = [
+        ("drivers/base/platform.c", ["platform_match"]),
+        ("drivers/base/dd.c", ["really_probe", "driver_probe_device", "__device_attach_driver", "__driver_attach"]),
+        ("drivers/base/core.c", ["device_links_check_suppliers"]),
+    ]
+    rows: list[dict[str, object]] = []
+    chunks: list[str] = []
+    for rel, names in pairs:
+        current_path = root / rel
+        tg_path = touchgrass / rel
+        current_text = current_path.read_text(encoding="utf-8", errors="replace") if current_path.is_file() else ""
+        tg_text = tg_path.read_text(encoding="utf-8", errors="replace") if tg_path.is_file() else ""
+        for name in names:
+            current_fn = extract_function(current_text, name)
+            tg_fn = extract_function(tg_text, name)
+            same = current_fn is not None and tg_fn is not None and current_fn == tg_fn
+            rows.append({
+                "path": rel,
+                "function": name,
+                "current_present": current_fn is not None,
+                "touchgrass_present": tg_fn is not None,
+                "identical": same,
+                "current_sha256": hashlib.sha256((current_fn or "").encode()).hexdigest() if current_fn is not None else None,
+                "touchgrass_sha256": hashlib.sha256((tg_fn or "").encode()).hexdigest() if tg_fn is not None else None,
+            })
+            chunks.append(f"### {rel}: {name}\n")
+            if current_fn is None or tg_fn is None:
+                chunks.append(f"missing current={current_fn is None} touchgrass={tg_fn is None}\n\n")
+            else:
+                diff = difflib.unified_diff(
+                    tg_fn.splitlines(keepends=True), current_fn.splitlines(keepends=True),
+                    fromfile=f"touchgrass/{rel}:{name}", tofile=f"current-pre-phase230/{rel}:{name}", n=3,
+                )
+                rendered = "".join(diff)
+                chunks.append(rendered if rendered else "IDENTICAL\n")
+                chunks.append("\n")
+    return {
+        "phase": 230,
+        "comparison_point": "generated Phase 229 source immediately before Phase 230 instrumentation",
+        "touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "functions": rows,
+    }, "".join(chunks)
+
+
+def write_comparisons(root: Path) -> None:
+    touchgrass = Path("workspace/touchgrass-a52xq")
+    destinations = [Path("workspace/phase230-comparison"), Path("artifacts/a52xq-graphics-startup-trace/comparison")]
+    current_nodes = find_gpu_nodes(root)
+    tg_nodes = find_gpu_nodes(touchgrass) if touchgrass.is_dir() else []
+    dt_report = {
+        "phase": 230,
+        "compatible": GPU_COMPAT,
+        "touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "current_nodes": current_nodes,
+        "touchgrass_nodes": tg_nodes,
+        "current_reference_union": sorted({ref for row in current_nodes for ref in row["references"]}),
+        "touchgrass_reference_union": sorted({ref for row in tg_nodes for ref in row["references"]}),
+    }
+    dt_chunks = ["# qcom,kgsl-3d0 device-tree comparison\n\n"]
+    max_rows = max(len(current_nodes), len(tg_nodes))
+    for idx in range(max_rows):
+        current = current_nodes[idx] if idx < len(current_nodes) else None
+        tg = tg_nodes[idx] if idx < len(tg_nodes) else None
+        dt_chunks.append(f"## node {idx}\n")
+        if tg:
+            dt_chunks.append(f"TouchGrass: {tg['path']}:{tg['start_line']}-{tg['end_line']}\n")
+        if current:
+            dt_chunks.append(f"Current: {current['path']}:{current['start_line']}-{current['end_line']}\n")
+        if current and tg:
+            diff = difflib.unified_diff(
+                str(tg["block"]).splitlines(keepends=True), str(current["block"]).splitlines(keepends=True),
+                fromfile=f"touchgrass/{tg['path']}", tofile=f"current/{current['path']}", n=3,
+            )
+            rendered = "".join(diff)
+            dt_chunks.append(rendered if rendered else "IDENTICAL\n")
+        elif current:
+            dt_chunks.append(str(current["block"]))
+        elif tg:
+            dt_chunks.append(str(tg["block"]))
+        dt_chunks.append("\n")
+    core_report, core_text = compare_driver_core(root, touchgrass) if touchgrass.is_dir() else ({"phase": 230, "error": "TouchGrass source unavailable"}, "TouchGrass source unavailable\n")
+    for dest in destinations:
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "phase230-gpu-dt-touchgrass.json").write_text(json.dumps(dt_report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (dest / "phase230-gpu-dt-touchgrass.txt").write_text("".join(dt_chunks), encoding="utf-8")
+        (dest / "phase230-drivercore-touchgrass.json").write_text(json.dumps(core_report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (dest / "phase230-drivercore-touchgrass.txt").write_text(core_text, encoding="utf-8")
+    print(f"Phase 230 DT comparison: current_nodes={len(current_nodes)} touchgrass_nodes={len(tg_nodes)}")
+
+
+def patch_generated(arguments: list[str]) -> Path:
+    root = locate_root(arguments)
+    write_comparisons(root)
+    targets = {
+        PLATFORM_REL: patch_platform,
+        DD_REL: patch_dd,
+        CORE_REL: patch_core,
+        RECORDER_REL: patch_recorder,
+    }
+    for rel, patcher in targets.items():
+        path = root / rel
+        path.write_text(patcher(path.read_text(encoding="utf-8"), str(path)), encoding="utf-8")
+    stage_destinations = [Path("workspace/phase230-stage"), Path("artifacts/a52xq-graphics-startup-trace/stage")]
+    for dest in stage_destinations:
+        dest.mkdir(parents=True, exist_ok=True)
+        for rel in (PLATFORM_REL, DD_REL, CORE_REL, RECORDER_REL):
+            shutil.copy2(root / rel, dest / (str(rel).replace("/", "-") + "-after-phase230.c"))
+    return root
+
+
+def synthetic_platform() -> str:
+    return '''#include <linux/of_device.h>
+#include <linux/a52_ack_secure_flight_recorder.h>
+static int platform_match_id(void *a, void *b);
+static int platform_match(struct device *dev, struct device_driver *drv)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct platform_driver *pdrv = to_platform_driver(drv);
+	int ret;
+
+	if (pdev->driver_override)
+		ret = !strcmp(pdev->driver_override, drv->name);
+	else if (of_driver_match_device(dev, drv))
+		ret = 1;
+	else if (acpi_driver_match_device(dev, drv))
+		ret = 1;
+	else if (pdrv->id_table)
+		ret = platform_match_id(pdrv->id_table, pdev) != NULL;
+	else
+		ret = strcmp(pdev->name, drv->name) == 0;
+
+	if (dev->of_node &&
+	    of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec") &&
+	    !strcmp(drv->name, "msmdrm_smmu"))
+		a52_ackfr_record("DCORE platform-match drv=%s rc=%d", drv->name, ret);
+	return ret;
+}
+'''
+
+
+def self_test() -> None:
+    recorder = '/* KGPPOST 229 */\n\treturn !strncmp(message, "BOOT ", 5) ||\n\t       !strncmp(message, "KGPPOST ", 8) ||\n\t       !strncmp(message, "ODSPOST ", 8);\n'
+    patched_recorder = patch_recorder(recorder, "recorder-fixture")
+    if patch_recorder(patched_recorder, "recorder-idempotent") != patched_recorder:
+        raise AssertionError("recorder patch is not idempotent")
+    platform = synthetic_platform()
+    patched_platform = patch_platform(platform, "platform-fixture")
+    if patch_platform(patched_platform, "platform-idempotent") != patched_platform:
+        raise AssertionError("platform patch is not idempotent")
+    # The exact generated 5.10 files are validated by strict anchors during the inherited build.
+    for name, fn in (("dd", patch_dd), ("core", patch_core)):
+        source = Path(__file__).resolve().parent / f"phase230-selftest-{name}.c"
+        if source.is_file():
+            patched = fn(source.read_text(encoding="utf-8"), f"{name}-fixture")
+            if fn(patched, f"{name}-idempotent") != patched:
+                raise AssertionError(f"{name} patch is not idempotent")
+    print("Phase 230 KGSL driver-core pre-probe self-test: PASS")
+
+
+def main() -> int:
+    base = Path(__file__).with_name("229_phase228_kgsl_wrapper.py")
+    if "--self-test" in sys.argv[1:]:
+        if not base.is_file():
+            raise SystemExit(f"missing Phase 229 base wrapper: {base}")
+        completed = subprocess.run([sys.executable, str(base), "--self-test"], check=False)
+        if completed.returncode:
+            return completed.returncode
+        self_test()
+        return 0
+    if not base.is_file():
+        raise SystemExit(f"missing Phase 229 base wrapper: {base}")
+    completed = subprocess.run([sys.executable, str(base), *sys.argv[1:]], check=False)
+    if completed.returncode:
+        return completed.returncode
+    root = patch_generated(sys.argv[1:])
+    print(f"Phase 230 KGSL driver-core trace applied to {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/230_trigger.txt
+++ b/scripts/230_trigger.txt
@@ -1,0 +1,18 @@
+Phase 230 hardware capture
+
+1. Verify every file with SHA256SUMS.
+2. Flash only package/boot.img to the BOOT partition.
+3. Boot normally and do not interact with the phone.
+4. Allow the same automatic restart to occur.
+5. After recovery, collect the raw RAMOOPS archive exactly as for Phase 229.
+6. Preserve both frozen and live pstore copies when available.
+
+Expected retained markers:
+  KGBPOST 230
+  KGPPOST 229
+  TRIPOST 228
+  ODSPOST 226
+  GFXPOST 225 ks1
+  GFXPOST 225 ks2
+
+Do not interpret odsign exit value 9 as successful completion.


### PR DESCRIPTION
## Purpose

Phase 229 hardware evidence established that the live `qcom,kgsl-3d0` node is enabled, its `platform_device` exists, both KGSL platform drivers register successfully, but the device remains unbound and `adreno_probe()` is never called.

Phase 230 traces the read-only driver-core boundary before that callback.

## Added evidence

- focused TouchGrass comparison of every `qcom,kgsl-3d0` DTS/DTSI node and its direct phandle dependencies
- focused comparison of `platform_match()`, attach traversal, `driver_probe_device()`, `really_probe()` and `device_links_check_suppliers()`
- bounded one-shot `KGBPOST 230` records for:
  - platform and direct OF matching
  - `driver_override` and ID-table state
  - driver-centric and device-centric attach paths
  - supplier and firmware-link gating
  - pinctrl, DMA, sysfs and PM-domain pre-callback stages
  - platform bus probe callback entry and return

## Preserved evidence

- `KGPPOST 229`
- `TRIPOST 228`, including vold, odsign/odrefresh, SurfaceFlinger and KGSL state
- detailed `ODSPOST 226`
- `GFXPOST 225 ks1/ks2`
- RS(255,207), 48 parity symbols, CRC32C and transport-fusion

## Non-behavioral scope

This phase does not change DT data, match results, `driver_override`, supplier links, retry policy, callback results, GPU power, firmware, services, security decisions or device-node creation.

CI candidate only. Hardware validation remains required.