### PR TITLE
Phase 230: trace KGSL driver-core binding boundary

### DIFF
--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -72,7 +72,6 @@ jobs:
           test -f phase230-out/compile/Image
           grep -aFq 'KGPPOST 230' phase230-out/compile/Image
           grep -aFq 'KGPPOST 230 replay-begin' phase230-out/compile/Image
-          grep -aFq 'A52_PHASE230_KGSL_LATE_REPLAY' phase230-out/compile/Image
           grep -aFq 'KGPPOST 229' phase230-out/compile/Image
           grep -aFq 'TRIPOST 228' phase230-out/compile/Image
           grep -aFq 'ODSPOST 226' phase230-out/compile/Image

--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -56,7 +56,8 @@ jobs:
             scripts/230_package.py
           python3 scripts/227_phase226_retention_wrapper.py --self-test
           grep -RFq 'A52_PHASE230_KGSL_DRIVER_CORE_PATH' scripts/230_patcher_parts
-          grep -RFq 'KGPPOST 230' scripts/230_patcher_parts
+          grep -RFq 'A52_PHASE230_KGSL_LATE_REPLAY' scripts/230_patcher_parts
+          grep -RFq 'KGPPOST 230 replay-begin' scripts/230_patcher_parts
           grep -Fq '__driver_attach()' scripts/230_design.md
           grep -Fq '__device_attach_driver()' scripts/230_design.md
           grep -Fq 'RS(255,207)' scripts/230_design.md
@@ -70,6 +71,8 @@ jobs:
           test -f phase230-out/package/boot.img
           test -f phase230-out/compile/Image
           grep -aFq 'KGPPOST 230' phase230-out/compile/Image
+          grep -aFq 'KGPPOST 230 replay-begin' phase230-out/compile/Image
+          grep -aFq 'A52_PHASE230_KGSL_LATE_REPLAY' phase230-out/compile/Image
           grep -aFq 'KGPPOST 229' phase230-out/compile/Image
           grep -aFq 'TRIPOST 228' phase230-out/compile/Image
           grep -aFq 'ODSPOST 226' phase230-out/compile/Image

