### PR TITLE
Phase 232: accept the exact GPU GX profile without mandatory AON reset

### DIFF
--- a/.github/workflows/232-dispatch-builder.yml
+++ b/.github/workflows/232-dispatch-builder.yml
@@ -1,0 +1,97 @@
+name: 232 - A52 GPU GX optional AON reset
+
+run-name: Build and audit Phase 232 GPU GX optional-AON candidate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase232-gpu-gx-optional-aon-v1
+    paths:
+      - .github/workflows/232-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/230_phase229_driver_core_wrapper.py
+      - scripts/231_phase230_gpu_gdsc_wrapper.py
+      - scripts/232_phase231_optional_aon_wrapper.py
+      - scripts/232_package.py
+      - scripts/232_design.md
+      - scripts/232_trigger.txt
+  pull_request:
+    branches:
+      - agent/a52-phase231-gpu-gx-gdsc-v1
+    paths:
+      - .github/workflows/232-dispatch-builder.yml
+      - scripts/227_phase226_retention_wrapper.py
+      - scripts/230_phase229_driver_core_wrapper.py
+      - scripts/231_phase230_gpu_gdsc_wrapper.py
+      - scripts/232_phase231_optional_aon_wrapper.py
+      - scripts/232_package.py
+      - scripts/232_design.md
+      - scripts/232_trigger.txt
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: a52-phase232-gpu-gx-optional-aon-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-package:
+    name: Build and package Phase 232
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out Phase 232 branch
+        uses: actions/checkout@v4
+
+      - name: Verify Phase 232 source
+        run: |
+          set -Eeuo pipefail
+          python3 -m py_compile \
+            scripts/227_phase226_retention_wrapper.py \
+            scripts/230_phase229_driver_core_wrapper.py \
+            scripts/231_phase230_gpu_gdsc_wrapper.py \
+            scripts/232_phase231_optional_aon_wrapper.py \
+            scripts/232_package.py
+          python3 scripts/227_phase226_retention_wrapper.py --self-test
+          grep -Fq 'A52_PHASE232_GPU_GX_OPTIONAL_AON' \
+            scripts/232_phase231_optional_aon_wrapper.py
+          grep -Fq 'EXPECTED_AFTER_SHA256' \
+            scripts/232_phase231_optional_aon_wrapper.py
+          grep -Fq 'if (gdsc->reset_aon)' \
+            scripts/231_fixtures/a52-legacy-gdsc-after.c
+          ! grep -Fq '"gpu_cx_gdsc"' \
+            scripts/231_fixtures/a52-legacy-gdsc-after.c
+          grep -Fq 'device_links_check_suppliers()' scripts/232_design.md
+          grep -Fq 'Phase 230 driver-core tracing and late replay' \
+            scripts/232_design.md
+
+      - name: Dispatch inherited builder and package Phase 232
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          python3 scripts/232_package.py
+          test -f phase232-out/package/boot.img
+          test -f phase232-out/compile/Image
+          grep -aFq 'A52GDSC GPU_GX_PROFILE_V2' \
+            phase232-out/compile/Image
+          grep -aFq 'A52GDSC gpu-enable' phase232-out/compile/Image
+          grep -aFq 'KGPPOST 230 replay-begin' \
+            phase232-out/compile/Image
+          grep -aFq 'KGPPOST 229' phase232-out/compile/Image
+          (
+            cd phase232-out
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Upload Phase 232 candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase232-GPU-GX-OPTIONAL-AON-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase232-out
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Load the Phase 231 GPU GX GDSC provider wrapper."""
+"""Load the Phase 232 GPU GX optional-AON wrapper."""
 from __future__ import annotations
 
 from pathlib import Path
 
-source_path = Path(__file__).with_name("231_phase230_gpu_gdsc_wrapper.py")
+source_path = Path(__file__).with_name("232_phase231_optional_aon_wrapper.py")
 if not source_path.is_file():
-    raise SystemExit(f"missing Phase 231 wrapper: {source_path}")
+    raise SystemExit(f"missing Phase 232 wrapper: {source_path}")
 source = source_path.read_text(encoding="utf-8")
 exec(compile(source, str(source_path), "exec"), globals(), globals())

--- a/scripts/232_design.md
+++ b/scripts/232_design.md
@@ -1,0 +1,63 @@
+# Phase 232: accept the exact Lagoon GPU GX DT profile
+
+## Hardware evidence
+
+The Phase 231 hardware capture retained 1,028 valid RS(255,207) records over
+approximately 140 seconds. At both the 150-second and 180-second Phase 230
+replays:
+
+- `qcom,kgsl-3d0` matched `kgsl-3d` and entered `really_probe()`.
+- `device_links_check_suppliers()` returned `-EPROBE_DEFER` (`-517`).
+- The exact supplier device `3d9100c.qcom,gdsc` existed but had no bound
+  driver.
+- `adreno_probe()` was not entered.
+
+The flashed DTB describes `/soc/qcom,gdsc@3d9100c` as:
+
+- compatible `qcom,gdsc`
+- regulator name `gpu_gx_gdsc`
+- MMIO `0x03d9100c`, size 4
+- `sw-reset` present
+- `domain-addr` present
+- `parent-supply` present
+- `qcom,reset-aon-logic` absent
+
+Phase 231 incorrectly treated the absent `qcom,reset-aon-logic` property as a
+fatal profile mismatch and returned `-EINVAL` before regulator registration.
+
+## Exact TouchGrass behavior
+
+The pinned TouchGrass Qualcomm GDSC helper performs the AON/GMEM reset pulse
+only when the `AON_RESET` flag is set. AON reset is optional; it is not a
+requirement for the GDSC to exist or bind.
+
+## Phase 232 change
+
+Phase 232 changes only the Phase 231 GPU GX profile:
+
+- keep the exact `gpu_gx_gdsc` name guard
+- keep the exact `0x03d9100c + 0x4` resource guard
+- keep mandatory `sw-reset` and `domain-addr` syscons
+- keep parent-regulator ordering
+- make `qcom,reset-aon-logic` optional
+- pulse GMEM/AON reset only when the property is present
+- retain clamp removal, software-collapse control, and `PWR_ON` polling
+- emit the retained marker `A52GDSC GPU_GX_PROFILE_V2 ... aon=<0|1>`
+
+## Non-goals and safety limits
+
+Phase 232 does not:
+
+- claim `gpu_cx_gdsc`
+- claim unrelated `qcom,gdsc` nodes
+- bypass `device_links_check_suppliers()`
+- force KGSL binding
+- alter driver-core return values
+- change the device tree, firmware, IOMMU, clocks, or userspace
+- remove Phase 230 driver-core tracing and late replay
+
+## Expected next hardware result
+
+The Phase 230 late replay should show `3d9100c.qcom,gdsc` bound to
+`a52-legacy-gdsc-regulator`. KGSL should then either enter `adreno_probe()` or
+identify the next supplier or in-probe blocker precisely.

--- a/scripts/232_package.py
+++ b/scripts/232_package.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["GH_TOKEN"]
+REF = "agent/a52-phase232-gpu-gx-optional-aon-v1"
+WORKFLOW_ID = 325785868
+API = f"https://api.github.com/repos/{REPO}"
+
+
+def request(url: str, *, method: str = "GET", data: dict | None = None) -> bytes:
+    body = None if data is None else json.dumps(data).encode()
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=120) as response:
+        return response.read()
+
+
+def get_json(url: str) -> dict:
+    return json.loads(request(url))
+
+
+def dispatch_and_wait() -> tuple[int, str, int]:
+    started = (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    request(
+        f"{API}/actions/workflows/{WORKFLOW_ID}/dispatches",
+        method="POST",
+        data={"ref": REF},
+    )
+    run = None
+    for _ in range(40):
+        data = get_json(
+            f"{API}/actions/workflows/{WORKFLOW_ID}/runs?"
+            f"branch={REF}&event=workflow_dispatch&per_page=20"
+        )
+        candidates = [
+            item
+            for item in data.get("workflow_runs", [])
+            if item.get("created_at", "") >= started
+        ]
+        if candidates:
+            run = sorted(candidates, key=lambda item: item["created_at"])[-1]
+            break
+        time.sleep(15)
+    if not run:
+        raise RuntimeError("dispatched inherited build was not found")
+
+    run_id = int(run["id"])
+    print(f"Monitoring {run['html_url']}", flush=True)
+    for _ in range(720):
+        run = get_json(f"{API}/actions/runs/{run_id}")
+        print(
+            f"run={run_id} status={run['status']} "
+            f"conclusion={run.get('conclusion') or 'pending'}",
+            flush=True,
+        )
+        if run["status"] == "completed":
+            break
+        time.sleep(30)
+    if run.get("conclusion") != "success":
+        raise RuntimeError(
+            f"inherited builder conclusion: {run.get('conclusion')}"
+        )
+
+    artifacts = get_json(
+        f"{API}/actions/runs/{run_id}/artifacts?per_page=100"
+    ).get("artifacts", [])
+    artifacts = [item for item in artifacts if not item.get("expired")]
+    if not artifacts:
+        raise RuntimeError("successful inherited build produced no artifact")
+    artifact = artifacts[-1]
+    return run_id, run["html_url"], int(artifact["id"])
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def download_artifact(artifact_id: int, dest: Path) -> None:
+    api_url = f"{API}/actions/artifacts/{artifact_id}/zip"
+    req = urllib.request.Request(api_url, method="GET")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        opener.open(req, timeout=120)
+        raise RuntimeError("artifact download returned without redirect")
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (301, 302, 303, 307, 308):
+            raise
+        location = exc.headers.get("Location")
+        if not location:
+            raise RuntimeError("artifact redirect missing Location") from exc
+    with urllib.request.urlopen(location, timeout=120) as response:
+        dest.write_bytes(response.read())
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def locate_root(base: Path) -> Path:
+    matches = list(base.rglob("package/boot.img"))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one package/boot.img, found {len(matches)}"
+        )
+    return matches[0].parent.parent
+
+
+def verify_markers(image: Path) -> None:
+    data = image.read_bytes()
+    for marker in (
+        b"A52GDSC GPU_GX_PROFILE_V2",
+        b"A52GDSC gpu-enable",
+        b"KGPPOST 230 replay-begin",
+        b"KGPPOST 230",
+        b"KGPPOST 229",
+        b"TRIPOST 228",
+        b"ODSPOST 226",
+    ):
+        if marker not in data:
+            raise RuntimeError(f"missing binary marker: {marker.decode()}")
+        print(f"binary marker present: {marker.decode()}")
+
+
+def package(root: Path, source_run_id: int, source_run_url: str) -> Path:
+    verify_markers(root / "compile/Image")
+
+    audit_dir = root / "audit/phase232"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "227_phase226_retention_wrapper.py",
+        "230_phase229_driver_core_wrapper.py",
+        "231_phase230_gpu_gdsc_wrapper.py",
+        "232_phase231_optional_aon_wrapper.py",
+        "232_package.py",
+    ):
+        shutil.copy2(Path("scripts") / name, audit_dir / name)
+    shutil.copy2("scripts/232_design.md", root / "PHASE232-DESIGN.md")
+    shutil.copy2(
+        "scripts/232_trigger.txt",
+        root / "PHASE232-HARDWARE-TEST.txt",
+    )
+
+    audit_path = root / "final-audit.json"
+    audit = json.loads(audit_path.read_text())
+    audit.update({
+        "phase": 232,
+        "base_phase": 231,
+        "functional_base_phase": 230,
+        "hardware_validated": False,
+        "status": "phase232-gpu-gx-optional-aon-ci-audited-not-hardware-validated",
+        "phase232_behavior_changed": True,
+        "phase232_exact_supplier": "3d9100c.qcom,gdsc",
+        "phase232_exact_regulator": "gpu_gx_gdsc",
+        "phase232_exact_mmio": "0x03d9100c+0x4",
+        "phase232_aon_reset_optional": True,
+        "phase232_observed_dtb_aon_property": False,
+        "phase232_gpu_cx_claimed": False,
+        "phase232_unrelated_gdsc_claimed": False,
+        "phase232_driver_core_bypass": False,
+        "phase232_phase230_replay_retained": True,
+    })
+    audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n")
+
+    identity = {
+        "phase": 232,
+        "git_sha": os.environ.get("GITHUB_SHA"),
+        "git_ref": os.environ.get("GITHUB_REF"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_number": os.environ.get("GITHUB_RUN_NUMBER"),
+        "source_builder_run_id": str(source_run_id),
+        "source_builder_run_url": source_run_url,
+        "touchgrass_commit": "6bf351bdf18bdb228db79e66f14a7a9c0178e5d7",
+        "hardware_validated": False,
+        "change": "accept exact Lagoon gpu_gx_gdsc with optional AON reset",
+        "phase230_replay_retained": True,
+        "rs_roots": 48,
+    }
+    (root / "BUILD-IDENTITY.json").write_text(
+        json.dumps(identity, indent=2, sort_keys=True) + "\n"
+    )
+    (root / "README-FIRST.txt").write_text(
+        "A52 GKI 5.10 Phase 232 GPU GX optional-AON candidate\n\n"
+        "FLASH ONLY AFTER SHA256SUMS AND THE PACKAGE AUDIT PASS:\n"
+        "  package/boot.img -> BOOT partition\n\n"
+        "The Phase 231 hardware capture proved that the exact GPU GX GDSC\n"
+        "remained unbound. The flashed DTB omits qcom,reset-aon-logic, but\n"
+        "Phase 231 incorrectly required that optional property. Phase 232\n"
+        "keeps every exact profile and resource guard while executing the\n"
+        "AON reset pulse only when the property is present.\n\n"
+        "Phase 230 driver-core tracing and late replay remain enabled.\n\n"
+        "CI-validated, not hardware-validated. Follow\n"
+        "PHASE232-HARDWARE-TEST.txt.\n"
+    )
+
+    sums = root / "SHA256SUMS"
+    if sums.exists():
+        sums.unlink()
+    files = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.name != "SHA256SUMS"
+    )
+    sums.write_text(
+        "".join(
+            f"{sha256(path)}  ./{path.relative_to(root)}\n" for path in files
+        )
+    )
+
+    out = Path("phase232-out")
+    shutil.rmtree(out, ignore_errors=True)
+    shutil.copytree(root, out)
+    return out
+
+
+def main() -> int:
+    run_id, run_url, artifact_id = dispatch_and_wait()
+    work = Path("phase232-work")
+    shutil.rmtree(work, ignore_errors=True)
+    work.mkdir()
+    zip_path = work / "inherited.zip"
+    download_artifact(artifact_id, zip_path)
+    extract = work / "inherited"
+    extract.mkdir()
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extractall(extract)
+    root = locate_root(extract)
+    package(root, run_id, run_url)
+    print(f"Phase 232 package prepared from source run {run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, urllib.error.URLError, zipfile.BadZipFile) as exc:
+        print(f"Phase 232 packaging failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/232_phase231_optional_aon_wrapper.py
+++ b/scripts/232_phase231_optional_aon_wrapper.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Run Phase 231, then accept the exact Lagoon GPU GX DT without AON reset."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+PHASE231_MARKER = "A52_PHASE231_GPU_GX_GDSC_PROVIDER"
+PHASE232_MARKER = "A52_PHASE232_GPU_GX_OPTIONAL_AON"
+GDSC_REL = Path("drivers/regulator/a52-legacy-gdsc-regulator.c")
+DD_REL = Path("drivers/base/dd.c")
+EXPECTED_BEFORE_SHA256 = "5567c52f4cab8c6667d423b2303ebf8ddd9b408b5061604fce9d4413b885c49c"
+EXPECTED_AFTER_SHA256 = "d5dd48b76da3a84fa411bf2c0b271e14ef3522ddec6aedd745a57f70cb3bd2b0"
+
+_FATAL_AON = '''        gdsc->reset_aon = of_property_read_bool(pdev->dev.of_node,
+                                                "qcom,reset-aon-logic");
+        if (!gdsc->reset_aon)
+            return -EINVAL;
+
+        before = readl_relaxed(gdsc->gdscr);'''
+
+_OPTIONAL_AON = '''        gdsc->reset_aon = of_property_read_bool(pdev->dev.of_node,
+                                                "qcom,reset-aon-logic");
+        /*
+         * The Lagoon DT does not set qcom,reset-aon-logic for GPU GX.
+         * Match the Qualcomm GDSC helper semantics: the AON/GMEM reset
+         * pulse is optional and is executed only when the property exists.
+         */
+
+        before = readl_relaxed(gdsc->gdscr);'''
+
+_V1_LOG = '''        a52_ackfr_record(
+            "A52GDSC GPU_GX_PROFILE_V1 init name=%s before=0x%x after=0x%x",
+            name, before, val);'''
+
+_V2_LOG = '''        a52_ackfr_record(
+            "A52GDSC GPU_GX_PROFILE_V2 init name=%s before=0x%x after=0x%x aon=%u",
+            name, before, val, gdsc->reset_aon);
+        a52_persistent_diag_mark(
+            "A52GDSC GPU_PROFILE dev=%s name=%s aon=%u reg=0x%08x\\n",
+            dev_name(&pdev->dev), name, gdsc->reset_aon, val);'''
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def patch_gdsc(text: str, label: str) -> str:
+    if PHASE232_MARKER in text:
+        return text
+    actual = sha256_text(text)
+    if actual != EXPECTED_BEFORE_SHA256:
+        raise RuntimeError(
+            f"{label}: unexpected Phase 231 GDSC source sha256 {actual}"
+        )
+    if text.count(PHASE231_MARKER) != 1:
+        raise RuntimeError(f"{label}: Phase 231 marker count is not one")
+    if text.count(_FATAL_AON) != 1:
+        raise RuntimeError(f"{label}: fatal AON block count is not one")
+    if text.count(_V1_LOG) != 1:
+        raise RuntimeError(f"{label}: Phase 231 GPU profile log count is not one")
+
+    patched = text.replace(
+        PHASE231_MARKER,
+        PHASE231_MARKER + "\n * " + PHASE232_MARKER,
+        1,
+    )
+    patched = patched.replace(_FATAL_AON, _OPTIONAL_AON, 1)
+    patched = patched.replace(_V1_LOG, _V2_LOG, 1)
+
+    actual_after = sha256_text(patched)
+    if actual_after != EXPECTED_AFTER_SHA256:
+        raise RuntimeError(
+            f"{label}: unexpected Phase 232 GDSC sha256 {actual_after}"
+        )
+    for token in (
+        PHASE231_MARKER,
+        PHASE232_MARKER,
+        "A52GDSC GPU_GX_PROFILE_V2",
+        "if (gdsc->reset_aon)",
+        "a52_legacy_gdsc_enable_gpu_gx",
+        "a52_legacy_gdsc_disable_gpu_gx",
+    ):
+        if token not in patched:
+            raise RuntimeError(f"{label}: missing Phase 232 token {token}")
+    if _FATAL_AON in patched:
+        raise RuntimeError(f"{label}: optional AON property remains fatal")
+    return patched
+
+
+def candidate_roots(arguments: list[str]) -> list[Path]:
+    roots: list[Path] = []
+    for value in arguments:
+        if value.startswith("-"):
+            continue
+        path = Path(value)
+        roots.extend((path, path.parent))
+    roots.extend((Path("workspace/gki-phase199-src"), Path("gki/common")))
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        key = root.resolve(strict=False)
+        if key not in seen:
+            seen.add(key)
+            unique.append(root)
+    return unique
+
+
+def locate_root(arguments: list[str]) -> Path:
+    matches: list[Path] = []
+    for root in candidate_roots(arguments):
+        gdsc = root / GDSC_REL
+        dd = root / DD_REL
+        if not gdsc.is_file() or not dd.is_file():
+            continue
+        if PHASE231_MARKER not in gdsc.read_text(encoding="utf-8"):
+            continue
+        matches.append(root)
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in matches:
+        key = root.resolve()
+        if key not in seen:
+            seen.add(key)
+            unique.append(root)
+    if len(unique) != 1:
+        rendered = ", ".join(str(path) for path in unique) or "none"
+        raise RuntimeError(
+            f"expected one generated Phase 231 source root, found "
+            f"{len(unique)}: {rendered}"
+        )
+    return unique[0]
+
+
+def patch_generated(arguments: list[str]) -> Path:
+    root = locate_root(arguments)
+    path = root / GDSC_REL
+    original = path.read_text(encoding="utf-8")
+    path.write_text(patch_gdsc(original, str(path)), encoding="utf-8")
+    return root
+
+
+def self_test() -> None:
+    before_path = (
+        Path(__file__).resolve().parent
+        / "231_fixtures"
+        / "a52-legacy-gdsc-after.c"
+    )
+    if not before_path.is_file():
+        raise RuntimeError(f"missing Phase 231 source fixture: {before_path}")
+    original = before_path.read_text(encoding="utf-8")
+    if sha256_text(original) != EXPECTED_BEFORE_SHA256:
+        raise RuntimeError("Phase 232 input fixture checksum mismatch")
+    patched = patch_gdsc(original, "fixture")
+    if sha256_text(patched) != EXPECTED_AFTER_SHA256:
+        raise AssertionError("Phase 232 output checksum mismatch")
+    if patch_gdsc(patched, "fixture/idempotent") != patched:
+        raise AssertionError("Phase 232 patch is not idempotent")
+    if patched.count('"gpu_gx_gdsc"') != 2:
+        raise AssertionError("Phase 232 GPU GX whitelist is not exact")
+    if '"gpu_cx_gdsc"' in patched:
+        raise AssertionError("Phase 232 unexpectedly claims GPU CX")
+    print("Phase 232 exact GPU GX optional-AON self-test: PASS")
+
+
+def main() -> int:
+    base = Path(__file__).with_name("231_phase230_gpu_gdsc_wrapper.py")
+    if not base.is_file():
+        raise SystemExit(f"missing Phase 231 base wrapper: {base}")
+    completed = subprocess.run(
+        [sys.executable, str(base), *sys.argv[1:]], check=False
+    )
+    if completed.returncode:
+        return completed.returncode
+    if "--self-test" in sys.argv[1:]:
+        self_test()
+        return 0
+    root = patch_generated(sys.argv[1:])
+    print(f"Phase 232 exact GPU GX optional-AON fix applied to {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/232_trigger.txt
+++ b/scripts/232_trigger.txt
@@ -1,0 +1,16 @@
+A52XQ Phase 232 hardware test
+
+1. Verify every entry in SHA256SUMS.
+2. Flash only package/boot.img to the BOOT partition.
+3. Start one normal boot and leave the phone untouched for at least 210 seconds,
+   or until the watchdog/coordinated restart occurs.
+4. Boot directly into recovery without attempting a second normal boot.
+5. Collect the untouched raw RAMOOPS ZIP.
+
+Expected retained evidence:
+- A52GDSC GPU_GX_PROFILE_V2 with aon=0
+- 3d9100c.qcom,gdsc bound to a52-legacy-gdsc-regulator
+- device_links_check_suppliers no longer blocked by the GPU GX GDSC
+- adreno_probe entered, or a later exact blocker recorded
+
+This image is CI-validated but not hardware-validated.


### PR DESCRIPTION
## Hardware result from Phase 231

The Phase 231 RAMOOPS capture remained behaviorally unchanged, but its retained Phase 230 replay was decisive:

- `qcom,kgsl-3d0` still matched `kgsl-3d`
- `really_probe()` was still reached
- `device_links_check_suppliers()` still returned `-EPROBE_DEFER`
- `3d9100c.qcom,gdsc` remained unbound
- `adreno_probe()` was not reached

The exact Phase 231 implementation incorrectly required `qcom,reset-aon-logic` for the GPU GX profile and returned `-EINVAL` when the property was absent. The actual Lagoon DT profile omits this optional downstream flag.

## Phase 232 correction

Keep every exact Phase 231 guard, but treat AON/GMEM reset like the downstream implementation does:

- regulator name must still be exactly `gpu_gx_gdsc`
- MMIO must still be exactly `0x03d9100c`, size 4
- `domain-addr` and `sw-reset` remain required
- `qcom,reset-aon-logic` is optional
- the AON/GMEM reset pulse runs only when that property exists
- parent-supply regulator ordering is preserved

## Safety limits

- Does not claim GPU CX
- Does not claim unrelated `qcom,gdsc` nodes
- Does not bypass or remove device links
- Does not force KGSL binding
- Does not alter driver-core return values
- Does not modify DT, firmware, IOMMU, or userspace
- Preserves Phase 230 tracing and late replay

## Validation

- Exact Phase 231 input SHA-256 gate passed
- Deterministic Phase 232 output SHA-256 gate passed
- Patcher idempotence passed
- Exact GPU-only whitelist passed
- Full cumulative source self-test passed
- Full inherited kernel compile passed
- Final Phase 232 Image rebuild passed
- Binary-marker audit passed
- Package checksum audit passed
- Independently downloaded artifact verified against GitHub digest and internal `SHA256SUMS`

Artifact: `A52XQ-Phase232-GPU-GX-OPTIONAL-AON-1-NOT-HARDWARE-VALIDATED`

## Expected hardware evidence

- `A52GDSC GPU_GX_PROFILE_V2 ... aon=0`
- `3d9100c.qcom,gdsc` bound to `a52-legacy-gdsc-regulator`
- supplier checking proceeds past GPU GX
- `adreno_probe()` is entered, or a later exact blocker is retained