### PR TITLE
Phase 231: bind the exact GPU GX GDSC supplier

### DIFF
--- a/.github/workflows/231-dispatch-builder.yml
+++ b/.github/workflows/231-dispatch-builder.yml
@@ -1,0 +1,96 @@
+name: 231 - A52 exact GPU GX GDSC provider
+
+run-name: Build and audit Phase 231 GPU GX GDSC candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase231-gpu-gx-gdsc-v1
+    paths:
+      - .github/workflows/231-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/230_phase229_driver_core_wrapper.py
+      - scripts/231_phase230_gpu_gdsc_wrapper.py
+      - scripts/231_fixtures/**
+      - scripts/231_package.py
+      - scripts/231_design.md
+      - scripts/231_trigger.txt
+  pull_request:
+    branches:
+      - agent/a52-phase230-kgsl-driver-core-path-v1
+    paths:
+      - .github/workflows/231-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/230_phase229_driver_core_wrapper.py
+      - scripts/231_phase230_gpu_gdsc_wrapper.py
+      - scripts/231_fixtures/**
+      - scripts/231_package.py
+      - scripts/231_design.md
+      - scripts/231_trigger.txt
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: a52-phase231-gpu-gx-gdsc-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-package:
+    name: Build and package Phase 231
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 231 branch
+        uses: actions/checkout@v4
+
+      - name: Verify Phase 231 source
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile \
+            scripts/227_phase226_retention_wrapper.py \
+            scripts/230_phase229_driver_core_wrapper.py \
+            scripts/231_phase230_gpu_gdsc_wrapper.py \
+            scripts/231_package.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+          grep -Fq 'A52_PHASE231_GPU_GX_GDSC_PROVIDER' \
+            scripts/231_fixtures/a52-legacy-gdsc-after.c
+          grep -Fq 'A52GDSC GPU_GX_PROFILE_V1' \
+            scripts/231_fixtures/a52-legacy-gdsc-after.c
+          grep -Fq 'A52_GDSC_GPU_GX_ADDR      0x03d9100c' \
+            scripts/231_fixtures/a52-legacy-gdsc-after.c
+          ! grep -Fq '"gpu_cx_gdsc"' \
+            scripts/231_fixtures/a52-legacy-gdsc-after.c
+          grep -Fq 'device_links_check_suppliers()' scripts/231_design.md
+          grep -Fq 'Phase 230 driver-core tracing and late replay' \
+            scripts/231_design.md
+
+      - name: Dispatch inherited builder and package Phase 231
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          python3 scripts/231_package.py
+          test -f phase231-out/package/boot.img
+          test -f phase231-out/compile/Image
+          grep -aFq 'A52GDSC GPU_GX_PROFILE_V1' \
+            phase231-out/compile/Image
+          grep -aFq 'A52GDSC gpu-enable' phase231-out/compile/Image
+          grep -aFq 'KGPPOST 230 replay-begin' \
+            phase231-out/compile/Image
+          grep -aFq 'KGPPOST 229' phase231-out/compile/Image
+          (
+            cd phase231-out
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Upload Phase 231 candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase231-GPU-GX-GDSC-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase231-out
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -1,18 +1,11 @@
 #!/usr/bin/env python3
-"""Load the checked-in, readable Phase 230 implementation fragments."""
+"""Load the Phase 231 GPU GX GDSC provider wrapper."""
 from __future__ import annotations
 
 from pathlib import Path
 
-payload_dir = Path(__file__).resolve().parent / "230_patcher_parts"
-parts = sorted(payload_dir.glob("*.pyfrag"))
-if not parts:
-    raise SystemExit(f"missing Phase 230 patcher source fragments: {payload_dir}")
-source = "".join(part.read_text(encoding="utf-8") for part in parts)
-main_guard = '\nif __name__ == "__main__":\n    raise SystemExit(main())\n'
-if source.count(main_guard) != 1:
-    raise SystemExit(
-        f"expected one Phase 230 main guard before extension, found {source.count(main_guard)}"
-    )
-source = source.replace(main_guard, "\n", 1) + main_guard
-exec(compile(source, str(payload_dir / "phase230_patcher_impl.py"), "exec"), globals(), globals())
+source_path = Path(__file__).with_name("231_phase230_gpu_gdsc_wrapper.py")
+if not source_path.is_file():
+    raise SystemExit(f"missing Phase 231 wrapper: {source_path}")
+source = source_path.read_text(encoding="utf-8")
+exec(compile(source, str(source_path), "exec"), globals(), globals())

--- a/scripts/230_phase229_driver_core_wrapper.py
+++ b/scripts/230_phase229_driver_core_wrapper.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Load the checked-in, readable Phase 230 implementation fragments."""
+from __future__ import annotations
+
+from pathlib import Path
+
+payload_dir = Path(__file__).resolve().parent / "230_patcher_parts"
+parts = sorted(payload_dir.glob("*.pyfrag"))
+if not parts:
+    raise SystemExit(f"missing Phase 230 patcher source fragments: {payload_dir}")
+source = "".join(part.read_text(encoding="utf-8") for part in parts)
+main_guard = '\nif __name__ == "__main__":\n    raise SystemExit(main())\n'
+if source.count(main_guard) != 1:
+    raise SystemExit(
+        f"expected one Phase 230 main guard before extension, found {source.count(main_guard)}"
+    )
+source = source.replace(main_guard, "\n", 1) + main_guard
+exec(compile(source, str(payload_dir / "phase230_patcher_impl.py"), "exec"), globals(), globals())

--- a/scripts/231_design.md
+++ b/scripts/231_design.md
@@ -1,0 +1,60 @@
+# Phase 231: exact Lagoon GPU GX legacy GDSC provider
+
+## Hardware evidence entering this phase
+
+Phase 230 proved that the exact `qcom,kgsl-3d0` platform device matches
+`kgsl-3d`, enters `really_probe()`, and is stopped before `adreno_probe()` by
+`device_links_check_suppliers()` returning `-EPROBE_DEFER`.
+
+The persistent unresolved supplier is:
+
+- OF node: `/soc/qcom,gdsc@3d9100c`
+- platform device: `3d9100c.qcom,gdsc`
+- regulator name: `gpu_gx_gdsc`
+- bound driver: none
+
+The existing A52 compatibility driver matches `qcom,gdsc`, but its explicit
+profile whitelist accepts only `gcc_ufs_phy_gdsc` and `mdss_core_gdsc`.
+Therefore the GPU GX device reaches that driver and is rejected with
+`-ENODEV`.
+
+## Change
+
+Extend only `drivers/regulator/a52-legacy-gdsc-regulator.c` with one exact
+Lagoon GPU GX profile.
+
+The profile is accepted only when all of these conditions hold:
+
+- `regulator-name` is exactly `gpu_gx_gdsc`
+- the MMIO resource is exactly `0x03d9100c` with size 4
+- `domain-addr` resolves through syscon
+- `sw-reset` resolves through syscon
+- `qcom,reset-aon-logic` is present
+
+The enable sequence follows the downstream Qualcomm GDSC contract:
+
+1. Pulse the GPU software-reset bit.
+2. Pulse the GMEM/AON reset bit.
+3. Remove the GMEM I/O clamp.
+4. Clear hardware control, software override, and software collapse.
+5. Poll `PWR_ON`.
+
+Disable sets software collapse, polls power-off, then restores the GMEM I/O
+clamp. The regulator core retains normal `parent-supply` ordering.
+
+## Deliberate limits
+
+- GPU CX is not claimed.
+- No unrelated `qcom,gdsc` node is claimed.
+- No supplier link is removed or ignored.
+- No forced KGSL bind is performed.
+- No return value in driver core is changed.
+- No DT, firmware, IOMMU, or userspace file is changed.
+- Phase 230 driver-core tracing and late replay remain enabled.
+
+## Expected evidence
+
+The Phase 230 replay should show `3d9100c.qcom,gdsc` bound to
+`a52-legacy-gdsc-regulator`, supplier checking returning zero, and
+`adreno_probe()` being entered. A later defer or probe error is acceptable
+new evidence and must not be hidden.

--- a/scripts/231_fixtures/a52-legacy-gdsc-after.c
+++ b/scripts/231_fixtures/a52-legacy-gdsc-after.c
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Qualcomm legacy standalone GDSC regulator bridge for Samsung A52 Lagoon DT.
+ *
+ * The vendor DT exposes standalone "qcom,gdsc" regulators that Android
+ * common 5.10 does not otherwise bind:
+ *
+ *   - gcc_ufs_phy_gdsc: boot-critical UFS profile, kept on after enable
+ *   - mdss_core_gdsc: display profile, normal software collapse supported
+ *   - gpu_gx_gdsc: exact Lagoon GX profile with reset and clamp sequencing
+ *
+ * Keep the profiles explicit. Do not claim unrelated qcom,gdsc nodes.
+ *
+ * A52_PHASE231_GPU_GX_GDSC_PROVIDER
+ */
+
+#include <linux/a52_ack_secure_flight_recorder.h>
+#include <linux/bitops.h>
+#include <linux/delay.h>
+#include <linux/io.h>
+#include <linux/ioport.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+#include <linux/mfd/syscon.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+#include <linux/regulator/driver.h>
+#include <linux/regulator/machine.h>
+#include <linux/regulator/of_regulator.h>
+#include <linux/regmap.h>
+#include <linux/string.h>
+
+#define A52_GDSC_PWR_ON          BIT(31)
+#define A52_GDSC_SW_OVERRIDE     BIT(2)
+#define A52_GDSC_HW_CONTROL      BIT(1)
+#define A52_GDSC_SW_COLLAPSE     BIT(0)
+#define A52_GDSC_TIMEOUT_US      100
+#define A52_GDSC_GPU_GX_ADDR      0x03d9100c
+#define A52_GDSC_GMEM_CLAMP_IO    BIT(0)
+#define A52_GDSC_GMEM_RESET       BIT(4)
+#define A52_GDSC_GPU_SW_RESET     BIT(0)
+
+enum a52_legacy_gdsc_profile {
+    A52_GDSC_PROFILE_UFS,
+    A52_GDSC_PROFILE_MDSS,
+    A52_GDSC_PROFILE_GPU_GX,
+};
+
+struct a52_legacy_gdsc {
+    struct device *dev;
+    void __iomem *gdscr;
+    struct regulator_desc desc;
+    enum a52_legacy_gdsc_profile profile;
+    struct regmap *domain_addr;
+    struct regmap *sw_reset;
+    bool support_hw_trigger;
+    bool reset_aon;
+};
+
+extern void a52_persistent_diag_mark(const char *fmt, ...);
+
+static const char *a52_legacy_gdsc_profile_name(
+        const struct a52_legacy_gdsc *gdsc)
+{
+    switch (gdsc->profile) {
+    case A52_GDSC_PROFILE_MDSS:
+        return "mdss";
+    case A52_GDSC_PROFILE_GPU_GX:
+        return "gpu-gx";
+    case A52_GDSC_PROFILE_UFS:
+    default:
+        return "ufs";
+    }
+}
+
+static int a52_legacy_gdsc_poll(struct a52_legacy_gdsc *gdsc, bool on,
+                               u32 *last)
+{
+    u32 val;
+    int ret;
+
+    if (on)
+        ret = readl_poll_timeout(gdsc->gdscr, val,
+                                 val & A52_GDSC_PWR_ON,
+                                 1, A52_GDSC_TIMEOUT_US);
+    else
+        ret = readl_poll_timeout(gdsc->gdscr, val,
+                                 !(val & A52_GDSC_PWR_ON),
+                                 1, A52_GDSC_TIMEOUT_US);
+    if (last)
+        *last = val;
+    return ret;
+}
+
+static int a52_legacy_gdsc_is_enabled(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    return !!((val & A52_GDSC_PWR_ON) &&
+              !(val & A52_GDSC_SW_COLLAPSE));
+}
+
+static int a52_legacy_gdsc_enable(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    val &= ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE |
+             A52_GDSC_SW_COLLAPSE);
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+    a52_ackfr_record(
+        "A52GDSC enable profile=%s name=%s rc=%d before=0x%x after=0x%x",
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->desc.name,
+        ret, before, val);
+    a52_persistent_diag_mark(
+        "A52GDSC ENABLE dev=%s name=%s ret=%d reg=0x%08x\n",
+        dev_name(gdsc->dev), gdsc->desc.name, ret, val);
+
+    if (ret)
+        dev_err(gdsc->dev, "enable timed out, GDSCR=0x%08x\n", val);
+    return ret;
+}
+
+static int a52_legacy_gdsc_regmap_bit(struct regmap *map, u32 mask,
+                                     bool set, u32 *last)
+{
+    u32 val;
+    int ret;
+
+    ret = regmap_read(map, 0, &val);
+    if (ret)
+        return ret;
+
+    if (set)
+        val |= mask;
+    else
+        val &= ~mask;
+
+    ret = regmap_write(map, 0, val);
+    if (ret)
+        return ret;
+
+    ret = regmap_read(map, 0, &val);
+    if (!ret && last)
+        *last = val;
+    return ret;
+}
+
+static int a52_legacy_gdsc_enable_gpu_gx(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val, reset = 0, domain = 0;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+
+    ret = a52_legacy_gdsc_regmap_bit(gdsc->sw_reset,
+                                     A52_GDSC_GPU_SW_RESET, true, &reset);
+    if (ret)
+        goto out;
+    udelay(1);
+    ret = a52_legacy_gdsc_regmap_bit(gdsc->sw_reset,
+                                     A52_GDSC_GPU_SW_RESET, false, &reset);
+    if (ret)
+        goto out;
+
+    if (gdsc->reset_aon) {
+        ret = a52_legacy_gdsc_regmap_bit(gdsc->domain_addr,
+                                         A52_GDSC_GMEM_RESET, true,
+                                         &domain);
+        if (ret)
+            goto out;
+        udelay(1);
+        ret = a52_legacy_gdsc_regmap_bit(gdsc->domain_addr,
+                                         A52_GDSC_GMEM_RESET, false,
+                                         &domain);
+        if (ret)
+            goto out;
+    }
+
+    ret = a52_legacy_gdsc_regmap_bit(gdsc->domain_addr,
+                                     A52_GDSC_GMEM_CLAMP_IO, false,
+                                     &domain);
+    if (ret)
+        goto out;
+
+    val = readl_relaxed(gdsc->gdscr);
+    val &= ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE |
+             A52_GDSC_SW_COLLAPSE);
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+out:
+    if (ret)
+        val = readl_relaxed(gdsc->gdscr);
+    a52_ackfr_record(
+        "A52GDSC gpu-enable rc=%d before=0x%x after=0x%x reset=0x%x domain=0x%x",
+        ret, before, val, reset, domain);
+    a52_persistent_diag_mark(
+        "A52GDSC GPU_ENABLE dev=%s ret=%d reg=0x%08x reset=0x%08x domain=0x%08x\n",
+        dev_name(gdsc->dev), ret, val, reset, domain);
+    if (ret)
+        dev_err(gdsc->dev, "GPU GX enable failed: %d, GDSCR=0x%08x\n",
+                ret, val);
+    return ret;
+}
+
+static int a52_legacy_gdsc_disable_gpu_gx(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val, domain = 0;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    if (val & A52_GDSC_HW_CONTROL)
+        val &= ~A52_GDSC_HW_CONTROL;
+    val |= A52_GDSC_SW_COLLAPSE;
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, false, &val);
+    if (!ret)
+        ret = a52_legacy_gdsc_regmap_bit(gdsc->domain_addr,
+                                         A52_GDSC_GMEM_CLAMP_IO, true,
+                                         &domain);
+
+    a52_ackfr_record(
+        "A52GDSC gpu-disable rc=%d before=0x%x after=0x%x domain=0x%x",
+        ret, before, val, domain);
+    if (ret)
+        dev_err(gdsc->dev, "GPU GX disable failed: %d, GDSCR=0x%08x\n",
+                ret, val);
+    return ret;
+}
+
+static int a52_legacy_gdsc_disable_ufs(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    a52_ackfr_record(
+        "A52GDSC disable-keep-on profile=ufs name=%s reg=0x%x",
+        gdsc->desc.name, val);
+    a52_persistent_diag_mark(
+        "A52GDSC DISABLE_KEEP_ON dev=%s name=%s reg=0x%08x\n",
+        dev_name(gdsc->dev), gdsc->desc.name, val);
+    return 0;
+}
+
+static int a52_legacy_gdsc_disable_mdss(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    if (val & A52_GDSC_HW_CONTROL) {
+        val &= ~A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+    }
+
+    val |= A52_GDSC_SW_COLLAPSE;
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, false, &val);
+    a52_ackfr_record(
+        "A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x",
+        gdsc->desc.name, ret, before, val);
+    if (ret)
+        dev_err(gdsc->dev, "disable timed out, GDSCR=0x%08x\n", val);
+    return ret;
+}
+
+static unsigned int a52_legacy_gdsc_get_mode(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    return val & A52_GDSC_HW_CONTROL ?
+           REGULATOR_MODE_FAST : REGULATOR_MODE_NORMAL;
+}
+
+static int a52_legacy_gdsc_set_mode(struct regulator_dev *rdev,
+                                    unsigned int mode)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret = 0;
+
+    if (!gdsc->support_hw_trigger)
+        return -EINVAL;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    switch (mode) {
+    case REGULATOR_MODE_FAST:
+        val |= A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+        break;
+    case REGULATOR_MODE_NORMAL:
+        val &= ~A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+        if ((val & A52_GDSC_PWR_ON) &&
+            !(val & A52_GDSC_SW_COLLAPSE))
+            ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    a52_ackfr_record(
+        "A52GDSC mode profile=%s name=%s mode=%u rc=%d before=0x%x after=0x%x",
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->desc.name,
+        mode, ret, before, val);
+    return ret;
+}
+
+static const struct regulator_ops a52_legacy_gdsc_ufs_ops = {
+    .enable = a52_legacy_gdsc_enable,
+    .disable = a52_legacy_gdsc_disable_ufs,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+};
+
+static const struct regulator_ops a52_legacy_gdsc_mdss_ops = {
+    .enable = a52_legacy_gdsc_enable,
+    .disable = a52_legacy_gdsc_disable_mdss,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+    .set_mode = a52_legacy_gdsc_set_mode,
+    .get_mode = a52_legacy_gdsc_get_mode,
+};
+
+static const struct regulator_ops a52_legacy_gdsc_gpu_gx_ops = {
+    .enable = a52_legacy_gdsc_enable_gpu_gx,
+    .disable = a52_legacy_gdsc_disable_gpu_gx,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+};
+
+static int a52_legacy_gdsc_probe(struct platform_device *pdev)
+{
+    struct regulator_config config = { };
+    struct regulator_init_data *init_data = NULL;
+    struct a52_legacy_gdsc *gdsc;
+    struct regulator_dev *rdev;
+    struct resource *res;
+    const char *name;
+    u32 before, val;
+
+    if (of_property_read_string(pdev->dev.of_node, "regulator-name", &name))
+        return -EINVAL;
+
+    if (!strcmp(name, "gcc_ufs_phy_gdsc")) {
+    } else if (!strcmp(name, "mdss_core_gdsc")) {
+    } else if (!strcmp(name, "gpu_gx_gdsc")) {
+    } else {
+        return -ENODEV;
+    }
+
+    gdsc = devm_kzalloc(&pdev->dev, sizeof(*gdsc), GFP_KERNEL);
+    if (!gdsc)
+        return -ENOMEM;
+
+    gdsc->dev = &pdev->dev;
+    if (!strcmp(name, "mdss_core_gdsc"))
+        gdsc->profile = A52_GDSC_PROFILE_MDSS;
+    else if (!strcmp(name, "gpu_gx_gdsc"))
+        gdsc->profile = A52_GDSC_PROFILE_GPU_GX;
+    else
+        gdsc->profile = A52_GDSC_PROFILE_UFS;
+    gdsc->support_hw_trigger =
+        of_property_read_bool(pdev->dev.of_node,
+                              "qcom,support-hw-trigger");
+
+    res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+    if (!res)
+        return -EINVAL;
+    if (gdsc->profile == A52_GDSC_PROFILE_GPU_GX &&
+        (res->start != A52_GDSC_GPU_GX_ADDR || resource_size(res) != 4)) {
+        dev_err(&pdev->dev, "refusing unexpected GPU GX resource\n");
+        return -EINVAL;
+    }
+    gdsc->gdscr = devm_ioremap(&pdev->dev, res->start, resource_size(res));
+    if (!gdsc->gdscr)
+        return -ENOMEM;
+
+    gdsc->desc.name = name;
+    gdsc->desc.of_match = name;
+    gdsc->desc.type = REGULATOR_VOLTAGE;
+    gdsc->desc.owner = THIS_MODULE;
+    switch (gdsc->profile) {
+    case A52_GDSC_PROFILE_MDSS:
+        gdsc->desc.ops = &a52_legacy_gdsc_mdss_ops;
+        break;
+    case A52_GDSC_PROFILE_GPU_GX:
+        gdsc->desc.ops = &a52_legacy_gdsc_gpu_gx_ops;
+        break;
+    case A52_GDSC_PROFILE_UFS:
+    default:
+        gdsc->desc.ops = &a52_legacy_gdsc_ufs_ops;
+        break;
+    }
+
+    if (gdsc->profile == A52_GDSC_PROFILE_MDSS) {
+        init_data = of_get_regulator_init_data(&pdev->dev,
+                                               pdev->dev.of_node,
+                                               &gdsc->desc);
+        if (init_data && gdsc->support_hw_trigger) {
+            init_data->constraints.valid_ops_mask |= REGULATOR_CHANGE_MODE;
+            init_data->constraints.valid_modes_mask |=
+                REGULATOR_MODE_NORMAL | REGULATOR_MODE_FAST;
+        }
+
+        before = readl_relaxed(gdsc->gdscr);
+        val = before & ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE);
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        a52_ackfr_record(
+            "A52GDSC mdss-init name=%s before=0x%x after=0x%x hw=%u",
+            name, before, val, gdsc->support_hw_trigger);
+    } else if (gdsc->profile == A52_GDSC_PROFILE_GPU_GX) {
+        init_data = of_get_regulator_init_data(&pdev->dev,
+                                               pdev->dev.of_node,
+                                               &gdsc->desc);
+        if (!init_data)
+            return -ENOMEM;
+        if (of_get_property(pdev->dev.of_node, "parent-supply", NULL))
+            init_data->supply_regulator = "parent";
+
+        gdsc->domain_addr = syscon_regmap_lookup_by_phandle(
+                                pdev->dev.of_node, "domain-addr");
+        if (IS_ERR(gdsc->domain_addr))
+            return PTR_ERR(gdsc->domain_addr);
+        gdsc->sw_reset = syscon_regmap_lookup_by_phandle(
+                             pdev->dev.of_node, "sw-reset");
+        if (IS_ERR(gdsc->sw_reset))
+            return PTR_ERR(gdsc->sw_reset);
+        gdsc->reset_aon = of_property_read_bool(pdev->dev.of_node,
+                                                "qcom,reset-aon-logic");
+        if (!gdsc->reset_aon)
+            return -EINVAL;
+
+        before = readl_relaxed(gdsc->gdscr);
+        val = before & ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE);
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        a52_ackfr_record(
+            "A52GDSC GPU_GX_PROFILE_V1 init name=%s before=0x%x after=0x%x",
+            name, before, val);
+    }
+
+    config.dev = &pdev->dev;
+    config.of_node = pdev->dev.of_node;
+    config.init_data = init_data;
+    config.driver_data = gdsc;
+
+    a52_ackfr_record(
+        "A52GDSC register enter dev=%s name=%s profile=%s hw=%u",
+        dev_name(&pdev->dev), name,
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->support_hw_trigger);
+    rdev = devm_regulator_register(&pdev->dev, &gdsc->desc, &config);
+    if (IS_ERR(rdev)) {
+        int ret = PTR_ERR(rdev);
+
+        a52_ackfr_record(
+            "A52GDSC register exit dev=%s name=%s rc=%d",
+            dev_name(&pdev->dev), name, ret);
+        if (ret != -EPROBE_DEFER)
+            dev_err(&pdev->dev, "failed to register %s: %d\n", name, ret);
+        return ret;
+    }
+
+    platform_set_drvdata(pdev, gdsc);
+    val = readl_relaxed(gdsc->gdscr);
+    a52_ackfr_record(
+        "A52GDSC register exit dev=%s name=%s rc=0 reg=0x%x profile=%s",
+        dev_name(&pdev->dev), name, val,
+        a52_legacy_gdsc_profile_name(gdsc));
+    a52_persistent_diag_mark(
+        "A52GDSC PROBE dev=%s name=%s reg=0x%08x pwr=%u collapse=%u\n",
+        dev_name(&pdev->dev), name, val,
+        !!(val & A52_GDSC_PWR_ON), !!(val & A52_GDSC_SW_COLLAPSE));
+    dev_info(&pdev->dev, "registered A52 legacy GDSC regulator %s (%s)\n",
+             name, a52_legacy_gdsc_profile_name(gdsc));
+    return 0;
+}
+
+static const struct of_device_id a52_legacy_gdsc_match[] = {
+    { .compatible = "qcom,gdsc" },
+    { }
+};
+MODULE_DEVICE_TABLE(of, a52_legacy_gdsc_match);
+
+static struct platform_driver a52_legacy_gdsc_driver = {
+    .probe = a52_legacy_gdsc_probe,
+    .driver = {
+        .name = "a52-legacy-gdsc-regulator",
+        .of_match_table = a52_legacy_gdsc_match,
+    },
+};
+
+static int __init a52_legacy_gdsc_init(void)
+{
+    int ret;
+
+    a52_ackfr_record("A52GDSC driver-register enter");
+    ret = platform_driver_register(&a52_legacy_gdsc_driver);
+    a52_ackfr_record("A52GDSC driver-register exit rc=%d", ret);
+    return ret;
+}
+subsys_initcall(a52_legacy_gdsc_init);
+
+static void __exit a52_legacy_gdsc_exit(void)
+{
+    platform_driver_unregister(&a52_legacy_gdsc_driver);
+}
+module_exit(a52_legacy_gdsc_exit);
+
+MODULE_DESCRIPTION("Samsung A52 legacy Qualcomm UFS, MDSS and GPU GX GDSC regulator bridge");
+MODULE_LICENSE("GPL");

