### PR TITLE
Phase 234 commit cumulative RSCC layout repair

### DIFF
--- a/scripts/227_phase226_retention_wrapper.py
+++ b/scripts/227_phase226_retention_wrapper.py
@@ -484,6 +484,59 @@ static bool a52_rscc_probe_driver(const struct device_driver *drv)
     return text
 
 
+
+# A52_PHASE234_PHASE230_LAYOUT_FIX_V2
+# Phase 230 inserts bounded KGSL records between driver_match_device() and the
+# inherited RSCC records. Match only the two contiguous RSCC record blocks so
+# all KGSL and Phase 202 SMMU instrumentation remains byte-for-byte intact.
+def patch_phase234_dd_text(text: str, label: str) -> str:
+    if "A52_PHASE234_RSCC_MATCH_FILTER_V1" in text:
+        return text
+
+    helper_old = """static bool a52_rscc_probe_device(const struct device *dev)
+{
+\treturn dev && dev->of_node &&
+\t\tof_device_is_compatible(dev->of_node, \"qcom,sde-rsc\");
+}
+"""
+    helper_new = helper_old + """
+/* A52_PHASE234_RSCC_MATCH_FILTER_V1 */
+static bool a52_rscc_probe_driver(const struct device_driver *drv)
+{
+\treturn drv && drv->name && !strcmp(drv->name, \"sde_rsc\");
+}
+"""
+    text = _replace_exact_once(
+        text, helper_old, helper_new, f"{label}: RSCC driver helper v2"
+    )
+
+    old_device = """\tif (a52_rscc_probe_device(dev))
+\t\ta52_ackfr_record(\"RSCCCORE match path=device-attach dev=%s drv=%s rc=%d\",
+\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\", ret);
+"""
+    new_device = """\tif (a52_rscc_probe_device(dev) &&
+\t    (ret || a52_rscc_probe_driver(drv)))
+\t\ta52_ackfr_record(\"RSCCFOCUS match path=device-attach dev=%s drv=%s rc=%d\",
+\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\", ret);
+"""
+    text = _replace_exact_once(
+        text, old_device, new_device, f"{label}: device-attach focused block v2"
+    )
+
+    old_driver = """\tif (a52_rscc_probe_device(dev))
+\t\ta52_ackfr_record(\"RSCCCORE match path=driver-attach dev=%s drv=%s rc=%d\",
+\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\", ret);
+"""
+    new_driver = """\tif (a52_rscc_probe_device(dev) &&
+\t    (ret || a52_rscc_probe_driver(drv)))
+\t\ta52_ackfr_record(\"RSCCFOCUS match path=driver-attach dev=%s drv=%s rc=%d\",
+\t\t\tdev_name(dev), drv && drv->name ? drv->name : \"-\", ret);
+"""
+    text = _replace_exact_once(
+        text, old_driver, new_driver, f"{label}: driver-attach focused block v2"
+    )
+    return text
+
 def locate_phase234_kernel_root() -> Path | None:
     for candidate in (
         Path.cwd() / "gki/common",

--- a/scripts/234_trigger.txt
+++ b/scripts/234_trigger.txt
@@ -29,5 +29,4 @@ Interpretation order:
 
 Do not use the bundled recorder-v3 decoder. This candidate intentionally retains the Phase 210 R48 RS48 + CRC32C format.
 
-Build retrigger: cumulative Phase 230 RSCC layout repair v2.
-Push-event trigger: Git data commit.
+Artifact request: same-repository pull-request build after cumulative Phase 230 layout repair v2.


### PR DESCRIPTION
Merges the exact previously generated Phase 230-aware RSCC wrapper override into the Phase 234 base branch. This is required because the Phase 234 packager dispatches the inherited builder from the branch ref, not from the workflow runner's temporary working tree.