### PR TITLE
Phase 234 audited RSCC collector build

### DIFF
--- a/scripts/234_trigger.txt
+++ b/scripts/234_trigger.txt
@@ -31,3 +31,4 @@ Do not use the bundled recorder-v3 decoder. This candidate intentionally retains
 
 Build retrigger: cumulative Phase 230 RSCC layout repair v2.
 Push-event trigger: Git data commit.
+PR-event trigger: audited Phase 234 branch-head build.

--- a/scripts/234_trigger.txt
+++ b/scripts/234_trigger.txt
@@ -32,3 +32,4 @@ Do not use the bundled recorder-v3 decoder. This candidate intentionally retains
 Build retrigger: cumulative Phase 230 RSCC layout repair v2.
 Push-event trigger: Git data commit.
 PR-event trigger: audited Phase 234 branch-head build.
+PR retry: committed Phase 230 layout override at base head.


### PR DESCRIPTION
Triggers the Phase 234 PR workflow from the repaired branch head. The only head-branch change is an explicit trigger note in scripts/234_trigger.txt; the workflow performs the cumulative Phase 230 layout repair in its working tree and packages the RSCC-focused recorder candidate for audit.