--- a/scripts/231_fixtures/a52-legacy-gdsc-before.c
+++ b/scripts/231_fixtures/a52-legacy-gdsc-before.c
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Qualcomm legacy standalone GDSC regulator bridge for Samsung A52 Lagoon DT.
+ *
+ * The vendor DT exposes two standalone "qcom,gdsc" regulators that Android
+ * common 5.10 does not otherwise bind:
+ *
+ *   - gcc_ufs_phy_gdsc: boot-critical UFS profile, kept on after enable
+ *   - mdss_core_gdsc: display profile, normal software collapse supported
+ *
+ * Keep the profiles explicit. Do not claim unrelated qcom,gdsc nodes.
+ */
+
+#include <linux/a52_ack_secure_flight_recorder.h>
+#include <linux/bitops.h>
+#include <linux/delay.h>
+#include <linux/io.h>
+#include <linux/ioport.h>
+#include <linux/iopoll.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+#include <linux/regulator/driver.h>
+#include <linux/regulator/machine.h>
+#include <linux/regulator/of_regulator.h>
+#include <linux/string.h>
+
+#define A52_GDSC_PWR_ON          BIT(31)
+#define A52_GDSC_SW_OVERRIDE     BIT(2)
+#define A52_GDSC_HW_CONTROL      BIT(1)
+#define A52_GDSC_SW_COLLAPSE     BIT(0)
+#define A52_GDSC_TIMEOUT_US      100
+
+enum a52_legacy_gdsc_profile {
+    A52_GDSC_PROFILE_UFS,
+    A52_GDSC_PROFILE_MDSS,
+};
+
+struct a52_legacy_gdsc {
+    struct device *dev;
+    void __iomem *gdscr;
+    struct regulator_desc desc;
+    enum a52_legacy_gdsc_profile profile;
+    bool support_hw_trigger;
+};
+
+extern void a52_persistent_diag_mark(const char *fmt, ...);
+
+static const char *a52_legacy_gdsc_profile_name(
+        const struct a52_legacy_gdsc *gdsc)
+{
+    return gdsc->profile == A52_GDSC_PROFILE_MDSS ? "mdss" : "ufs";
+}
+
+static int a52_legacy_gdsc_poll(struct a52_legacy_gdsc *gdsc, bool on,
+                               u32 *last)
+{
+    u32 val;
+    int ret;
+
+    if (on)
+        ret = readl_poll_timeout(gdsc->gdscr, val,
+                                 val & A52_GDSC_PWR_ON,
+                                 1, A52_GDSC_TIMEOUT_US);
+    else
+        ret = readl_poll_timeout(gdsc->gdscr, val,
+                                 !(val & A52_GDSC_PWR_ON),
+                                 1, A52_GDSC_TIMEOUT_US);
+    if (last)
+        *last = val;
+    return ret;
+}
+
+static int a52_legacy_gdsc_is_enabled(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    return !!((val & A52_GDSC_PWR_ON) &&
+              !(val & A52_GDSC_SW_COLLAPSE));
+}
+
+static int a52_legacy_gdsc_enable(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    val &= ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE |
+             A52_GDSC_SW_COLLAPSE);
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+    a52_ackfr_record(
+        "A52GDSC enable profile=%s name=%s rc=%d before=0x%x after=0x%x",
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->desc.name,
+        ret, before, val);
+    a52_persistent_diag_mark(
+        "A52GDSC ENABLE dev=%s name=%s ret=%d reg=0x%08x\n",
+        dev_name(gdsc->dev), gdsc->desc.name, ret, val);
+
+    if (ret)
+        dev_err(gdsc->dev, "enable timed out, GDSCR=0x%08x\n", val);
+    return ret;
+}
+
+static int a52_legacy_gdsc_disable_ufs(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    a52_ackfr_record(
+        "A52GDSC disable-keep-on profile=ufs name=%s reg=0x%x",
+        gdsc->desc.name, val);
+    a52_persistent_diag_mark(
+        "A52GDSC DISABLE_KEEP_ON dev=%s name=%s reg=0x%08x\n",
+        dev_name(gdsc->dev), gdsc->desc.name, val);
+    return 0;
+}
+
+static int a52_legacy_gdsc_disable_mdss(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    if (val & A52_GDSC_HW_CONTROL) {
+        val &= ~A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+    }
+
+    val |= A52_GDSC_SW_COLLAPSE;
+    writel_relaxed(val, gdsc->gdscr);
+    mb();
+    udelay(1);
+
+    ret = a52_legacy_gdsc_poll(gdsc, false, &val);
+    a52_ackfr_record(
+        "A52GDSC disable profile=mdss name=%s rc=%d before=0x%x after=0x%x",
+        gdsc->desc.name, ret, before, val);
+    if (ret)
+        dev_err(gdsc->dev, "disable timed out, GDSCR=0x%08x\n", val);
+    return ret;
+}
+
+static unsigned int a52_legacy_gdsc_get_mode(struct regulator_dev *rdev)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 val = readl_relaxed(gdsc->gdscr);
+
+    return val & A52_GDSC_HW_CONTROL ?
+           REGULATOR_MODE_FAST : REGULATOR_MODE_NORMAL;
+}
+
+static int a52_legacy_gdsc_set_mode(struct regulator_dev *rdev,
+                                    unsigned int mode)
+{
+    struct a52_legacy_gdsc *gdsc = rdev_get_drvdata(rdev);
+    u32 before, val;
+    int ret = 0;
+
+    if (!gdsc->support_hw_trigger)
+        return -EINVAL;
+
+    before = readl_relaxed(gdsc->gdscr);
+    val = before;
+    switch (mode) {
+    case REGULATOR_MODE_FAST:
+        val |= A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+        break;
+    case REGULATOR_MODE_NORMAL:
+        val &= ~A52_GDSC_HW_CONTROL;
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        udelay(1);
+        if ((val & A52_GDSC_PWR_ON) &&
+            !(val & A52_GDSC_SW_COLLAPSE))
+            ret = a52_legacy_gdsc_poll(gdsc, true, &val);
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    a52_ackfr_record(
+        "A52GDSC mode profile=%s name=%s mode=%u rc=%d before=0x%x after=0x%x",
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->desc.name,
+        mode, ret, before, val);
+    return ret;
+}
+
+static const struct regulator_ops a52_legacy_gdsc_ufs_ops = {
+    .enable = a52_legacy_gdsc_enable,
+    .disable = a52_legacy_gdsc_disable_ufs,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+};
+
+static const struct regulator_ops a52_legacy_gdsc_mdss_ops = {
+    .enable = a52_legacy_gdsc_enable,
+    .disable = a52_legacy_gdsc_disable_mdss,
+    .is_enabled = a52_legacy_gdsc_is_enabled,
+    .set_mode = a52_legacy_gdsc_set_mode,
+    .get_mode = a52_legacy_gdsc_get_mode,
+};
+
+static int a52_legacy_gdsc_probe(struct platform_device *pdev)
+{
+    struct regulator_config config = { };
+    struct regulator_init_data *init_data = NULL;
+    struct a52_legacy_gdsc *gdsc;
+    struct regulator_dev *rdev;
+    struct resource *res;
+    const char *name;
+    u32 before, val;
+
+    if (of_property_read_string(pdev->dev.of_node, "regulator-name", &name))
+        return -EINVAL;
+
+    if (!strcmp(name, "gcc_ufs_phy_gdsc")) {
+    } else if (!strcmp(name, "mdss_core_gdsc")) {
+    } else {
+        return -ENODEV;
+    }
+
+    gdsc = devm_kzalloc(&pdev->dev, sizeof(*gdsc), GFP_KERNEL);
+    if (!gdsc)
+        return -ENOMEM;
+
+    gdsc->dev = &pdev->dev;
+    gdsc->profile = !strcmp(name, "mdss_core_gdsc") ?
+                    A52_GDSC_PROFILE_MDSS : A52_GDSC_PROFILE_UFS;
+    gdsc->support_hw_trigger =
+        of_property_read_bool(pdev->dev.of_node,
+                              "qcom,support-hw-trigger");
+
+    res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+    if (!res)
+        return -EINVAL;
+    gdsc->gdscr = devm_ioremap(&pdev->dev, res->start, resource_size(res));
+    if (!gdsc->gdscr)
+        return -ENOMEM;
+
+    gdsc->desc.name = name;
+    gdsc->desc.of_match = name;
+    gdsc->desc.type = REGULATOR_VOLTAGE;
+    gdsc->desc.owner = THIS_MODULE;
+    gdsc->desc.ops = gdsc->profile == A52_GDSC_PROFILE_MDSS ?
+                     &a52_legacy_gdsc_mdss_ops :
+                     &a52_legacy_gdsc_ufs_ops;
+
+    if (gdsc->profile == A52_GDSC_PROFILE_MDSS) {
+        init_data = of_get_regulator_init_data(&pdev->dev,
+                                               pdev->dev.of_node,
+                                               &gdsc->desc);
+        if (init_data && gdsc->support_hw_trigger) {
+            init_data->constraints.valid_ops_mask |= REGULATOR_CHANGE_MODE;
+            init_data->constraints.valid_modes_mask |=
+                REGULATOR_MODE_NORMAL | REGULATOR_MODE_FAST;
+        }
+
+        before = readl_relaxed(gdsc->gdscr);
+        val = before & ~(A52_GDSC_HW_CONTROL | A52_GDSC_SW_OVERRIDE);
+        writel_relaxed(val, gdsc->gdscr);
+        mb();
+        a52_ackfr_record(
+            "A52GDSC mdss-init name=%s before=0x%x after=0x%x hw=%u",
+            name, before, val, gdsc->support_hw_trigger);
+    }
+
+    config.dev = &pdev->dev;
+    config.of_node = pdev->dev.of_node;
+    config.init_data = init_data;
+    config.driver_data = gdsc;
+
+    a52_ackfr_record(
+        "A52GDSC register enter dev=%s name=%s profile=%s hw=%u",
+        dev_name(&pdev->dev), name,
+        a52_legacy_gdsc_profile_name(gdsc), gdsc->support_hw_trigger);
+    rdev = devm_regulator_register(&pdev->dev, &gdsc->desc, &config);
+    if (IS_ERR(rdev)) {
+        int ret = PTR_ERR(rdev);
+
+        a52_ackfr_record(
+            "A52GDSC register exit dev=%s name=%s rc=%d",
+            dev_name(&pdev->dev), name, ret);
+        if (ret != -EPROBE_DEFER)
+            dev_err(&pdev->dev, "failed to register %s: %d\n", name, ret);
+        return ret;
+    }
+
+    platform_set_drvdata(pdev, gdsc);
+    val = readl_relaxed(gdsc->gdscr);
+    a52_ackfr_record(
+        "A52GDSC register exit dev=%s name=%s rc=0 reg=0x%x profile=%s",
+        dev_name(&pdev->dev), name, val,
+        a52_legacy_gdsc_profile_name(gdsc));
+    a52_persistent_diag_mark(
+        "A52GDSC PROBE dev=%s name=%s reg=0x%08x pwr=%u collapse=%u\n",
+        dev_name(&pdev->dev), name, val,
+        !!(val & A52_GDSC_PWR_ON), !!(val & A52_GDSC_SW_COLLAPSE));
+    dev_info(&pdev->dev, "registered A52 legacy GDSC regulator %s (%s)\n",
+             name, a52_legacy_gdsc_profile_name(gdsc));
+    return 0;
+}
+
+static const struct of_device_id a52_legacy_gdsc_match[] = {
+    { .compatible = "qcom,gdsc" },
+    { }
+};
+MODULE_DEVICE_TABLE(of, a52_legacy_gdsc_match);
+
+static struct platform_driver a52_legacy_gdsc_driver = {
+    .probe = a52_legacy_gdsc_probe,
+    .driver = {
+        .name = "a52-legacy-gdsc-regulator",
+        .of_match_table = a52_legacy_gdsc_match,
+    },
+};
+
+static int __init a52_legacy_gdsc_init(void)
+{
+    int ret;
+
+    a52_ackfr_record("A52GDSC driver-register enter");
+    ret = platform_driver_register(&a52_legacy_gdsc_driver);
+    a52_ackfr_record("A52GDSC driver-register exit rc=%d", ret);
+    return ret;
+}
+subsys_initcall(a52_legacy_gdsc_init);
+
+static void __exit a52_legacy_gdsc_exit(void)
+{
+    platform_driver_unregister(&a52_legacy_gdsc_driver);
+}
+module_exit(a52_legacy_gdsc_exit);
+
+MODULE_DESCRIPTION("Samsung A52 legacy Qualcomm UFS and MDSS GDSC regulator bridge");
+MODULE_LICENSE("GPL");

--- a/scripts/231_package.py
+++ b/scripts/231_package.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["GH_TOKEN"]
+REF = "agent/a52-phase231-gpu-gx-gdsc-v1"
+WORKFLOW_ID = 325785868
+API = f"https://api.github.com/repos/{REPO}"
+
+
+def request(url: str, *, method: str = "GET", data: dict | None = None) -> bytes:
+    body = None if data is None else json.dumps(data).encode()
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=120) as response:
+        return response.read()
+
+
+def get_json(url: str) -> dict:
+    return json.loads(request(url))
+
+
+def dispatch_and_wait() -> tuple[int, str, int]:
+    started = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    request(
+        f"{API}/actions/workflows/{WORKFLOW_ID}/dispatches",
+        method="POST",
+        data={"ref": REF},
+    )
+    run = None
+    for _ in range(40):
+        data = get_json(
+            f"{API}/actions/workflows/{WORKFLOW_ID}/runs?"
+            f"branch={REF}&event=workflow_dispatch&per_page=20"
+        )
+        candidates = [
+            item for item in data.get("workflow_runs", [])
+            if item.get("created_at", "") >= started
+        ]
+        if candidates:
+            run = sorted(candidates, key=lambda item: item["created_at"])[-1]
+            break
+        time.sleep(15)
+    if not run:
+        raise RuntimeError("dispatched inherited build was not found")
+
+    run_id = int(run["id"])
+    print(f"Monitoring {run['html_url']}", flush=True)
+    for _ in range(720):
+        run = get_json(f"{API}/actions/runs/{run_id}")
+        print(
+            f"run={run_id} status={run['status']} "
+            f"conclusion={run.get('conclusion') or 'pending'}",
+            flush=True,
+        )
+        if run["status"] == "completed":
+            break
+        time.sleep(30)
+    if run.get("conclusion") != "success":
+        raise RuntimeError(
+            f"inherited builder conclusion: {run.get('conclusion')}"
+        )
+
+    artifacts = get_json(
+        f"{API}/actions/runs/{run_id}/artifacts?per_page=100"
+    ).get("artifacts", [])
+    artifacts = [item for item in artifacts if not item.get("expired")]
+    if not artifacts:
+        raise RuntimeError("successful inherited build produced no artifact")
+    artifact = artifacts[-1]
+    return run_id, run["html_url"], int(artifact["id"])
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def download_artifact(artifact_id: int, dest: Path) -> None:
+    api_url = f"{API}/actions/artifacts/{artifact_id}/zip"
+    req = urllib.request.Request(api_url, method="GET")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        opener.open(req, timeout=120)
+        raise RuntimeError(
+            "artifact download unexpectedly returned without redirect"
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (301, 302, 303, 307, 308):
+            raise
+        location = exc.headers.get("Location")
+        if not location:
+            raise RuntimeError(
+                "artifact redirect did not include Location"
+            ) from exc
+    with urllib.request.urlopen(location, timeout=120) as response:
+        dest.write_bytes(response.read())
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def locate_root(base: Path) -> Path:
+    matches = list(base.rglob("package/boot.img"))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one package/boot.img, found {len(matches)}"
+        )
+    return matches[0].parent.parent
+
+
+def verify_markers(image: Path) -> None:
+    data = image.read_bytes()
+    for marker in (
+        b"A52GDSC GPU_GX_PROFILE_V1",
+        b"A52GDSC gpu-enable",
+        b"KGPPOST 230 replay-begin",
+        b"KGPPOST 230",
+        b"KGPPOST 229",
+        b"TRIPOST 228",
+        b"ODSPOST 226",
+    ):
+        if marker not in data:
+            raise RuntimeError(
+                f"missing binary marker: {marker.decode()}"
+            )
+        print(f"binary marker present: {marker.decode()}")
+
+
+def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
+    verify_markers(root / "compile/Image")
+
+    audit_dir = root / "audit/phase231"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "227_phase226_retention_wrapper.py",
+        "230_phase229_driver_core_wrapper.py",
+        "231_phase230_gpu_gdsc_wrapper.py",
+        "231_package.py",
+    ):
+        shutil.copy2(Path("scripts") / name, audit_dir / name)
+    shutil.copytree(
+        "scripts/231_fixtures",
+        audit_dir / "fixtures",
+        dirs_exist_ok=True,
+    )
+    shutil.copy2("scripts/231_design.md", root / "PHASE231-DESIGN.md")
+    shutil.copy2(
+        "scripts/231_trigger.txt",
+        root / "PHASE231-HARDWARE-TEST.txt",
+    )
+
+    audit_path = root / "final-audit.json"
+    audit = json.loads(audit_path.read_text())
+    audit.update({
+        "phase": 231,
+        "base_phase": 230,
+        "functional_base_phase": 230,
+        "hardware_validated": False,
+        "status": "phase231-gpu-gx-gdsc-ci-audited-not-hardware-validated",
+        "phase231_behavior_changed": True,
+        "phase231_exact_supplier": "3d9100c.qcom,gdsc",
+        "phase231_exact_regulator": "gpu_gx_gdsc",
+        "phase231_exact_mmio": "0x03d9100c+0x4",
+        "phase231_gpu_cx_claimed": False,
+        "phase231_unrelated_gdsc_claimed": False,
+        "phase231_driver_core_bypass": False,
+        "phase231_phase230_replay_retained": True,
+    })
+    audit_path.write_text(
+        json.dumps(audit, indent=2, sort_keys=True) + "\n"
+    )
+
+    identity = {
+        "phase": 231,
+        "git_sha": os.environ.get("GITHUB_SHA"),
+        "git_ref": os.environ.get("GITHUB_REF"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_number": os.environ.get("GITHUB_RUN_NUMBER"),
+        "source_builder_run_id": str(source_run_id),
+        "source_builder_run_url": source_run_url,
+        "touchgrass_commit":
+            "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "hardware_validated": False,
+        "change":
+            "exact Lagoon gpu_gx_gdsc provider with downstream reset and clamp sequence",
+        "phase230_replay_retained": True,
+        "rs_roots": 48,
+    }
+    (root / "BUILD-IDENTITY.json").write_text(
+        json.dumps(identity, indent=2, sort_keys=True) + "\n"
+    )
+    (root / "README-FIRST.txt").write_text(
+        "A52 GKI 5.10 Phase 231 GPU GX GDSC candidate\n\n"
+        "FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:\n"
+        "  package/boot.img -> BOOT partition\n\n"
+        "Phase 231 extends the existing explicit A52 legacy GDSC bridge with\n"
+        "one exact gpu_gx_gdsc profile at 0x03d9100c. It implements the\n"
+        "downstream GPU software-reset, GMEM/AON reset, clamp, and software\n"
+        "collapse sequence. It does not claim GPU CX or unrelated GDSCs.\n\n"
+        "Phase 230 driver-core tracing and late replay remain enabled so the\n"
+        "next RAMOOPS capture will prove whether KGSL reaches adreno_probe or\n"
+        "identify the next precise blocker.\n\n"
+        "CI-validated, not hardware-validated. Follow\n"
+        "PHASE231-HARDWARE-TEST.txt.\n"
+    )
+
+    sums = root / "SHA256SUMS"
+    if sums.exists():
+        sums.unlink()
+    files = sorted(
+        path for path in root.rglob("*")
+        if path.is_file() and path.name != "SHA256SUMS"
+    )
+    sums.write_text(
+        "".join(
+            f"{sha256(path)}  ./{path.relative_to(root)}\n"
+            for path in files
+        )
+    )
+
+    out = Path("phase231-out")
+    shutil.rmtree(out, ignore_errors=True)
+    shutil.copytree(root, out)
+    return out
+
+
+def main() -> int:
+    run_id, run_url, artifact_id = dispatch_and_wait()
+    work = Path("phase231-work")
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir()
+    zip_path = work / "inherited.zip"
+    download_artifact(artifact_id, zip_path)
+    extract = work / "inherited"
+    extract.mkdir()
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extractall(extract)
+    root = locate_root(extract)
+    package(root, run_id, run_url)
+    print(f"Phase 231 package prepared from source run {run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, urllib.error.URLError, zipfile.BadZipFile) as exc:
+        print(f"Phase 231 packaging failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/231_phase230_gpu_gdsc_wrapper.py
+++ b/scripts/231_phase230_gpu_gdsc_wrapper.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Run Phase 230, then provide the exact Lagoon GPU GX legacy GDSC."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+PHASE230_MARKER = "A52_PHASE230_KGSL_DRIVER_CORE_PATH"
+PHASE231_MARKER = "A52_PHASE231_GPU_GX_GDSC_PROVIDER"
+GDSC_REL = Path("drivers/regulator/a52-legacy-gdsc-regulator.c")
+DD_REL = Path("drivers/base/dd.c")
+EXPECTED_BEFORE_SHA256 = "e86d86b42609c4e7b84ace339dfc21e4387846f32b8c88b9ce6b241f5673dc56"
+EXPECTED_AFTER_SHA256 = "5567c52f4cab8c6667d423b2303ebf8ddd9b408b5061604fce9d4413b885c49c"
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def fixture_dir() -> Path:
+    return Path(__file__).resolve().parent / "231_fixtures"
+
+
+def replacement_source() -> str:
+    path = fixture_dir() / "a52-legacy-gdsc-after.c"
+    if not path.is_file():
+        raise RuntimeError(f"missing Phase 231 replacement fixture: {path}")
+    text = path.read_text(encoding="utf-8")
+    if sha256_text(text) != EXPECTED_AFTER_SHA256:
+        raise RuntimeError("Phase 231 replacement fixture checksum mismatch")
+    return text
+
+
+def patch_gdsc(text: str, label: str) -> str:
+    if PHASE231_MARKER in text:
+        return text
+    actual = sha256_text(text)
+    if actual != EXPECTED_BEFORE_SHA256:
+        raise RuntimeError(
+            f"{label}: unexpected legacy GDSC source sha256 {actual}"
+        )
+    patched = replacement_source()
+    for token in (
+        PHASE231_MARKER,
+        "A52GDSC GPU_GX_PROFILE_V1",
+        "A52_GDSC_GPU_GX_ADDR",
+        "syscon_regmap_lookup_by_phandle",
+        "a52_legacy_gdsc_enable_gpu_gx",
+        "a52_legacy_gdsc_disable_gpu_gx",
+    ):
+        if token not in patched:
+            raise RuntimeError(f"{label}: missing Phase 231 token {token}")
+    return patched
+
+
+def candidate_roots(arguments: list[str]) -> list[Path]:
+    roots: list[Path] = []
+    for value in arguments:
+        if value.startswith("-"):
+            continue
+        path = Path(value)
+        roots.extend((path, path.parent))
+    roots.extend((Path("workspace/gki-phase199-src"), Path("gki/common")))
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        key = root.resolve(strict=False)
+        if key not in seen:
+            seen.add(key)
+            unique.append(root)
+    return unique
+
+
+def locate_root(arguments: list[str]) -> Path:
+    matches: list[Path] = []
+    for root in candidate_roots(arguments):
+        gdsc = root / GDSC_REL
+        dd = root / DD_REL
+        if not gdsc.is_file() or not dd.is_file():
+            continue
+        if PHASE230_MARKER not in dd.read_text(encoding="utf-8"):
+            continue
+        matches.append(root)
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in matches:
+        key = root.resolve()
+        if key not in seen:
+            seen.add(key)
+            unique.append(root)
+    if len(unique) != 1:
+        rendered = ", ".join(str(path) for path in unique) or "none"
+        raise RuntimeError(
+            f"expected one generated Phase 230 source root, found "
+            f"{len(unique)}: {rendered}"
+        )
+    return unique[0]
+
+
+def patch_generated(arguments: list[str]) -> Path:
+    root = locate_root(arguments)
+    path = root / GDSC_REL
+    original = path.read_text(encoding="utf-8")
+    path.write_text(patch_gdsc(original, str(path)), encoding="utf-8")
+    return root
+
+
+def self_test() -> None:
+    before_path = fixture_dir() / "a52-legacy-gdsc-before.c"
+    if not before_path.is_file():
+        raise RuntimeError(f"missing Phase 231 source fixture: {before_path}")
+    original = before_path.read_text(encoding="utf-8")
+    if sha256_text(original) != EXPECTED_BEFORE_SHA256:
+        raise RuntimeError("Phase 231 input fixture checksum mismatch")
+    patched = patch_gdsc(original, "fixture")
+    if sha256_text(patched) != EXPECTED_AFTER_SHA256:
+        raise AssertionError("Phase 231 output checksum mismatch")
+    if patch_gdsc(patched, "fixture/idempotent") != patched:
+        raise AssertionError("Phase 231 patch is not idempotent")
+    if patched.count('"gpu_gx_gdsc"') != 2:
+        raise AssertionError("Phase 231 GPU GX whitelist is not exact")
+    if '"gpu_cx_gdsc"' in patched:
+        raise AssertionError("Phase 231 unexpectedly claims GPU CX")
+    print("Phase 231 exact GPU GX GDSC provider self-test: PASS")
+
+
+def main() -> int:
+    base = Path(__file__).with_name("230_phase229_driver_core_wrapper.py")
+    if not base.is_file():
+        raise SystemExit(f"missing Phase 230 base wrapper: {base}")
+    completed = subprocess.run(
+        [sys.executable, str(base), *sys.argv[1:]], check=False
+    )
+    if completed.returncode:
+        return completed.returncode
+    if "--self-test" in sys.argv[1:]:
+        self_test()
+        return 0
+    root = patch_generated(sys.argv[1:])
+    print(f"Phase 231 exact GPU GX GDSC provider applied to {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/231_trigger.txt
+++ b/scripts/231_trigger.txt
@@ -1,0 +1,16 @@
+A52 Phase 231 hardware test
+
+1. Verify every entry in SHA256SUMS.
+2. Flash only package/boot.img to the BOOT partition.
+3. Allow one normal boot to run for at least 210 seconds, or until the
+   coordinated restart.
+4. Boot directly into recovery without another normal boot.
+5. Collect the untouched raw RAMOOPS ZIP.
+6. Upload the raw ZIP without decoding or editing it.
+
+Expected Phase 230 replay evidence:
+- supplier 3d9100c.qcom,gdsc has driver a52-legacy-gdsc-regulator
+- device_links_check_suppliers no longer stops KGSL on that supplier
+- adreno_probe entry is reached, or a later precise blocker is recorded
+
+This is CI-audited but not hardware-validated.


### PR DESCRIPTION
## Hardware evidence

Phase 230 proved that `qcom,kgsl-3d0` matches `kgsl-3d` and enters `really_probe()`, but `device_links_check_suppliers()` returns `-EPROBE_DEFER` before `adreno_probe()` because `3d9100c.qcom,gdsc` remains unbound.

The existing A52 legacy GDSC compatibility driver matches `qcom,gdsc`, but its explicit whitelist accepts only UFS and MDSS profiles. It therefore rejects the exact `gpu_gx_gdsc` node with `-ENODEV`.

## Phase 231 change

Extend only `drivers/regulator/a52-legacy-gdsc-regulator.c` with one exact Lagoon GPU GX profile:

- regulator name exactly `gpu_gx_gdsc`
- MMIO exactly `0x03d9100c`, size 4
- requires `domain-addr`, `sw-reset`, and `qcom,reset-aon-logic`
- retains regulator-core parent-supply ordering
- implements downstream GPU software-reset, GMEM/AON reset, clamp, software-collapse, and `PWR_ON` polling sequence

## Safety limits

- Does not claim GPU CX
- Does not claim unrelated `qcom,gdsc` nodes
- Does not remove or ignore device links
- Does not force KGSL binding
- Does not modify driver-core return values
- Does not change DT, firmware, IOMMU, or userspace
- Preserves Phase 230 driver-core tracing and late replay

## Validation

- Exact pre-change source SHA-256 gate passed
- Deterministic post-change SHA-256 gate passed
- Patcher idempotence test passed
- Exact GPU-only whitelist test passed
- Phase 231 GitHub source verification passed
- Full cumulative kernel compile passed
- Final Phase 231 rebuild and package audit passed
- Binary contains `A52GDSC GPU_GX_PROFILE_V1`, `A52GDSC gpu-enable`, `A52GDSC gpu-disable`, and Phase 230 replay markers
- Independent downloaded-artifact `SHA256SUMS` verification passed

Artifact: `A52XQ-Phase231-GPU-GX-GDSC-2-NOT-HARDWARE-VALIDATED`

## Expected hardware result

The Phase 230 replay should show `3d9100c.qcom,gdsc` bound to `a52-legacy-gdsc-regulator`, supplier checking proceeding past this dependency, and `adreno_probe()` being entered or a later precise blocker being recorded.