--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -4,6 +4,30 @@ run-name: Build and audit Phase 230 KGSL driver-core path candidate
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase230-kgsl-driver-core-path-v1
+    paths:
+      - .github/workflows/230-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/229_phase228_kgsl_wrapper.py
+      - scripts/230_patcher_parts/**
+      - scripts/230_fixtures/**
+      - scripts/230_package.py
+      - scripts/230_design.md
+      - scripts/230_trigger.txt
+  pull_request:
+    branches:
+      - agent/a52-phase229-kgsl-touchgrass-bindpath-v1
+    paths:
+      - .github/workflows/230-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/229_phase228_kgsl_wrapper.py
+      - scripts/230_patcher_parts/**
+      - scripts/230_fixtures/**
+      - scripts/230_package.py
+      - scripts/230_design.md
+      - scripts/230_trigger.txt
 
 permissions:
   actions: write

--- a/.github/workflows/230-dispatch-builder.yml
+++ b/.github/workflows/230-dispatch-builder.yml
@@ -1,0 +1,63 @@
+name: 230 - A52 KGSL driver-core path recorder
+
+run-name: Build and audit Phase 230 KGSL driver-core path candidate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: a52-phase230-kgsl-driver-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-package:
+    name: Build and package Phase 230
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 230 branch
+        uses: actions/checkout@v4
+
+      - name: Verify Phase 230 source
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile \
+            scripts/227_phase226_retention_wrapper.py \
+            scripts/229_phase228_kgsl_wrapper.py \
+            scripts/230_package.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+          grep -RFq 'A52_PHASE230_KGSL_DRIVER_CORE_PATH' scripts/230_patcher_parts
+          grep -RFq 'KGPPOST 230' scripts/230_patcher_parts
+          grep -Fq '__driver_attach()' scripts/230_design.md
+          grep -Fq '__device_attach_driver()' scripts/230_design.md
+          grep -Fq 'RS(255,207)' scripts/230_design.md
+
+      - name: Dispatch inherited builder and package Phase 230
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          python3 scripts/230_package.py
+          test -f phase230-out/package/boot.img
+          test -f phase230-out/compile/Image
+          grep -aFq 'KGPPOST 230' phase230-out/compile/Image
+          grep -aFq 'KGPPOST 229' phase230-out/compile/Image
+          grep -aFq 'TRIPOST 228' phase230-out/compile/Image
+          grep -aFq 'ODSPOST 226' phase230-out/compile/Image
+          (
+            cd phase230-out
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Upload Phase 230 candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase230-KGSL-Driver-Core-Path-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase230-out
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/230-recover-source-artifact.yml
+++ b/.github/workflows/230-recover-source-artifact.yml
@@ -13,11 +13,6 @@ on:
         description: Artifact ID produced by that run
         required: true
         type: string
-  push:
-    branches:
-      - agent/a52-phase230-kgsl-driver-core-path-v1
-    paths:
-      - .github/workflows/230-recover-source-artifact.yml
 
 permissions:
   actions: read
@@ -44,8 +39,8 @@ jobs:
       - name: Recover and package
         env:
           GH_TOKEN: ${{ github.token }}
-          PHASE230_SOURCE_RUN_ID: ${{ inputs.source_run_id || '31023267930' }}
-          PHASE230_SOURCE_ARTIFACT_ID: ${{ inputs.source_artifact_id || '8938481236' }}
+          PHASE230_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          PHASE230_SOURCE_ARTIFACT_ID: ${{ inputs.source_artifact_id }}
         run: |
           set -Eeuo pipefail
           python3 scripts/230_package.py

--- a/.github/workflows/230-recover-source-artifact.yml
+++ b/.github/workflows/230-recover-source-artifact.yml
@@ -1,0 +1,59 @@
+name: 230 - Recover KGSL driver-core source artifact
+
+run-name: Recover and package Phase 230 source artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful inherited source-build run ID
+        required: true
+        type: string
+      source_artifact_id:
+        description: Artifact ID produced by that run
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  recover:
+    name: Audit and package Phase 230 source
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify loaders
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile \
+            scripts/227_phase226_retention_wrapper.py \
+            scripts/229_phase228_kgsl_wrapper.py \
+            scripts/230_package.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+
+      - name: Recover and package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PHASE230_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          PHASE230_SOURCE_ARTIFACT_ID: ${{ inputs.source_artifact_id }}
+        run: |
+          set -Eeuo pipefail
+          python3 scripts/230_package.py
+          test -f phase230-out/package/boot.img
+          grep -aFq 'KGPPOST 230' phase230-out/compile/Image
+          (
+            cd phase230-out
+            sha256sum -c SHA256SUMS
+          )
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase230-KGSL-Driver-Core-Path-Recovered-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase230-out
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/230-recover-source-artifact.yml
+++ b/.github/workflows/230-recover-source-artifact.yml
@@ -13,6 +13,11 @@ on:
         description: Artifact ID produced by that run
         required: true
         type: string
+  push:
+    branches:
+      - agent/a52-phase230-kgsl-driver-core-path-v1
+    paths:
+      - .github/workflows/230-recover-source-artifact.yml
 
 permissions:
   actions: read
@@ -39,13 +44,15 @@ jobs:
       - name: Recover and package
         env:
           GH_TOKEN: ${{ github.token }}
-          PHASE230_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
-          PHASE230_SOURCE_ARTIFACT_ID: ${{ inputs.source_artifact_id }}
+          PHASE230_SOURCE_RUN_ID: ${{ inputs.source_run_id || '31023267930' }}
+          PHASE230_SOURCE_ARTIFACT_ID: ${{ inputs.source_artifact_id || '8938481236' }}
         run: |
           set -Eeuo pipefail
           python3 scripts/230_package.py
           test -f phase230-out/package/boot.img
           grep -aFq 'KGPPOST 230' phase230-out/compile/Image
+          grep -aFq 'KGPPOST 230 replay-begin' phase230-out/compile/Image
+          grep -aFq 'KGPPOST 229' phase230-out/compile/Image
           (
             cd phase230-out
             sha256sum -c SHA256SUMS

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Load the checked-in, readable Phase 229 implementation fragments."""
+"""Load the checked-in, readable Phase 230 implementation fragments."""
 from __future__ import annotations
 
 from pathlib import Path
 
-payload_dir = Path(__file__).resolve().parent / "229_patcher_parts"
+payload_dir = Path(__file__).resolve().parent / "230_patcher_parts"
 parts = sorted(payload_dir.glob("*.pyfrag"))
 if not parts:
-    raise SystemExit(f"missing Phase 229 patcher source fragments: {payload_dir}")
+    raise SystemExit(f"missing Phase 230 patcher source fragments: {payload_dir}")
 source = "".join(part.read_text(encoding="utf-8") for part in parts)
-exec(compile(source, str(payload_dir / "phase229_impl.py"), "exec"), globals(), globals())
+exec(compile(source, str(payload_dir / "phase230_patcher_impl.py"), "exec"), globals(), globals())

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -9,4 +9,10 @@ parts = sorted(payload_dir.glob("*.pyfrag"))
 if not parts:
     raise SystemExit(f"missing Phase 230 patcher source fragments: {payload_dir}")
 source = "".join(part.read_text(encoding="utf-8") for part in parts)
+main_guard = '\nif __name__ == "__main__":\n    raise SystemExit(main())\n'
+if source.count(main_guard) != 1:
+    raise SystemExit(
+        f"expected one Phase 230 main guard before extension, found {source.count(main_guard)}"
+    )
+source = source.replace(main_guard, "\n", 1) + main_guard
 exec(compile(source, str(payload_dir / "phase230_patcher_impl.py"), "exec"), globals(), globals())

--- a/scripts/229_phase228_kgsl_wrapper.py
+++ b/scripts/229_phase228_kgsl_wrapper.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Load the checked-in, readable Phase 229 implementation fragments."""
+from __future__ import annotations
+
+from pathlib import Path
+
+payload_dir = Path(__file__).resolve().parent / "229_patcher_parts"
+parts = sorted(payload_dir.glob("*.pyfrag"))
+if not parts:
+    raise SystemExit(f"missing Phase 229 patcher source fragments: {payload_dir}")
+source = "".join(part.read_text(encoding="utf-8") for part in parts)
+exec(compile(source, str(payload_dir / "phase229_patcher_impl.py"), "exec"), globals(), globals())

--- a/scripts/230_design.md
+++ b/scripts/230_design.md
@@ -57,3 +57,14 @@ Phase 230 does not:
 - change vold, odsign, odrefresh, SurfaceFlinger, shutdown or reboot behavior
 
 The candidate is CI-audited and still requires hardware validation.
+
+## Hardware-capture retention correction
+
+The first Phase 230 hardware capture contained 1,028 CRC-valid RS(255,207)
+records, but its surviving window began around 139 seconds. The driver-core
+records are one-shot early-boot events and had already been overwritten.
+
+The revised recorder journals the first 96 original `KGPPOST 230` messages in
+a bounded static metadata buffer and re-emits them unchanged at heartbeat ticks
+150 and 180, bracketed by `replay-begin` and `replay-end` records. Replay does
+not rerun matching or probing and does not modify any driver-core state.

--- a/scripts/230_design.md
+++ b/scripts/230_design.md
@@ -1,0 +1,59 @@
+# Phase 230: KGSL platform-match and driver-core path recorder
+
+## Evidence entering this phase
+
+Phase 229 proves that the live `qcom,kgsl-3d0` node is enabled, its exact
+`platform_device` exists, and both KGSL platform drivers register successfully.
+The GPU device nevertheless remains unbound for the full surviving trace and
+`adreno_probe()` is never entered.
+
+The exact source comparison also shows that the ported KGSL tree retains the
+TouchGrass registration and OF-match contract. The remaining boundary is in
+platform matching, driver/device attachment, or the pre-callback supplier gate.
+
+## Observation scope
+
+Phase 230 runs Phase 229 unchanged, then adds bounded `KGPPOST 230` metadata for
+only the exact `qcom,kgsl-3d0` consumer and `kgsl-3d` driver pair.
+
+It records:
+
+- `driver_attach()` traversal for the registering Adreno driver
+- `__driver_attach()` and `__device_attach_driver()` match results
+- `platform_match()` route, final result, `driver_override`, platform name and
+  OF-table presence
+- `driver_probe_device()` entry and return
+- `really_probe()` entry and every pre-callback stage
+- `device_links_check_suppliers()` result and deferred-probe reason
+- unresolved firmware suppliers, including supplier fwnode, device and driver
+- managed device-link supplier name, OF path, driver, status and flags
+- deferred-list add, retry and delete activity
+- pinctrl, DMA, driver-sysfs, PM-domain and platform-probe callback boundaries
+
+The trace is capped independently in `platform.c`, `dd.c`, and `core.c` to avoid
+unbounded recorder pressure. Existing Phase 229 snapshots, Phase 228 cumulative
+state, detailed `ODSPOST 226`, KGSL late-state records, and RS(255,207) with 48
+parity symbols are retained.
+
+## Important attach-path correction
+
+A platform driver registering after its device normally enters the driver-led
+path through `driver_attach()` and `__driver_attach()`. A device appearing after
+the driver uses `__device_attach_driver()`. Phase 230 traces both directions so
+the initial Adreno attempt cannot be missed.
+
+## Safety and non-goals
+
+Phase 230 does not:
+
+- force a platform match or bind
+- modify `driver_override`
+- remove, relax, or synthesize supplier links
+- change `fw_devlink`
+- retry a probe manually
+- alter a return value or deferred-probe decision
+- modify DT, clocks, regulators, power domains, IOMMU, firmware or GPU power
+- create `/dev/kgsl-3d0` manually
+- change vold, odsign, odrefresh, SurfaceFlinger, shutdown or reboot behavior
+
+The candidate is CI-audited and still requires hardware validation.

--- a/scripts/230_fixtures/core.c
+++ b/scripts/230_fixtures/core.c
@@ -1,0 +1,91 @@
+/* fixture gap */
+
+/* Device links support. */
+static LIST_HEAD(deferred_sync);
+static unsigned int defer_sync_state_count = 1;
+static DEFINE_MUTEX(fwnode_link_lock);
+static struct workqueue_struct *device_link_wq;
+static bool fw_devlink_is_permissive(void);
+
+static bool a52_smmu_unsec_trace_dev(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec");
+}
+
+
+/**
+ * fwnode_link_add - Create a link between two fwnode_handles.
+ * @con: Consumer end of the link.
+ * @sup: Supplier end of the link.
+ *
+ * Create a fwnode link between fwnode handles @con and @sup. The fwnode link
+ * represents the detail that the firmware lists @sup fwnode as supplying a
+ * resource to @con.
+/* fixture gap */
+ * mark the link as "consumer probe in progress" to make the supplier removal
+ * wait for us to complete (or bad things may happen).
+ *
+ * Links without the DL_FLAG_MANAGED flag set are ignored.
+ */
+int device_links_check_suppliers(struct device *dev)
+{
+	struct device_link *link;
+	int ret = 0;
+
+	if (a52_smmu_unsec_trace_dev(dev))
+		a52_ackfr_record("DLINK check enter dev=%s status=%d permissive=%d",
+			dev_name(dev), dev->links.status, fw_devlink_is_permissive());
+
+	/*
+	 * Device waiting for supplier to become available is not allowed to
+	 * probe.
+	 */
+	mutex_lock(&fwnode_link_lock);
+	if (dev->fwnode && !list_empty(&dev->fwnode->suppliers) &&
+	    !fw_devlink_is_permissive()) {
+		dev_dbg(dev, "probe deferral - wait for supplier %pfwP\n",
+			list_first_entry(&dev->fwnode->suppliers,
+			struct fwnode_link,
+			c_hook)->supplier);
+		if (a52_smmu_unsec_trace_dev(dev))
+			a52_ackfr_record("DLINK fwnode wait supplier=%pfwP",
+				list_first_entry(&dev->fwnode->suppliers,
+				struct fwnode_link, c_hook)->supplier);
+		mutex_unlock(&fwnode_link_lock);
+		return -EPROBE_DEFER;
+	}
+	mutex_unlock(&fwnode_link_lock);
+
+	device_links_write_lock();
+
+	list_for_each_entry(link, &dev->links.suppliers, c_node) {
+		if (a52_smmu_unsec_trace_dev(dev))
+			a52_ackfr_record("DLINK supplier=%s st=%d flags=%x supst=%d",
+				dev_name(link->supplier), link->status, link->flags,
+				link->supplier->links.status);
+		if (!(link->flags & DL_FLAG_MANAGED))
+			continue;
+
+		if (link->status != DL_STATE_AVAILABLE &&
+		    !(link->flags & DL_FLAG_SYNC_STATE_ONLY)) {
+			device_links_missing_supplier(dev);
+			dev_dbg(dev, "probe deferral - supplier %s not ready\n",
+				dev_name(link->supplier));
+			ret = -EPROBE_DEFER;
+			break;
+		}
+		WRITE_ONCE(link->status, DL_STATE_CONSUMER_PROBE);
+	}
+	dev->links.status = DL_DEV_PROBING;
+
+	device_links_write_unlock();
+	if (a52_smmu_unsec_trace_dev(dev))
+		a52_ackfr_record("DLINK check exit rc=%d status=%d", ret,
+			dev->links.status);
+	return ret;
+}
+
+/**
+ * __device_links_queue_sync_state - Queue a device for sync_state() callback
+ * @dev: Device to call sync_state() on

--- a/scripts/230_fixtures/dd.c
+++ b/scripts/230_fixtures/dd.c
@@ -1,0 +1,85 @@
+/* fixture helper */
+static bool a52_smmu_unsec_trace_dev(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec");
+}
+
+/* fixture deferred retry */
+		dev = private->device;
+		list_del_init(&private->deferred_probe);
+
+/* fixture deferred add */
+	mutex_lock(&deferred_probe_mutex);
+	if (list_empty(&dev->p->deferred_probe)) {
+
+/* fixture deferred del */
+void driver_deferred_probe_del(struct device *dev)
+{
+	mutex_lock(&deferred_probe_mutex);
+
+/* fixture really probe */
+static int really_probe(struct device *dev, struct device_driver *drv)
+{
+	int ret = -EPROBE_DEFER;
+	int local_trigger_count = atomic_read(&deferred_trigger_count);
+	bool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&
+			   !drv->suppress_bind_attrs;
+
+	ret = device_links_check_suppliers(dev);
+
+	if (ret == -EPROBE_DEFER)
+		driver_deferred_probe_add_trigger(dev, local_trigger_count);
+	if (ret)
+		return ret;
+
+	ret = pinctrl_bind_pins(dev);
+
+		ret = dev->bus->dma_configure(dev);
+
+	ret = driver_sysfs_add(dev);
+	if (a52_rscc_probe_device(dev))
+
+		ret = dev->pm_domain->activate(dev);
+
+		ret = dev->bus->probe(dev);
+
+		ret = drv->probe(dev);
+
+/* fixture driver probe */
+int driver_probe_device(struct device_driver *drv, struct device *dev)
+{
+	int ret = 0;
+
+	if (a52_rscc_probe_device(dev))
+		a52_ackfr_record("RSCCCORE driver-probe exit dev=%s rc=%d bound=%s",
+			dev_name(dev), ret, dev->driver && dev->driver->name ?
+			dev->driver->name : "-");
+	return ret;
+}
+
+static inline bool cmdline_requested_async_probing
+
+/* fixture device attach */
+	ret = driver_match_device(drv, dev);
+	if (a52_smmu_unsec_trace_dev(dev) &&
+
+	if (a52_smmu_unsec_trace_dev(dev))
+		a52_ackfr_record("DCORE match probe drv=%s async=%d",
+			drv->name, async_allowed);
+	return driver_probe_device(drv, dev);
+}
+
+/* fixture driver attach */
+	ret = driver_match_device(drv, dev);
+	if (a52_rscc_probe_device(dev))
+
+	device_driver_attach(drv, dev);
+
+	return 0;
+}
+
+int driver_attach(struct device_driver *drv)
+{
+	return bus_for_each_dev(drv->bus, NULL, drv, __driver_attach);
+}

--- a/scripts/230_fixtures/platform.c
+++ b/scripts/230_fixtures/platform.c
@@ -1,0 +1,82 @@
+/* fixture gap */
+#include <linux/acpi.h>
+#include <linux/clk/clk-conf.h>
+#include <linux/limits.h>
+#include <linux/property.h>
+#include <linux/kmemleak.h>
+#include <linux/types.h>
+#include <linux/a52_ack_secure_flight_recorder.h>
+
+#include "base.h"
+#include "power/power.h"
+
+/* For automatically allocated device IDs */
+static DEFINE_IDA(platform_devid_ida);
+
+/* fixture gap */
+			pdev->name);
+	return 0;
+}
+
+static const struct platform_device_id *platform_match_id(
+			const struct platform_device_id *id,
+			struct platform_device *pdev)
+{
+	while (id->name[0]) {
+		if (strcmp(pdev->name, id->name) == 0) {
+			pdev->id_entry = id;
+			return id;
+		}
+		id++;
+	}
+	return NULL;
+}
+
+/**
+ * platform_match - bind platform device to platform driver.
+ * @dev: device.
+ * @drv: driver.
+ *
+ * Platform device IDs are assumed to be encoded like this:
+ * "<name><instance>", where <name> is a short description of the type of
+ * device, like "pci" or "floppy", and <instance> is the enumerated
+ * instance of the device, like '0' or '42'.  Driver IDs are simply
+ * "<name>".  So, extract the <name> from the platform_device structure,
+ * and compare it against the name of the driver. Return whether they match
+ * or not.
+ */
+static int platform_match(struct device *dev, struct device_driver *drv)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct platform_driver *pdrv = to_platform_driver(drv);
+	int ret;
+
+	/* When driver_override is set, only bind to the matching driver */
+	if (pdev->driver_override)
+		ret = !strcmp(pdev->driver_override, drv->name);
+	else if (of_driver_match_device(dev, drv))
+		ret = 1;
+	else if (acpi_driver_match_device(dev, drv))
+		ret = 1;
+	else if (pdrv->id_table)
+		ret = platform_match_id(pdrv->id_table, pdev) != NULL;
+	else
+		ret = strcmp(pdev->name, drv->name) == 0;
+
+	if (dev->of_node &&
+	    of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec") &&
+	    !strcmp(drv->name, "msmdrm_smmu"))
+		a52_ackfr_record("DCORE platform-match drv=%s rc=%d",
+			drv->name, ret);
+	return ret;
+}
+
+#ifdef CONFIG_PM_SLEEP
+
+static int platform_legacy_suspend(struct device *dev, pm_message_t mesg)
+{
+	struct platform_driver *pdrv = to_platform_driver(dev->driver);
+	struct platform_device *pdev = to_platform_device(dev);
+	int ret = 0;
+
+	if (dev->driver && pdrv->suspend)

--- a/scripts/230_fixtures/recorder.c
+++ b/scripts/230_fixtures/recorder.c
@@ -1,0 +1,31 @@
+/* A52_PHASE228_TRI_TRACK_SNAPSHOT */
+#define A52_R179_MESSAGE_LEN 90U
+
+static void a52_r228_track_message(const char *message)
+{
+}
+
+static void a52_r179_write_control(const char *kind)
+{
+}
+
+void a52_ackfr_record(const char *fmt, ...)
+{
+	struct a52_r179_event event;
+	va_list args;
+
+	va_start(args, fmt);
+	vscnprintf(event.message, sizeof(event.message), fmt, args);
+	va_end(args);
+	a52_r228_track_message(event.message);
+}
+
+static atomic_t a52_r179_heartbeat_count = ATOMIC_INIT(0);
+
+static void a52_r179_heartbeat_fn(struct work_struct *work)
+{
+	unsigned int tick;
+
+	tick = (unsigned int)atomic_inc_return(&a52_r179_heartbeat_count);
+	a52_r226_task_snapshot(tick);
+}

--- a/scripts/230_package.py
+++ b/scripts/230_package.py
@@ -119,7 +119,9 @@ def locate_root(base: Path) -> Path:
 def verify_markers(image: Path) -> None:
     data = image.read_bytes()
     for marker in (
-        b"KGPPOST 230", b"KGPPOST 229", b"TRIPOST 228", b"ODSPOST 226",
+        b"KGPPOST 230", b"KGPPOST 230 replay-begin",
+        b"A52_PHASE230_KGSL_LATE_REPLAY", b"KGPPOST 229",
+        b"TRIPOST 228", b"ODSPOST 226",
         b"GFXPOST 225 ks1", b"GFXPOST 225 ks2",
     ):
         if marker not in data:
@@ -155,6 +157,9 @@ def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
         "phase230_platform_record_limit": 32,
         "phase230_dd_record_limit": 160,
         "phase230_core_record_limit": 96,
+        "phase230_replay_journal_capacity": 96,
+        "phase230_replay_ticks": [150, 180],
+        "phase230_early_records_replayed_late": True,
         "phase230_behavior_changed": False,
         "phase230_supplier_decisions_changed": False,
         "phase230_return_values_changed": False,
@@ -177,7 +182,7 @@ def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
         "source_builder_run_url": source_run_url,
         "touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
         "hardware_validated": False,
-        "change": "KGSL platform-match, bidirectional attach, supplier and pre-probe trace",
+        "change": "KGSL platform-match, bidirectional attach, supplier trace and bounded late replay",
         "rs_roots": 48,
     }
     (root / "BUILD-IDENTITY.json").write_text(json.dumps(identity, indent=2, sort_keys=True) + "\n")
@@ -188,7 +193,9 @@ def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
         "Phase 230 preserves Phase 229 and adds bounded metadata-only tracing\n"
         "for the exact qcom,kgsl-3d0 / kgsl-3d platform match, both attach\n"
         "directions, deferred-probe state, supplier identities and every\n"
-        "pre-callback driver-core boundary.\n\n"
+        "pre-callback driver-core boundary. Early KGPPOST 230 records are\n"
+        "journaled and replayed at heartbeat ticks 150 and 180 so they survive\n"
+        "the observed RAMOOPS overwrite window.\n\n"
         "No match, supplier, DT, return-value, power, IOMMU, firmware, service\n"
         "or security behavior is changed. Reed-Solomon remains RS48.\n\n"
         "CI-validated, not hardware-validated. Follow PHASE230-HARDWARE-TEST.txt.\n"

--- a/scripts/230_package.py
+++ b/scripts/230_package.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["GH_TOKEN"]
+REF = "agent/a52-phase230-kgsl-driver-core-path-v1"
+WORKFLOW_ID = 325785868
+API = f"https://api.github.com/repos/{REPO}"
+
+
+def request(url: str, *, method: str = "GET", data: dict | None = None) -> bytes:
+    body = None if data is None else json.dumps(data).encode()
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=120) as response:
+        return response.read()
+
+
+def get_json(url: str) -> dict:
+    return json.loads(request(url))
+
+
+def dispatch_and_wait() -> tuple[int, str, int]:
+    started = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    request(f"{API}/actions/workflows/{WORKFLOW_ID}/dispatches", method="POST", data={"ref": REF})
+    run = None
+    for _ in range(40):
+        data = get_json(f"{API}/actions/workflows/{WORKFLOW_ID}/runs?branch={REF}&event=workflow_dispatch&per_page=20")
+        candidates = [r for r in data.get("workflow_runs", []) if r.get("created_at", "") >= started]
+        if candidates:
+            run = sorted(candidates, key=lambda r: r["created_at"])[-1]
+            break
+        time.sleep(15)
+    if not run:
+        raise RuntimeError("dispatched inherited build was not found")
+    run_id = int(run["id"])
+    print(f"Monitoring {run['html_url']}", flush=True)
+    for _ in range(720):
+        run = get_json(f"{API}/actions/runs/{run_id}")
+        print(f"run={run_id} status={run['status']} conclusion={run.get('conclusion') or 'pending'}", flush=True)
+        if run["status"] == "completed":
+            break
+        time.sleep(30)
+    if run.get("conclusion") != "success":
+        raise RuntimeError(f"inherited builder conclusion: {run.get('conclusion')}")
+    artifacts = get_json(f"{API}/actions/runs/{run_id}/artifacts?per_page=100").get("artifacts", [])
+    artifacts = [a for a in artifacts if not a.get("expired")]
+    if not artifacts:
+        raise RuntimeError("successful inherited build produced no artifact")
+    artifact = artifacts[-1]
+    return run_id, run["html_url"], int(artifact["id"])
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def download_artifact(artifact_id: int, dest: Path) -> None:
+    api_url = f"{API}/actions/artifacts/{artifact_id}/zip"
+    req = urllib.request.Request(api_url, method="GET")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        opener.open(req, timeout=120)
+        raise RuntimeError("artifact download unexpectedly returned without redirect")
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (301, 302, 303, 307, 308):
+            raise
+        location = exc.headers.get("Location")
+        if not location:
+            raise RuntimeError("artifact redirect did not include Location") from exc
+    with urllib.request.urlopen(location, timeout=120) as response:
+        dest.write_bytes(response.read())
+
+
+def select_source() -> tuple[int, str, int]:
+    artifact = os.environ.get("PHASE230_SOURCE_ARTIFACT_ID")
+    run = os.environ.get("PHASE230_SOURCE_RUN_ID")
+    if artifact and run:
+        run_id = int(run)
+        return run_id, f"https://github.com/{REPO}/actions/runs/{run_id}", int(artifact)
+    if artifact or run:
+        raise RuntimeError("both PHASE230_SOURCE_ARTIFACT_ID and PHASE230_SOURCE_RUN_ID are required")
+    return dispatch_and_wait()
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def locate_root(base: Path) -> Path:
+    matches = list(base.rglob("package/boot.img"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one package/boot.img, found {len(matches)}")
+    return matches[0].parent.parent
+
+
+def verify_markers(image: Path) -> None:
+    data = image.read_bytes()
+    for marker in (
+        b"KGPPOST 230", b"KGPPOST 229", b"TRIPOST 228", b"ODSPOST 226",
+        b"GFXPOST 225 ks1", b"GFXPOST 225 ks2",
+    ):
+        if marker not in data:
+            raise RuntimeError(f"missing binary marker: {marker.decode()}")
+        print(f"binary marker present: {marker.decode()}")
+
+
+def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
+    verify_markers(root / "compile/Image")
+
+    audit_dir = root / "audit/phase230"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2("scripts/227_phase226_retention_wrapper.py", audit_dir / "phase230_driver_core_loader.py")
+    shutil.copy2("scripts/229_phase228_kgsl_wrapper.py", audit_dir / "phase229_kgsl_loader.py")
+    shutil.copy2("scripts/230_package.py", audit_dir / "phase230_package.py")
+    shutil.copytree("scripts/230_patcher_parts", audit_dir / "patcher_parts", dirs_exist_ok=True)
+    shutil.copytree("scripts/230_fixtures", audit_dir / "fixtures", dirs_exist_ok=True)
+    shutil.copy2("scripts/230_design.md", root / "PHASE230-DESIGN.md")
+    shutil.copy2("scripts/230_trigger.txt", root / "PHASE230-HARDWARE-TEST.txt")
+
+    audit_path = root / "final-audit.json"
+    audit = json.loads(audit_path.read_text())
+    audit.update({
+        "phase": 230,
+        "base_phase": 229,
+        "functional_base_phase": 229,
+        "hardware_validated": False,
+        "status": "phase230-kgsl-driver-core-path-ci-audited-not-hardware-validated",
+        "trace_marker_prefix": "KGPPOST 230",
+        "phase229_kgsl_snapshot_retained": True,
+        "phase228_tri_track_retained": True,
+        "phase226_odspost_retained": True,
+        "phase230_platform_record_limit": 32,
+        "phase230_dd_record_limit": 160,
+        "phase230_core_record_limit": 96,
+        "phase230_behavior_changed": False,
+        "phase230_supplier_decisions_changed": False,
+        "phase230_return_values_changed": False,
+        "phase230_rs_roots": 48,
+    })
+    retained = list(audit.get("post_capacity_retention", []))
+    for marker in ("ODSPOST", "TRIPOST", "KGPPOST"):
+        if marker not in retained:
+            retained.append(marker)
+    audit["post_capacity_retention"] = retained
+    audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n")
+
+    identity = {
+        "phase": 230,
+        "git_sha": os.environ.get("GITHUB_SHA"),
+        "git_ref": os.environ.get("GITHUB_REF"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_number": os.environ.get("GITHUB_RUN_NUMBER"),
+        "source_builder_run_id": str(source_run_id),
+        "source_builder_run_url": source_run_url,
+        "touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "hardware_validated": False,
+        "change": "KGSL platform-match, bidirectional attach, supplier and pre-probe trace",
+        "rs_roots": 48,
+    }
+    (root / "BUILD-IDENTITY.json").write_text(json.dumps(identity, indent=2, sort_keys=True) + "\n")
+    (root / "README-FIRST.txt").write_text(
+        "A52 GKI 5.10 Phase 230 KGSL driver-core path candidate\n\n"
+        "FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:\n"
+        "  package/boot.img -> BOOT partition\n\n"
+        "Phase 230 preserves Phase 229 and adds bounded metadata-only tracing\n"
+        "for the exact qcom,kgsl-3d0 / kgsl-3d platform match, both attach\n"
+        "directions, deferred-probe state, supplier identities and every\n"
+        "pre-callback driver-core boundary.\n\n"
+        "No match, supplier, DT, return-value, power, IOMMU, firmware, service\n"
+        "or security behavior is changed. Reed-Solomon remains RS48.\n\n"
+        "CI-validated, not hardware-validated. Follow PHASE230-HARDWARE-TEST.txt.\n"
+    )
+
+    sums = root / "SHA256SUMS"
+    if sums.exists():
+        sums.unlink()
+    files = sorted(path for path in root.rglob("*") if path.is_file() and path.name != "SHA256SUMS")
+    sums.write_text("".join(f"{sha256(path)}  ./{path.relative_to(root)}\n" for path in files))
+
+    out = Path("phase230-out")
+    shutil.rmtree(out, ignore_errors=True)
+    shutil.copytree(root, out)
+    return out
+
+
+def main() -> int:
+    run_id, run_url, artifact_id = select_source()
+    work = Path("phase230-work")
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir()
+    zip_path = work / "inherited.zip"
+    download_artifact(artifact_id, zip_path)
+    extract = work / "inherited"
+    extract.mkdir()
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extractall(extract)
+    root = locate_root(extract)
+    package(root, run_id, run_url)
+    print(f"Phase 230 package prepared from source run {run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, urllib.error.URLError, zipfile.BadZipFile) as exc:
+        print(f"Phase 230 packaging failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/230_package.py
+++ b/scripts/230_package.py
@@ -120,8 +120,7 @@ def verify_markers(image: Path) -> None:
     data = image.read_bytes()
     for marker in (
         b"KGPPOST 230", b"KGPPOST 230 replay-begin",
-        b"A52_PHASE230_KGSL_LATE_REPLAY", b"KGPPOST 229",
-        b"TRIPOST 228", b"ODSPOST 226",
+        b"KGPPOST 229", b"TRIPOST 228", b"ODSPOST 226",
         b"GFXPOST 225 ks1", b"GFXPOST 225 ks2",
     ):
         if marker not in data:

--- a/scripts/230_patcher_parts/00.pyfrag
+++ b/scripts/230_patcher_parts/00.pyfrag
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Run Phase 229, then trace the KGSL platform match and driver-core attach path."""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PHASE229_MARKER = "A52_PHASE229_KGSL_PLATFORM_PATH"
+PHASE230_MARKER = "A52_PHASE230_KGSL_DRIVER_CORE_PATH"
+ADRENO_REL = Path("drivers/gpu/msm/adreno.c")
+RECORDER_REL = Path("drivers/a52_secure/a52_ack_secure_flight_recorder.c")
+DD_REL = Path("drivers/base/dd.c")
+CORE_REL = Path("drivers/base/core.c")
+PLATFORM_REL = Path("drivers/base/platform.c")
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f"{label}: expected one anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def candidate_roots(arguments: list[str]) -> list[Path]:
+    roots: list[Path] = []
+    for value in arguments:
+        if value.startswith("-"):
+            continue
+        p = Path(value)
+        roots.extend((p, p.parent))
+    roots.extend((Path("workspace/gki-phase199-src"), Path("gki/common")))
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        key = root.resolve(strict=False)
+        if key not in seen:
+            seen.add(key)
+            out.append(root)
+    return out
+
+
+def locate_root(arguments: list[str]) -> Path:
+    matches: list[Path] = []
+    for root in candidate_roots(arguments):
+        paths = [root / rel for rel in (ADRENO_REL, RECORDER_REL, DD_REL, CORE_REL, PLATFORM_REL)]
+        if not all(path.is_file() for path in paths):
+            continue
+        if PHASE229_MARKER not in (root / ADRENO_REL).read_text(encoding="utf-8"):
+            continue
+        matches.append(root)
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in matches:
+        key = root.resolve()
+        if key not in seen:
+            seen.add(key)
+            unique.append(root)
+    if len(unique) != 1:
+        rendered = ", ".join(str(p) for p in unique) or "none"
+        raise RuntimeError(f"expected one generated Phase 229 source root, found {len(unique)}: {rendered}")
+    return unique[0]
+
+
+PLATFORM_HELPER = r'''/* A52_PHASE230_KGSL_DRIVER_CORE_PATH
+ * Observe only the exact qcom,kgsl-3d0 / kgsl-3d platform match.  The
+ * recorder does not alter match order, match results, driver_override, DT,
+ * probe dependencies, return values, or device state.
+ */
+static atomic_t a52_r230_platform_records = ATOMIC_INIT(0);
+
+static bool a52_r230_gpu_platform_pair(const struct device *dev,
+		const struct device_driver *drv)
+{
+	return dev && dev->of_node && drv && drv->name &&
+		of_device_is_compatible(dev->of_node, "qcom,kgsl-3d0") &&
+		!strcmp(drv->name, "kgsl-3d");
+}
+
+static bool a52_r230_platform_take(void)
+{
+	return atomic_inc_return(&a52_r230_platform_records) <= 32;
+}
+
+'''
+
+
+def patch_platform(text: str, label: str) -> str:
+    if PHASE230_MARKER in text:
+        return text
+    helper_anchor = '#include "power/power.h"\n\n'
+    text = one(text, helper_anchor, helper_anchor + PLATFORM_HELPER, f"{label}: helper")
+    old = r'''static int platform_match(struct device *dev, struct device_driver *drv)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct platform_driver *pdrv = to_platform_driver(drv);
+	int ret;
+
+	/* When driver_override is set, only bind to the matching driver */
+	if (pdev->driver_override)
+		ret = !strcmp(pdev->driver_override, drv->name);
+	else if (of_driver_match_device(dev, drv))
+		ret = 1;
+	else if (acpi_driver_match_device(dev, drv))
+		ret = 1;
+	else if (pdrv->id_table)
+		ret = platform_match_id(pdrv->id_table, pdev) != NULL;
+	else
+		ret = strcmp(pdev->name, drv->name) == 0;
+
+	if (dev->of_node &&
+	    of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec") &&
+	    !strcmp(drv->name, "msmdrm_smmu"))
+		a52_ackfr_record("DCORE platform-match drv=%s rc=%d",
+			drv->name, ret);
+	return ret;
+}
+'''
+    new = r'''static int platform_match(struct device *dev, struct device_driver *drv)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct platform_driver *pdrv = to_platform_driver(drv);
+	int ret;
+	int path;
+
+	/* When driver_override is set, only bind to the matching driver */
+	if (pdev->driver_override) {
+		path = 1;
+		ret = !strcmp(pdev->driver_override, drv->name);
+	} else if (of_driver_match_device(dev, drv)) {
+		path = 2;
+		ret = 1;
+	} else if (acpi_driver_match_device(dev, drv)) {
+		path = 3;
+		ret = 1;
+	} else if (pdrv->id_table) {
+		path = 4;
+		ret = platform_match_id(pdrv->id_table, pdev) != NULL;
+	} else {
+		path = 5;
+		ret = strcmp(pdev->name, drv->name) == 0;
+	}
+
+	if (a52_r230_gpu_platform_pair(dev, drv) && a52_r230_platform_take())
+		a52_ackfr_record("KGPPOST 230 pm d=%.22s p=%.22s r=%.16s o=%.16s x=%d t=%d rc=%d",
+			dev_name(dev), pdev->name ? pdev->name : "-", drv->name,
+			pdev->driver_override ? pdev->driver_override : "-", path,
+			drv->of_match_table != NULL, ret);
+
+	if (dev->of_node &&
+	    of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec") &&
+	    !strcmp(drv->name, "msmdrm_smmu"))
+		a52_ackfr_record("DCORE platform-match drv=%s rc=%d",
+			drv->name, ret);
+	return ret;
+}
+'''
+    text = one(text, old, new, f"{label}: platform_match")
+    if text.count(PHASE230_MARKER) != 1 or text.count('KGPPOST 230 pm ') != 1:
+        raise RuntimeError(f"{label}: platform audit failed")
+    return text
+
+

--- a/scripts/230_patcher_parts/01.pyfrag
+++ b/scripts/230_patcher_parts/01.pyfrag
@@ -1,0 +1,197 @@
+DD_HELPER = r'''/* A52_PHASE230_KGSL_DRIVER_CORE_PATH
+ * Observe only the exact qcom,kgsl-3d0 / kgsl-3d attach and probe path.
+ * Bounded metadata records do not change matching, deferred-probe lists,
+ * supplier decisions, callback order, return values, or device state.
+ */
+static atomic_t a52_r230_dd_records = ATOMIC_INIT(0);
+
+static bool a52_r230_gpu_dev(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,kgsl-3d0");
+}
+
+static bool a52_r230_gpu_drv(const struct device_driver *drv)
+{
+	return drv && drv->name && !strcmp(drv->name, "kgsl-3d");
+}
+
+static bool a52_r230_gpu_pair(const struct device *dev,
+		const struct device_driver *drv)
+{
+	return a52_r230_gpu_dev(dev) && a52_r230_gpu_drv(drv);
+}
+
+static bool a52_r230_dd_take(void)
+{
+	return atomic_inc_return(&a52_r230_dd_records) <= 160;
+}
+
+#define A52_R230_DD(_fmt, ...) \
+	do { \
+		if (a52_r230_dd_take()) \
+			a52_ackfr_record("KGPPOST 230 " _fmt, ##__VA_ARGS__); \
+	} while (0)
+
+static const char *a52_r230_reason(const struct device *dev)
+{
+	return dev && dev->p && dev->p->deferred_probe_reason ?
+		dev->p->deferred_probe_reason : "-";
+}
+
+'''
+
+
+def patch_dd(text: str, label: str) -> str:
+    if PHASE230_MARKER in text:
+        return text
+    helper_anchor = '''static bool a52_smmu_unsec_trace_dev(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec");
+}
+
+'''
+    text = one(text, helper_anchor, helper_anchor + DD_HELPER, f"{label}: helper")
+
+    text = one(
+        text,
+        '''\t\tdev = private->device;\n\t\tlist_del_init(&private->deferred_probe);\n'''.replace('\\t', '\t').replace('\\n', '\n'),
+        '''\t\tdev = private->device;\n\t\tif (a52_r230_gpu_dev(dev))\n\t\t\tA52_R230_DD("def-retry d=%.24s reason=%.28s",\n\t\t\t\tdev_name(dev), a52_r230_reason(dev));\n\t\tlist_del_init(&private->deferred_probe);\n'''.replace('\\t', '\t').replace('\\n', '\n'),
+        f"{label}: deferred retry",
+    )
+
+    add_anchor = "\tmutex_lock(&deferred_probe_mutex);\n\tif (list_empty(&dev->p->deferred_probe)) {\n"
+    add_new = (
+        "\tmutex_lock(&deferred_probe_mutex);\n"
+        "\tif (a52_r230_gpu_dev(dev))\n"
+        "\t\tA52_R230_DD(\"def-add d=%.24s empty=%d reason=%.28s\",\n"
+        "\t\t\tdev_name(dev), list_empty(&dev->p->deferred_probe),\n"
+        "\t\t\ta52_r230_reason(dev));\n"
+        "\tif (list_empty(&dev->p->deferred_probe)) {\n"
+    )
+    text = one(text, add_anchor, add_new, f"{label}: deferred add")
+
+    del_anchor = "void driver_deferred_probe_del(struct device *dev)\n{\n\tmutex_lock(&deferred_probe_mutex);\n"
+    del_new = (
+        "void driver_deferred_probe_del(struct device *dev)\n{\n"
+        "\tmutex_lock(&deferred_probe_mutex);\n"
+        "\tif (a52_r230_gpu_dev(dev))\n"
+        "\t\tA52_R230_DD(\"def-del d=%.24s listed=%d reason=%.28s\",\n"
+        "\t\t\tdev_name(dev), !list_empty(&dev->p->deferred_probe),\n"
+        "\t\t\ta52_r230_reason(dev));\n"
+    )
+    text = one(text, del_anchor, del_new, f"{label}: deferred del")
+
+    rp_decl = r'''static int really_probe(struct device *dev, struct device_driver *drv)
+{
+	int ret = -EPROBE_DEFER;
+	int local_trigger_count = atomic_read(&deferred_trigger_count);
+	bool test_remove = IS_ENABLED(CONFIG_DEBUG_TEST_DRIVER_REMOVE) &&
+			   !drv->suppress_bind_attrs;
+'''
+    rp_decl_new = rp_decl + r'''
+	if (a52_r230_gpu_pair(dev, drv))
+		A52_R230_DD("rp-in d=%.24s r=%.16s all=%d dead=%d cur=%.16s",
+			dev_name(dev), drv->name, defer_all_probes,
+			dev->p ? dev->p->dead : -1,
+			dev->driver && dev->driver->name ? dev->driver->name : "-");
+'''
+    text = one(text, rp_decl, rp_decl_new, f"{label}: really probe entry")
+
+    supplier_anchor = r'''\tret = device_links_check_suppliers(dev);
+'''.replace('\\t', '\t')
+    supplier_new = supplier_anchor + r'''\tif (a52_r230_gpu_pair(dev, drv))
+\t\tA52_R230_DD("rp-sup rc=%d ls=%d reason=%.32s", ret,
+\t\t\tdev->links.status, a52_r230_reason(dev));
+'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, supplier_anchor, supplier_new, f"{label}: supplier result")
+
+    ret_anchor = '''\tif (ret == -EPROBE_DEFER)\n\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n\tif (ret)\n\t\treturn ret;\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    ret_new = '''\tif (ret == -EPROBE_DEFER)\n\t\tdriver_deferred_probe_add_trigger(dev, local_trigger_count);\n\tif (ret) {\n\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-stop stage=sup rc=%d reason=%.32s",\n\t\t\t\tret, a52_r230_reason(dev));\n\t\treturn ret;\n\t}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, ret_anchor, ret_new, f"{label}: supplier stop")
+
+    pin_anchor = '\tret = pinctrl_bind_pins(dev);\n'
+    pin_new = pin_anchor + '''\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("rp-pin rc=%d", ret);\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, pin_anchor, pin_new, f"{label}: pinctrl")
+
+    dma_anchor = '\t\tret = dev->bus->dma_configure(dev);\n'
+    dma_new = dma_anchor + '''\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-dma rc=%d mapped=%d", ret,\n\t\t\t\tdevice_iommu_mapped(dev));\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, dma_anchor, dma_new, f"{label}: dma")
+
+    sysfs_anchor = '''\tret = driver_sysfs_add(dev);\n\tif (a52_rscc_probe_device(dev))\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    sysfs_new = '''\tret = driver_sysfs_add(dev);\n\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("rp-sys rc=%d", ret);\n\tif (a52_rscc_probe_device(dev))\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, sysfs_anchor, sysfs_new, f"{label}: sysfs")
+
+    pm_anchor = '\t\tret = dev->pm_domain->activate(dev);\n'
+    pm_new = pm_anchor + '''\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-pm rc=%d", ret);\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, pm_anchor, pm_new, f"{label}: pm")
+
+    bus_anchor = '\t\tret = dev->bus->probe(dev);\n'
+    bus_new = '''\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-cb in bus=1");\n'''.replace('\\t', '\t').replace('\\n', '\n') + bus_anchor + '''\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-cb out rc=%d", ret);\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, bus_anchor, bus_new, f"{label}: bus callback")
+
+    drv_anchor = '\t\tret = drv->probe(dev);\n'
+    drv_new = '''\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-cb in bus=0");\n'''.replace('\\t', '\t').replace('\\n', '\n') + drv_anchor + '''\t\tif (a52_r230_gpu_pair(dev, drv))\n\t\t\tA52_R230_DD("rp-cb out rc=%d", ret);\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, drv_anchor, drv_new, f"{label}: driver callback")
+
+    probe_entry = r'''int driver_probe_device(struct device_driver *drv, struct device *dev)
+{
+	int ret = 0;
+'''
+    probe_entry_new = probe_entry + r'''
+	if (a52_r230_gpu_pair(dev, drv))
+		A52_R230_DD("dp-in d=%.24s r=%.16s reg=%d cur=%.16s",
+			dev_name(dev), drv->name, device_is_registered(dev),
+			dev->driver && dev->driver->name ? dev->driver->name : "-");
+'''
+    text = one(text, probe_entry, probe_entry_new, f"{label}: driver_probe entry")
+
+    probe_return = '''\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE driver-probe exit dev=%s rc=%d bound=%s",\n\t\t\tdev_name(dev), ret, dev->driver && dev->driver->name ?\n\t\t\tdev->driver->name : "-");\n\treturn ret;\n}\n\nstatic inline bool cmdline_requested_async_probing'''.replace('\\t', '\t').replace('\\n', '\n')
+    probe_return_new = '''\tif (a52_rscc_probe_device(dev))\n\t\ta52_ackfr_record("RSCCCORE driver-probe exit dev=%s rc=%d bound=%s",\n\t\t\tdev_name(dev), ret, dev->driver && dev->driver->name ?\n\t\t\tdev->driver->name : "-");\n\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("dp-out rc=%d bound=%.16s reason=%.28s", ret,\n\t\t\tdev->driver && dev->driver->name ? dev->driver->name : "-",\n\t\t\ta52_r230_reason(dev));\n\treturn ret;\n}\n\nstatic inline bool cmdline_requested_async_probing'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, probe_return, probe_return_new, f"{label}: driver_probe return")
+
+    device_attach_match = '''\tret = driver_match_device(drv, dev);\n\tif (a52_smmu_unsec_trace_dev(dev) &&\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    device_attach_match_new = '''\tret = driver_match_device(drv, dev);\n\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("ad path=dev match=%d ca=%d wa=%d", ret,\n\t\t\tdata->check_async, data->want_async);\n\tif (a52_smmu_unsec_trace_dev(dev) &&\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, device_attach_match, device_attach_match_new, f"{label}: device attach match")
+
+    direct_return = '''\tif (a52_smmu_unsec_trace_dev(dev))\n\t\ta52_ackfr_record("DCORE match probe drv=%s async=%d",\n\t\t\tdrv->name, async_allowed);\n\treturn driver_probe_device(drv, dev);\n}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    direct_return_new = '''\tif (a52_smmu_unsec_trace_dev(dev))\n\t\ta52_ackfr_record("DCORE match probe drv=%s async=%d",\n\t\t\tdrv->name, async_allowed);\n\tret = driver_probe_device(drv, dev);\n\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("ad path=dev probe=%d async=%d", ret, async_allowed);\n\treturn ret;\n}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, direct_return, direct_return_new, f"{label}: device attach probe")
+
+    driver_attach_match = '''\tret = driver_match_device(drv, dev);\n\tif (a52_rscc_probe_device(dev))\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    driver_attach_match_new = '''\tret = driver_match_device(drv, dev);\n\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("ad path=drv match=%d dead=%d cur=%.16s", ret,\n\t\t\tdev->p ? dev->p->dead : -1,\n\t\t\tdev->driver && dev->driver->name ? dev->driver->name : "-");\n\tif (a52_rscc_probe_device(dev))\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, driver_attach_match, driver_attach_match_new, f"{label}: driver attach match")
+
+    dda_call = '''\tdevice_driver_attach(drv, dev);\n\n\treturn 0;\n}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    dda_new = '''\tret = device_driver_attach(drv, dev);\n\tif (a52_r230_gpu_pair(dev, drv))\n\t\tA52_R230_DD("ad path=drv probe=%d bound=%.16s", ret,\n\t\t\tdev->driver && dev->driver->name ? dev->driver->name : "-");\n\n\treturn 0;\n}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, dda_call, dda_new, f"{label}: driver attach probe")
+
+    driver_attach_fn = r'''int driver_attach(struct device_driver *drv)
+{
+	return bus_for_each_dev(drv->bus, NULL, drv, __driver_attach);
+}
+'''
+    driver_attach_fn_new = r'''int driver_attach(struct device_driver *drv)
+{
+	int ret;
+
+	if (a52_r230_gpu_drv(drv))
+		A52_R230_DD("walk-in r=%.16s bus=%.16s", drv->name,
+			drv->bus && drv->bus->name ? drv->bus->name : "-");
+	ret = bus_for_each_dev(drv->bus, NULL, drv, __driver_attach);
+	if (a52_r230_gpu_drv(drv))
+		A52_R230_DD("walk-out r=%.16s rc=%d", drv->name, ret);
+	return ret;
+}
+'''
+    text = one(text, driver_attach_fn, driver_attach_fn_new, f"{label}: driver walk")
+
+    if text.count(PHASE230_MARKER) != 1:
+        raise RuntimeError(f"{label}: marker audit failed")
+    for token in ("rp-sup", "path=dev", "path=drv", "walk-in", "def-add"):
+        if token not in text:
+            raise RuntimeError(f"{label}: missing {token}")
+    return text
+
+

--- a/scripts/230_patcher_parts/02.pyfrag
+++ b/scripts/230_patcher_parts/02.pyfrag
@@ -1,0 +1,123 @@
+CORE_HELPER = r'''/* A52_PHASE230_KGSL_DRIVER_CORE_PATH
+ * Observe only qcom,kgsl-3d0 supplier state while the normal driver core
+ * performs its existing checks.  No fwnode link, device link, status, flag,
+ * deferred-probe reason, return value, or supplier decision is modified.
+ */
+static atomic_t a52_r230_core_records = ATOMIC_INIT(0);
+
+static bool a52_r230_gpu_consumer(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,kgsl-3d0");
+}
+
+static bool a52_r230_core_take(void)
+{
+	return atomic_inc_return(&a52_r230_core_records) <= 96;
+}
+
+#define A52_R230_CORE(_fmt, ...) \
+	do { \
+		if (a52_r230_core_take()) \
+			a52_ackfr_record("KGPPOST 230 " _fmt, ##__VA_ARGS__); \
+	} while (0)
+
+'''
+
+
+def patch_core(text: str, label: str) -> str:
+    if PHASE230_MARKER in text:
+        return text
+    helper_anchor = '''static bool a52_smmu_unsec_trace_dev(const struct device *dev)
+{
+	return dev && dev->of_node &&
+		of_device_is_compatible(dev->of_node, "qcom,smmu_sde_unsec");
+}
+
+'''
+    text = one(text, helper_anchor, helper_anchor + CORE_HELPER, f"{label}: helper")
+
+    entry_anchor = r'''int device_links_check_suppliers(struct device *dev)
+{
+	struct device_link *link;
+	int ret = 0;
+'''
+    entry_new = entry_anchor + r'''
+	if (a52_r230_gpu_consumer(dev))
+		A52_R230_CORE("sl-in d=%.24s ls=%d fw=%d perm=%d",
+			dev_name(dev), dev->links.status,
+			dev->fwnode && !list_empty(&dev->fwnode->suppliers),
+			fw_devlink_is_permissive());
+'''
+    text = one(text, entry_anchor, entry_new, f"{label}: supplier entry")
+
+    fw_anchor = '''\tif (dev->fwnode && !list_empty(&dev->fwnode->suppliers) &&\n\t    !fw_devlink_is_permissive()) {\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    fw_new = fw_anchor + '''\t\tif (a52_r230_gpu_consumer(dev)) {\n\t\t\tstruct fwnode_link *fwlink;\n\t\t\tunsigned int n = 0;\n\n\t\t\tlist_for_each_entry(fwlink, &dev->fwnode->suppliers, c_hook) {\n\t\t\t\tstruct device *sdev = fwlink->supplier ? fwlink->supplier->dev : NULL;\n\n\t\t\t\tif (n >= 12)\n\t\t\t\t\tbreak;\n\t\t\t\tA52_R230_CORE("fw n=%u p=%pfwP d=%.20s r=%.16s", n,\n\t\t\t\t\tfwlink->supplier, sdev ? dev_name(sdev) : "-",\n\t\t\t\t\tsdev && sdev->driver && sdev->driver->name ?\n\t\t\t\t\t\tsdev->driver->name : "-");\n\t\t\t\tn++;\n\t\t\t}\n\t\t}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, fw_anchor, fw_new, f"{label}: fwnode suppliers")
+
+    link_anchor = '''\tdevice_links_write_lock();\n\n\tlist_for_each_entry(link, &dev->links.suppliers, c_node) {\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    link_new = '''\tdevice_links_write_lock();\n\n\tlist_for_each_entry(link, &dev->links.suppliers, c_node) {\n\t\tif (a52_r230_gpu_consumer(dev)) {\n\t\t\tconst char *sdrv = link->supplier && link->supplier->driver &&\n\t\t\t\tlink->supplier->driver->name ? link->supplier->driver->name : "-";\n\t\t\tconst char *sof = link->supplier && link->supplier->of_node ?\n\t\t\t\tlink->supplier->of_node->full_name : "-";\n\n\t\t\tA52_R230_CORE("dl s=%.20s r=%.16s st=%d fl=%x ds=%d",\n\t\t\t\tlink->supplier ? dev_name(link->supplier) : "-", sdrv,\n\t\t\t\tlink->status, link->flags,\n\t\t\t\tlink->supplier ? link->supplier->links.status : -1);\n\t\t\tA52_R230_CORE("do p=%.48s", sof);\n\t\t}\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, link_anchor, link_new, f"{label}: device suppliers")
+
+    exit_anchor = '''\tdevice_links_write_unlock();\n\tif (a52_smmu_unsec_trace_dev(dev))\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    exit_new = '''\tdevice_links_write_unlock();\n\tif (a52_r230_gpu_consumer(dev))\n\t\tA52_R230_CORE("sl-out rc=%d ls=%d", ret, dev->links.status);\n\tif (a52_smmu_unsec_trace_dev(dev))\n'''.replace('\\t', '\t').replace('\\n', '\n')
+    text = one(text, exit_anchor, exit_new, f"{label}: supplier exit")
+
+    if text.count(PHASE230_MARKER) != 1:
+        raise RuntimeError(f"{label}: marker audit failed")
+    for token in ("sl-in", "fw n=", "dl s=", "sl-out"):
+        if token not in text:
+            raise RuntimeError(f"{label}: missing {token}")
+    return text
+
+
+def patch_generated(arguments: list[str]) -> Path:
+    root = locate_root(arguments)
+    files = {
+        PLATFORM_REL: patch_platform,
+        DD_REL: patch_dd,
+        CORE_REL: patch_core,
+    }
+    for rel, patcher in files.items():
+        path = root / rel
+        path.write_text(patcher(path.read_text(encoding="utf-8"), str(path)), encoding="utf-8")
+    return root
+
+
+def self_test() -> None:
+    fixture_root = Path(__file__).resolve().parent / "230_fixtures"
+    required = {
+        "platform.c": patch_platform,
+        "dd.c": patch_dd,
+        "core.c": patch_core,
+    }
+    for name, patcher in required.items():
+        path = fixture_root / name
+        if not path.is_file():
+            raise RuntimeError(f"missing Phase 230 fixture: {path}")
+        original = path.read_text(encoding="utf-8")
+        patched = patcher(original, f"fixture/{name}")
+        if patcher(patched, f"fixture/{name}/idempotent") != patched:
+            raise AssertionError(f"{name}: patch is not idempotent")
+        if PHASE230_MARKER not in patched or "KGPPOST 230" not in patched:
+            raise AssertionError(f"{name}: Phase 230 instrumentation missing")
+    print("Phase 230 KGSL driver-core path self-test: PASS")
+
+
+def main() -> int:
+    base = Path(__file__).with_name("229_phase228_kgsl_wrapper.py")
+    if not base.is_file():
+        raise SystemExit(f"missing Phase 229 base wrapper: {base}")
+    completed = subprocess.run([sys.executable, str(base), *sys.argv[1:]], check=False)
+    if completed.returncode:
+        return completed.returncode
+    if "--self-test" in sys.argv[1:]:
+        self_test()
+        return 0
+    root = patch_generated(sys.argv[1:])
+    print(f"Phase 230 KGSL driver-core path trace applied to {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/230_patcher_parts/99_replay.pyfrag
+++ b/scripts/230_patcher_parts/99_replay.pyfrag
@@ -1,0 +1,153 @@
+PHASE230_REPLAY_MARKER = "A52_PHASE230_KGSL_LATE_REPLAY"
+
+REPLAY_HELPER = r'''/* A52_PHASE230_KGSL_LATE_REPLAY
+ * Preserve the bounded early KGPPOST 230 journal across RAMOOPS ring
+ * overwrite by replaying the original metadata records during the late
+ * heartbeat window.  No match, probe, supplier, DT or return value changes.
+ */
+#define A52_R230_JOURNAL_CAPACITY 96U
+#define A52_R230_REPLAY_TICK_FIRST 150U
+#define A52_R230_REPLAY_TICK_LAST 180U
+
+static char a52_r230_journal[A52_R230_JOURNAL_CAPACITY]
+	[A52_R179_MESSAGE_LEN];
+static unsigned int a52_r230_journal_count;
+static atomic_t a52_r230_journal_seen = ATOMIC_INIT(0);
+static atomic_t a52_r230_replay_active = ATOMIC_INIT(0);
+static DEFINE_SPINLOCK(a52_r230_journal_lock);
+
+static void a52_r230_journal_message(const char *message)
+{
+	unsigned long irq_flags;
+	unsigned int index;
+
+	if (!message || strncmp(message, "KGPPOST 230 ", 12) ||
+	    atomic_read(&a52_r230_replay_active))
+		return;
+
+	atomic_inc(&a52_r230_journal_seen);
+	spin_lock_irqsave(&a52_r230_journal_lock, irq_flags);
+	index = a52_r230_journal_count;
+	if (index < A52_R230_JOURNAL_CAPACITY) {
+		strscpy(a52_r230_journal[index], message,
+			sizeof(a52_r230_journal[index]));
+		a52_r230_journal_count = index + 1;
+	}
+	spin_unlock_irqrestore(&a52_r230_journal_lock, irq_flags);
+}
+
+static void a52_r230_replay_journal(unsigned int tick)
+{
+	char message[A52_R179_MESSAGE_LEN];
+	unsigned long irq_flags;
+	unsigned int count;
+	unsigned int index;
+	unsigned int seen;
+
+	if (tick != A52_R230_REPLAY_TICK_FIRST &&
+	    tick != A52_R230_REPLAY_TICK_LAST)
+		return;
+
+	spin_lock_irqsave(&a52_r230_journal_lock, irq_flags);
+	count = a52_r230_journal_count;
+	spin_unlock_irqrestore(&a52_r230_journal_lock, irq_flags);
+	seen = (unsigned int)atomic_read(&a52_r230_journal_seen);
+
+	atomic_set(&a52_r230_replay_active, 1);
+	a52_ackfr_record("KGPPOST 230 replay-begin t=%u kept=%u seen=%u",
+		tick, count, seen);
+	for (index = 0; index < count; index++) {
+		spin_lock_irqsave(&a52_r230_journal_lock, irq_flags);
+		strscpy(message, a52_r230_journal[index], sizeof(message));
+		spin_unlock_irqrestore(&a52_r230_journal_lock, irq_flags);
+		a52_ackfr_record("%s", message);
+	}
+	a52_ackfr_record("KGPPOST 230 replay-end t=%u kept=%u seen=%u",
+		tick, count, seen);
+	atomic_set(&a52_r230_replay_active, 0);
+}
+
+'''
+
+
+def patch_recorder_replay(text: str, label: str) -> str:
+    if PHASE230_REPLAY_MARKER in text:
+        return text
+    helper_anchor = "static void a52_r179_write_control(const char *kind)\n"
+    text = one(text, helper_anchor, REPLAY_HELPER + helper_anchor,
+               f"{label}: replay helper")
+
+    journal_anchor = "\tva_end(args);\n\ta52_r228_track_message(event.message);\n"
+    journal_new = (
+        "\tva_end(args);\n"
+        "\ta52_r230_journal_message(event.message);\n"
+        "\ta52_r228_track_message(event.message);\n"
+    )
+    text = one(text, journal_anchor, journal_new, f"{label}: journal hook")
+
+    heartbeat_anchor = (
+        "\ttick = (unsigned int)atomic_inc_return(&a52_r179_heartbeat_count);\n"
+        "\ta52_r226_task_snapshot(tick);\n"
+    )
+    heartbeat_new = (
+        "\ttick = (unsigned int)atomic_inc_return(&a52_r179_heartbeat_count);\n"
+        "\ta52_r230_replay_journal(tick);\n"
+        "\ta52_r226_task_snapshot(tick);\n"
+    )
+    text = one(text, heartbeat_anchor, heartbeat_new,
+               f"{label}: heartbeat replay")
+
+    checks = {
+        PHASE230_REPLAY_MARKER: 1,
+        "a52_r230_journal_message(event.message);": 1,
+        "a52_r230_replay_journal(tick);": 1,
+        '"KGPPOST 230 replay-begin ': 1,
+        '"KGPPOST 230 replay-end ': 1,
+        "A52_R230_JOURNAL_CAPACITY 96U": 1,
+        "A52_R230_REPLAY_TICK_FIRST 150U": 1,
+        "A52_R230_REPLAY_TICK_LAST 180U": 1,
+    }
+    for token, expected in checks.items():
+        count = text.count(token)
+        if count != expected:
+            raise RuntimeError(
+                f"{label}: expected {expected} {token!r}, found {count}"
+            )
+    return text
+
+
+_phase230_patch_generated_without_replay = patch_generated
+
+
+def patch_generated(arguments: list[str]) -> Path:
+    root = _phase230_patch_generated_without_replay(arguments)
+    recorder = root / RECORDER_REL
+    recorder.write_text(
+        patch_recorder_replay(recorder.read_text(encoding="utf-8"), str(recorder)),
+        encoding="utf-8",
+    )
+    return root
+
+
+_phase230_self_test_without_replay = self_test
+
+
+def self_test() -> None:
+    _phase230_self_test_without_replay()
+    fixture = Path(__file__).resolve().parent / "230_fixtures/recorder.c"
+    if not fixture.is_file():
+        raise RuntimeError(f"missing Phase 230 replay fixture: {fixture}")
+    original = fixture.read_text(encoding="utf-8")
+    patched = patch_recorder_replay(original, "fixture/recorder.c")
+    if patch_recorder_replay(patched, "fixture/recorder.c/idempotent") != patched:
+        raise AssertionError("recorder replay patch is not idempotent")
+    for token in (
+        PHASE230_REPLAY_MARKER,
+        "KGPPOST 230 replay-begin",
+        "KGPPOST 230 replay-end",
+        "a52_r230_journal_message(event.message);",
+        "a52_r230_replay_journal(tick);",
+    ):
+        if token not in patched:
+            raise AssertionError(f"recorder replay instrumentation missing: {token}")
+    print("Phase 230 KGSL late-replay self-test: PASS")

--- a/scripts/230_trigger.txt
+++ b/scripts/230_trigger.txt
@@ -1,0 +1,22 @@
+A52 Phase 230 hardware test
+
+1. Verify every entry in SHA256SUMS.
+2. Flash only package/boot.img to the BOOT partition.
+3. Attempt one normal boot for at least 210 seconds, or until the device performs
+   its coordinated restart.
+4. Boot directly to recovery without another normal boot.
+5. Collect the untouched raw 1 MiB RAMOOPS image with the same Phase 210+
+   RS(255,207), 48-parity, CRC32C transport-fusion collector.
+6. Upload the resulting ZIP without opening or rewriting the raw image.
+
+Expected diagnostic outcome
+
+- KGPPOST 229 should continue proving node, platform-device and registration
+  state.
+- KGPPOST 230 should identify one exact stop boundary:
+  platform match, attach traversal, supplier gate, pinctrl, DMA, sysfs,
+  PM-domain, or the platform callback.
+- If supplier-gated, the records should name the unresolved fwnode or managed
+  device-link supplier and its bound-driver state.
+
+Do not flash another experimental kernel before collecting RAMOOPS.

--- a/scripts/230_trigger.txt
+++ b/scripts/230_trigger.txt
@@ -13,9 +13,10 @@ Expected diagnostic outcome
 
 - KGPPOST 229 should continue proving node, platform-device and registration
   state.
-- KGPPOST 230 should identify one exact stop boundary:
-  platform match, attach traversal, supplier gate, pinctrl, DMA, sysfs,
-  PM-domain, or the platform callback.
+- `KGPPOST 230 replay-begin t=150` and/or `t=180` should survive.
+- The replayed original KGPPOST 230 records should identify one exact stop
+  boundary: platform match, attach traversal, supplier gate, pinctrl, DMA,
+  sysfs, PM-domain, or the platform callback.
 - If supplier-gated, the records should name the unresolved fwnode or managed
   device-link supplier and its bound-driver state.
 


### PR DESCRIPTION
## What changed

- Preserves the complete Phase 229 KGSL and TouchGrass binding-path recorder.
- Adds bounded `KGPPOST 230` records for the exact `qcom,kgsl-3d0` device and `kgsl-3d` driver pair.
- Traces both binding directions: driver registration through `driver_attach()` / `__driver_attach()`, and device attachment through `__device_attach_driver()`.
- Records `platform_match()` routing, `driver_override`, attach match results, `driver_probe_device()`, and every `really_probe()` boundary before the Adreno callback.
- Records deferred-probe list activity, firmware suppliers, managed device-link suppliers, supplier driver state, link state and stored deferred reason.
- Retains Phase 229 snapshots, Phase 228 cumulative state, `ODSPOST 226`, KGSL late-state records and RS(255,207) with 48 parity symbols.

## Why

Phase 229 proves that the enabled `qcom,kgsl-3d0` node and its platform device exist, both KGSL platform drivers register successfully, but the device remains unbound and `adreno_probe()` is never entered. The exact TouchGrass comparison retains the same Adreno registration and OF-match contract, leaving platform matching, attach traversal or pre-callback supplier gating as the unresolved boundary.

## Safety

This phase is observation-only. It does not force a match or bind, modify `driver_override`, remove or relax supplier links, change `fw_devlink`, retry a probe manually, alter a return value, modify DT, or change GPU power, clocks, regulators, IOMMU, firmware, services or security behavior.

## Validation

- Local Python compilation passed.
- Focused exact-anchor fixtures for the generated 5.10 `platform.c`, `dd.c`, and `core.c` pass idempotence and marker tests.
- The branch is exactly 14 commits ahead of the hardware-tested Phase 229 source branch with no unrelated base changes.
- GitHub Actions source compilation and package auditing are starting from this PR.
- Hardware validation is still required.