### PR TITLE
Phase 279: broad display failure recorder

### DIFF
--- a/.github/workflows/279-a52-broad-display-failure-snapshot.yml
+++ b/.github/workflows/279-a52-broad-display-failure-snapshot.yml
@@ -1,0 +1,81 @@
+name: 279 - A52 broad display failure snapshot
+run-name: Phase 279 - broad DSI SMMU failure cross-section
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase279-broad-display-failure-snapshot-v1
+    paths:
+      - .github/workflows/279-a52-broad-display-failure-snapshot.yml
+      - scripts/279_apply_live_dsi_iova_translation.py
+      - scripts/279_check_live_dsi_iova_translation.py
+      - scripts/279_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase279-broad-display-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase278 and build Phase279 broad recorder
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase279 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct Phase278 add broad cross-section compile audit repack Phase279
+        run: bash scripts/279_ci_build.sh
+      - name: Upload Phase279 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase279-BROAD-DISPLAY-FAILURE-SNAPSHOT-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase279-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase279-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/279-a52-broad-display-failure-snapshot.yml
+++ b/.github/workflows/279-a52-broad-display-failure-snapshot.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - agent/a52-phase278-live-display-smmu-state-v1
+      - agent/a52-phase279-broad-display-failure-snapshot-v1
     paths:
       - .github/workflows/279-a52-broad-display-failure-snapshot.yml
       - scripts/279_apply_live_dsi_iova_translation.py

--- a/.github/workflows/279-a52-broad-display-failure-snapshot.yml
+++ b/.github/workflows/279-a52-broad-display-failure-snapshot.yml
@@ -10,6 +10,14 @@ on:
       - scripts/279_apply_live_dsi_iova_translation.py
       - scripts/279_check_live_dsi_iova_translation.py
       - scripts/279_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase278-live-display-smmu-state-v1
+    paths:
+      - .github/workflows/279-a52-broad-display-failure-snapshot.yml
+      - scripts/279_apply_live_dsi_iova_translation.py
+      - scripts/279_check_live_dsi_iova_translation.py
+      - scripts/279_ci_build.sh
 permissions:
   contents: read
   actions: read

--- a/scripts/279_apply_live_dsi_iova_translation.py
+++ b/scripts/279_apply_live_dsi_iova_translation.py
@@ -33,7 +33,7 @@ def patch_smmu(text: str) -> str:
 /* A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1
  * Broad but read-only cross-section at the already-proven DSI DMA failure
  * boundary. The command IOVA is translated through the software io-pgtable
- * walk only; this deliberately avoids arm_smmu_iova_to_phys_hard()/ATS1PR.
+ * walk only; no hardware translation request is issued by this recorder.
  * Context/global fault registers are read but never cleared here. TTBR0/TCR
  * are read back only to correlate the active hardware root with cached state.
  */

--- a/scripts/279_apply_live_dsi_iova_translation.py
+++ b/scripts/279_apply_live_dsi_iova_translation.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import shutil
+import tempfile
+from pathlib import Path
+
+SMMU = Path('drivers/iommu/arm/arm-smmu/arm-smmu.c')
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1'
+DECL278 = 'extern void a52_p278_display_smmu_snapshot(unsigned int point);\n'
+DECL279 = ('extern void a52_p279_display_iova_snapshot(unsigned int point,\n'
+           '\t\tdma_addr_t iova, u32 len);\n'
+           'extern void a52_p279_display_fault_snapshot(unsigned int point);\n')
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_smmu(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE278_LIVE_DISPLAY_SMMU_SNAPSHOT_V1' not in text:
+        raise SystemExit('Phase278 live SMMU marker missing')
+
+    anchor = 'EXPORT_SYMBOL_GPL(a52_p278_display_smmu_snapshot);\n'
+    helper = r'''
+
+/* A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1
+ * Broad but read-only cross-section at the already-proven DSI DMA failure
+ * boundary. The command IOVA is translated through the software io-pgtable
+ * walk only; this deliberately avoids arm_smmu_iova_to_phys_hard()/ATS1PR.
+ * Context/global fault registers are read but never cleared here. TTBR0/TCR
+ * are read back only to correlate the active hardware root with cached state.
+ */
+void a52_p279_display_iova_snapshot(unsigned int point,
+		dma_addr_t iova, u32 len)
+{
+	bool any = false;
+	int slot;
+
+	for (slot = 0; slot < ARRAY_SIZE(a52_p278_display_ctx); slot++) {
+		struct a52_p278_display_ctx *ctx = &a52_p278_display_ctx[slot];
+		struct arm_smmu_device *smmu;
+		struct arm_smmu_cb *cb;
+		struct arm_smmu_cfg *cfg;
+		struct arm_smmu_domain *smmu_domain;
+		struct io_pgtable_ops *ops;
+		dma_addr_t end = iova;
+		phys_addr_t pa_first, pa_last;
+		u64 hw_ttbr = 0, cached_ttbr;
+		u32 hw_tcr = 0, cached_tcr;
+		int ret;
+
+		if (!ctx->valid)
+			continue;
+		any = true;
+		smmu = ctx->smmu;
+		if (!smmu || ctx->cbndx >= smmu->num_context_banks) {
+			a52_ackfr_record("SMMU P279 X p=%u sid=%x r=2",
+					  point, ctx->sid);
+			continue;
+		}
+
+		cb = &smmu->cbs[ctx->cbndx];
+		cfg = cb->cfg;
+		if (!cfg) {
+			a52_ackfr_record("SMMU P279 X p=%u sid=%x r=3",
+					  point, ctx->sid);
+			continue;
+		}
+		smmu_domain = cfg_to_smmu_domain(cfg);
+		ops = smmu_domain->pgtbl_ops;
+		if (!ops || !ops->iova_to_phys) {
+			a52_ackfr_record("SMMU P279 X p=%u sid=%x r=4",
+					  point, ctx->sid);
+			continue;
+		}
+
+		if (len) {
+			end = iova + (dma_addr_t)len - 1;
+			if (end < iova) {
+				a52_ackfr_record("SMMU P279 X p=%u sid=%x r=5",
+						  point, ctx->sid);
+				continue;
+			}
+		}
+
+		pa_first = ops->iova_to_phys(ops, iova);
+		pa_last = ops->iova_to_phys(ops, end);
+		cached_ttbr = cb->ttbr[0];
+		cached_tcr = cb->tcr[0];
+
+		ret = arm_smmu_rpm_get(smmu);
+		if (ret >= 0) {
+			if (cfg->fmt == ARM_SMMU_CTX_FMT_AARCH32_S)
+				hw_ttbr = arm_smmu_cb_read(smmu, ctx->cbndx,
+							 ARM_SMMU_CB_TTBR0);
+			else
+				hw_ttbr = arm_smmu_cb_readq(smmu, ctx->cbndx,
+							  ARM_SMMU_CB_TTBR0);
+			hw_tcr = arm_smmu_cb_read(smmu, ctx->cbndx,
+						 ARM_SMMU_CB_TCR);
+			arm_smmu_rpm_put(smmu);
+		}
+
+		a52_ackfr_record(
+			"SMMU P279 I p=%u sid=%x cb=%u i=%llx l=%u e=%llx p0=%llx p1=%llx",
+			point, ctx->sid, ctx->cbndx,
+			(unsigned long long)iova, len,
+			(unsigned long long)end,
+			(unsigned long long)pa_first,
+			(unsigned long long)pa_last);
+		a52_ackfr_record(
+			"SMMU P279 T p=%u sid=%x r=%d ht=%llx ct=%llx hr=%x cr=%x",
+			point, ctx->sid, ret,
+			(unsigned long long)hw_ttbr,
+			(unsigned long long)cached_ttbr,
+			hw_tcr, cached_tcr);
+	}
+
+	if (!any)
+		a52_ackfr_record("SMMU P279 X p=%u sid=0 r=1", point);
+}
+EXPORT_SYMBOL_GPL(a52_p279_display_iova_snapshot);
+
+void a52_p279_display_fault_snapshot(unsigned int point)
+{
+	struct arm_smmu_device *global_smmu = NULL;
+	bool any = false;
+	int slot;
+
+	for (slot = 0; slot < ARRAY_SIZE(a52_p278_display_ctx); slot++) {
+		struct a52_p278_display_ctx *ctx = &a52_p278_display_ctx[slot];
+		struct arm_smmu_device *smmu;
+		u32 fsr, fsynr0, cbfrsynra;
+		u64 far;
+		int ret;
+
+		if (!ctx->valid)
+			continue;
+		any = true;
+		smmu = ctx->smmu;
+		if (!smmu || ctx->cbndx >= smmu->num_context_banks) {
+			a52_ackfr_record("SMMU P279 X p=%u sid=%x r=6",
+					  point, ctx->sid);
+			continue;
+		}
+
+		ret = arm_smmu_rpm_get(smmu);
+		if (ret < 0) {
+			a52_ackfr_record("SMMU P279 X p=%u sid=%x r=7",
+					  point, ctx->sid);
+			continue;
+		}
+
+		fsr = arm_smmu_cb_read(smmu, ctx->cbndx, ARM_SMMU_CB_FSR);
+		fsynr0 = arm_smmu_cb_read(smmu, ctx->cbndx, ARM_SMMU_CB_FSYNR0);
+		far = arm_smmu_cb_readq(smmu, ctx->cbndx, ARM_SMMU_CB_FAR);
+		cbfrsynra = arm_smmu_gr1_read(smmu,
+					 ARM_SMMU_GR1_CBFRSYNRA(ctx->cbndx));
+		a52_ackfr_record(
+			"SMMU P279 F p=%u sid=%x cb=%u fs=%x sy=%x far=%llx cfr=%x",
+			point, ctx->sid, ctx->cbndx, fsr, fsynr0,
+			(unsigned long long)far, cbfrsynra);
+
+		if (global_smmu != smmu) {
+			u32 gfsr, g0, g1, g2;
+
+			gfsr = arm_smmu_gr0_read(smmu, ARM_SMMU_GR0_sGFSR);
+			g0 = arm_smmu_gr0_read(smmu, ARM_SMMU_GR0_sGFSYNR0);
+			g1 = arm_smmu_gr0_read(smmu, ARM_SMMU_GR0_sGFSYNR1);
+			g2 = arm_smmu_gr0_read(smmu, ARM_SMMU_GR0_sGFSYNR2);
+			a52_ackfr_record(
+				"SMMU P279 G p=%u gf=%x g0=%x g1=%x g2=%x",
+				point, gfsr, g0, g1, g2);
+			global_smmu = smmu;
+		}
+
+		arm_smmu_rpm_put(smmu);
+	}
+
+	if (!any)
+		a52_ackfr_record("SMMU P279 X p=%u sid=0 r=8", point);
+}
+EXPORT_SYMBOL_GPL(a52_p279_display_fault_snapshot);
+'''
+    return replace_one(text, anchor, anchor + helper,
+                       'Phase279 SMMU broad snapshot helper insertion')
+
+
+def patch_dsi(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE278_LIVE_DISPLAY_SMMU_SNAPSHOT_V1' not in text:
+        raise SystemExit('Phase278 live SMMU marker missing from dsi_ctrl.c')
+
+    text = replace_one(
+        text, DECL278,
+        DECL278 + DECL279 + '/* ' + MARK + ' */\n',
+        'Phase279 DSI declarations')
+
+    old = '''\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p278_display_smmu_snapshot(0);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_ackfr_record("P276 H K o=%llx l=%u h=%x",\n'''
+    new = '''\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p278_display_smmu_snapshot(0);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p279_display_iova_snapshot(0, cmd_mem->offset,\n\t\t\t\t\t\tcmd_mem->length);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p279_display_fault_snapshot(0);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_ackfr_record("P276 H K o=%llx l=%u h=%x",\n'''
+    text = replace_one(text, old, new, 'Phase279 pre-kickoff broad snapshot')
+
+    old = '''\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p278_display_smmu_snapshot(1);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_ackfr_record("P276 H R c=%x s=%x d=%x i=%x k=%x q=%x o=%x l=%x",\n'''
+    new = '''\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p278_display_smmu_snapshot(1);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p279_display_fault_snapshot(1);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_ackfr_record("P276 H R c=%x s=%x d=%x i=%x k=%x q=%x o=%x l=%x",\n'''
+    text = replace_one(text, old, new, 'Phase279 post-kickoff fault snapshot')
+
+    old = '''\t\tif (a52_p276r_deep_active())\n\t\t\ta52_p278_display_smmu_snapshot(2);\n\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n'''
+    new = '''\t\tif (a52_p276r_deep_active())\n\t\t\ta52_p278_display_smmu_snapshot(2);\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_p279_display_fault_snapshot(2);\n\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n'''
+    return replace_one(text, old, new, 'Phase279 timeout fault snapshot')
+
+
+def apply(root: Path) -> None:
+    smmu = root / SMMU
+    dsi = root / DSI
+    if not smmu.is_file() or not dsi.is_file():
+        raise SystemExit(f'missing reconstructed source: {smmu} / {dsi}')
+    smmu.write_text(patch_smmu(smmu.read_text()))
+    dsi.write_text(patch_dsi(dsi.read_text()))
+
+
+def self_test(root: Path) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for rel in (SMMU, DSI):
+            src = root / rel
+            if not src.is_file():
+                raise SystemExit(f'missing source for self-test: {src}')
+            dst = tmp / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+        apply(tmp)
+        once = [(tmp / rel).read_text() for rel in (SMMU, DSI)]
+        apply(tmp)
+        twice = [(tmp / rel).read_text() for rel in (SMMU, DSI)]
+        if once != twice:
+            raise SystemExit('Phase279 patch is not idempotent')
+        joined = '\n'.join(once)
+        required = [
+            MARK,
+            'ops->iova_to_phys(ops, iova)',
+            'ops->iova_to_phys(ops, end)',
+            'ARM_SMMU_CB_TTBR0', 'ARM_SMMU_CB_TCR',
+            'ARM_SMMU_CB_FSYNR0', 'ARM_SMMU_CB_FAR',
+            'ARM_SMMU_GR1_CBFRSYNRA(ctx->cbndx)',
+            'ARM_SMMU_GR0_sGFSR', 'ARM_SMMU_GR0_sGFSYNR0',
+            'ARM_SMMU_GR0_sGFSYNR1', 'ARM_SMMU_GR0_sGFSYNR2',
+            'SMMU P279 I p=%u sid=%x cb=%u i=%llx l=%u e=%llx p0=%llx p1=%llx',
+            'SMMU P279 T p=%u sid=%x r=%d ht=%llx ct=%llx hr=%x cr=%x',
+            'SMMU P279 F p=%u sid=%x cb=%u fs=%x sy=%x far=%llx cfr=%x',
+            'SMMU P279 G p=%u gf=%x g0=%x g1=%x g2=%x',
+            'a52_p279_display_iova_snapshot(0, cmd_mem->offset,',
+            'a52_p279_display_fault_snapshot(0);',
+            'a52_p279_display_fault_snapshot(1);',
+            'a52_p279_display_fault_snapshot(2);',
+            'a52_p278_display_smmu_snapshot(0);',
+            'a52_p278_display_smmu_snapshot(1);',
+            'a52_p278_display_smmu_snapshot(2);',
+        ]
+        for token in required:
+            if token not in joined:
+                raise SystemExit('Phase279 self-test marker missing: ' + token)
+        helper = joined.split('/* ' + MARK, 1)[1].split(
+            'EXPORT_SYMBOL_GPL(a52_p279_display_fault_snapshot);', 1)[0]
+        forbidden = [
+            'ARM_SMMU_CB_ATS1PR', 'arm_smmu_iova_to_phys_hard(',
+            'arm_smmu_cb_write(', 'arm_smmu_cb_writeq(',
+            'arm_smmu_gr0_write(', 'arm_smmu_gr1_write(',
+            'tlb_flush', 'ops->map(', 'ops->unmap(',
+            'map_pages(', 'unmap_pages(',
+        ]
+        for token in forbidden:
+            if token in helper:
+                raise SystemExit('Phase279 helper contains forbidden mutator: ' + token)
+        if joined.count('a52_p279_display_iova_snapshot(0, cmd_mem->offset,') != 1:
+            raise SystemExit('Phase279 kickoff IOVA snapshot count wrong')
+        for point in (0, 1, 2):
+            if joined.count(f'a52_p279_display_fault_snapshot({point});') != 1:
+                raise SystemExit(f'Phase279 fault snapshot point {point} count wrong')
+    print('Phase279 broad display failure snapshot self-test: PASS')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--self-test', action='store_true')
+    args = ap.parse_args()
+    if args.self_test:
+        self_test(args.root)
+    else:
+        apply(args.root)
+        print('Phase279 broad display failure recorder applied')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/279_check_live_dsi_iova_translation.py
+++ b/scripts/279_check_live_dsi_iova_translation.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+SMMU = Path('drivers/iommu/arm/arm-smmu/arm-smmu.c')
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1'
+
+
+def fail(msg: str) -> None:
+    raise SystemExit('Phase279 check FAIL: ' + msg)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    args = ap.parse_args()
+    smmu_path = args.root / SMMU
+    dsi_path = args.root / DSI
+    if not smmu_path.is_file() or not dsi_path.is_file():
+        fail('reconstructed source missing')
+    smmu = smmu_path.read_text()
+    dsi = dsi_path.read_text()
+    joined = smmu + '\n' + dsi
+
+    required = [
+        'A52_PHASE277_QSMMUV500_DISPLAY_ACTLR_PARITY_V1',
+        'A52_PHASE278_LIVE_DISPLAY_SMMU_SNAPSHOT_V1',
+        MARK,
+        'void a52_p279_display_iova_snapshot(unsigned int point,',
+        'void a52_p279_display_fault_snapshot(unsigned int point)',
+        'cfg = cb->cfg;',
+        'smmu_domain = cfg_to_smmu_domain(cfg);',
+        'ops = smmu_domain->pgtbl_ops;',
+        'pa_first = ops->iova_to_phys(ops, iova);',
+        'pa_last = ops->iova_to_phys(ops, end);',
+        'end = iova + (dma_addr_t)len - 1;',
+        'cached_ttbr = cb->ttbr[0];',
+        'cached_tcr = cb->tcr[0];',
+        'ARM_SMMU_CB_TTBR0', 'ARM_SMMU_CB_TCR',
+        'ARM_SMMU_CB_FSR', 'ARM_SMMU_CB_FSYNR0', 'ARM_SMMU_CB_FAR',
+        'ARM_SMMU_GR1_CBFRSYNRA(ctx->cbndx)',
+        'ARM_SMMU_GR0_sGFSR', 'ARM_SMMU_GR0_sGFSYNR0',
+        'ARM_SMMU_GR0_sGFSYNR1', 'ARM_SMMU_GR0_sGFSYNR2',
+        'SMMU P279 I p=%u sid=%x cb=%u i=%llx l=%u e=%llx p0=%llx p1=%llx',
+        'SMMU P279 T p=%u sid=%x r=%d ht=%llx ct=%llx hr=%x cr=%x',
+        'SMMU P279 F p=%u sid=%x cb=%u fs=%x sy=%x far=%llx cfr=%x',
+        'SMMU P279 G p=%u gf=%x g0=%x g1=%x g2=%x',
+        'EXPORT_SYMBOL_GPL(a52_p279_display_iova_snapshot);',
+        'EXPORT_SYMBOL_GPL(a52_p279_display_fault_snapshot);',
+        'a52_p279_display_iova_snapshot(0, cmd_mem->offset,',
+        'a52_p279_display_fault_snapshot(0);',
+        'a52_p279_display_fault_snapshot(1);',
+        'a52_p279_display_fault_snapshot(2);',
+        'P276 H K o=%llx l=%u h=%x',
+    ]
+    for token in required:
+        if token not in joined:
+            fail('missing token: ' + token)
+
+    if smmu.count(MARK) != 1 or dsi.count(MARK) != 1:
+        fail(f'marker count smmu={smmu.count(MARK)} dsi={dsi.count(MARK)}, expected 1/1')
+    if dsi.count('a52_p279_display_iova_snapshot(0, cmd_mem->offset,') != 1:
+        fail('DSI point-0 translation snapshot count is not exactly one')
+    for point in (0, 1, 2):
+        if dsi.count(f'a52_p279_display_fault_snapshot({point});') != 1:
+            fail(f'Phase279 fault snapshot point {point} is not exactly one')
+        if dsi.count(f'a52_p278_display_smmu_snapshot({point});') != 1:
+            fail(f'Phase278 snapshot point {point} was not preserved exactly once')
+
+    start = smmu.find('/* ' + MARK)
+    end = smmu.find('EXPORT_SYMBOL_GPL(a52_p279_display_fault_snapshot);', start)
+    if start < 0 or end < 0:
+        fail('cannot isolate Phase279 SMMU helpers')
+    helper = smmu[start:end]
+    forbidden = [
+        'ARM_SMMU_CB_ATS1PR',
+        'arm_smmu_iova_to_phys_hard(',
+        'arm_smmu_cb_write(', 'arm_smmu_cb_writeq(',
+        'arm_smmu_gr0_write(', 'arm_smmu_gr1_write(',
+        'tlb_flush', 'ops->map(', 'ops->unmap(',
+        'map_pages(', 'unmap_pages(',
+    ]
+    for token in forbidden:
+        if token in helper:
+            fail('recorder helper contains state-changing/hardware-translation token: ' + token)
+
+    p278_0 = dsi.find('a52_p278_display_smmu_snapshot(0);')
+    p279_i = dsi.find('a52_p279_display_iova_snapshot(0, cmd_mem->offset,')
+    p279_f0 = dsi.find('a52_p279_display_fault_snapshot(0);')
+    prog = dsi.find('a52_ackfr_record("P276 H K o=%llx l=%u h=%x"', p279_f0)
+    kick = dsi.find('dsi_hw_ops.kickoff_command(', p279_f0)
+    if min(p278_0, p279_i, p279_f0, prog, kick) < 0 or not (
+            p278_0 < p279_i < p279_f0 < prog < kick):
+        fail('pre-kickoff ordering is not P278 -> mapping/root -> fault -> P276 program -> kickoff')
+
+    p278_1 = dsi.find('a52_p278_display_smmu_snapshot(1);')
+    p279_f1 = dsi.find('a52_p279_display_fault_snapshot(1);')
+    readback = dsi.find('a52_ackfr_record("P276 H R c=%x s=%x d=%x i=%x k=%x q=%x o=%x l=%x"', p279_f1)
+    if min(p278_1, p279_f1, readback) < 0 or not (p278_1 < p279_f1 < readback):
+        fail('post-kickoff fault ordering is not preserved')
+
+    p278_2 = dsi.find('a52_p278_display_smmu_snapshot(2);')
+    p279_f2 = dsi.find('a52_p279_display_fault_snapshot(2);')
+    status = dsi.find('status = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);', p279_f2)
+    if min(p278_2, p279_f2, status) < 0 or not (p278_2 < p279_f2 < status):
+        fail('timeout fault ordering is not preserved')
+
+    if helper.count('ops->iova_to_phys(') != 2:
+        fail('expected exactly two software io-pgtable translation calls')
+    if helper.count('ARM_SMMU_GR0_sGFSR') != 1:
+        fail('expected exactly one global fault-status read token in helper')
+
+    print('Phase279 broad display failure snapshot checker: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/279_ci_build.sh
+++ b/scripts/279_ci_build.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+
+fail_report(){
+  set +e
+  rm -rf phase279-failure
+  mkdir -p phase279-failure/source phase279-failure/logs phase279-failure/audit
+  cp phase279-compile.log phase279-failure/logs/ 2>/dev/null || true
+  cp "$SMMU" phase279-failure/source/arm-smmu.c 2>/dev/null || true
+  cp "$DSI" phase279-failure/source/dsi_ctrl.c 2>/dev/null || true
+  cp scripts/279_apply_live_dsi_iova_translation.py phase279-failure/audit/ 2>/dev/null || true
+  cp scripts/279_check_live_dsi_iova_translation.py phase279-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact Phase278 live-SMMU recorder first. Phase279 broadens the
+# same proven DSI DMA boundary without changing translation or DSI control flow.
+bash scripts/278_ci_build.sh
+test -s phase278-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+cp "$OUT/.config" /tmp/p279-base.config
+cp "$SMMU" /tmp/p279-arm-smmu-before.c
+cp "$DSI" /tmp/p279-dsi-ctrl-before.c
+
+python3 -m py_compile \
+  scripts/279_apply_live_dsi_iova_translation.py \
+  scripts/279_check_live_dsi_iova_translation.py
+python3 scripts/279_apply_live_dsi_iova_translation.py --root "$ROOT" --self-test
+python3 scripts/279_apply_live_dsi_iova_translation.py --root "$ROOT"
+python3 scripts/279_check_live_dsi_iova_translation.py --root "$ROOT"
+
+! cmp -s /tmp/p279-arm-smmu-before.c "$SMMU"
+! cmp -s /tmp/p279-dsi-ctrl-before.c "$DSI"
+grep -Fq 'A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1' "$SMMU"
+grep -Fq 'A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1' "$DSI"
+grep -Fq 'ops->iova_to_phys(ops, iova)' "$SMMU"
+grep -Fq 'ops->iova_to_phys(ops, end)' "$SMMU"
+grep -Fq 'ARM_SMMU_CB_FSYNR0' "$SMMU"
+grep -Fq 'ARM_SMMU_GR0_sGFSR' "$SMMU"
+grep -Fq 'SMMU P279 I p=%u sid=%x cb=%u i=%llx l=%u e=%llx p0=%llx p1=%llx' "$SMMU"
+grep -Fq 'SMMU P279 F p=%u sid=%x cb=%u fs=%x sy=%x far=%llx cfr=%x' "$SMMU"
+grep -Fq 'SMMU P279 G p=%u gf=%x g0=%x g1=%x g2=%x' "$SMMU"
+grep -Fq 'a52_p279_display_iova_snapshot(0, cmd_mem->offset,' "$DSI"
+grep -Fq 'a52_p279_display_fault_snapshot(2);' "$DSI"
+
+# No config, mapping, TLB, stream-routing, ACTLR or DSI functional change is
+# allowed. The checker additionally rejects ATS1PR and SMMU write primitives.
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p279-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase279-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase279-out
+mkdir -p phase279-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase279-out/compile/Image
+cp "$OUT/.config" phase279-out/config/final.config
+cp /tmp/p279-base.config phase279-out/audit/phase278-final.config
+cp /tmp/p279-arm-smmu-before.c phase279-out/audit/arm-smmu-before.c
+cp /tmp/p279-dsi-ctrl-before.c phase279-out/audit/dsi-ctrl-before.c
+cp phase279-compile.log phase279-out/audit/
+cp scripts/279_apply_live_dsi_iova_translation.py phase279-out/audit/
+cp scripts/279_check_live_dsi_iova_translation.py phase279-out/audit/
+cp "$SMMU" phase279-out/source/arm-smmu.c
+cp "$DSI" phase279-out/source/dsi_ctrl.c
+
+gzip -n -c "$IMAGE" > phase279-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase278-out/package/boot.img \
+  --kernel phase279-out/package/Image.gz \
+  --output phase279-out/package/boot.img \
+  --report phase279-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase279-out')
+idn = {
+    'phase': '279',
+    'name': 'BROAD-DISPLAY-FAILURE-CROSS-SECTION',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'hardware_validated': False,
+    'base': 'Phase278 live SMMU state + Phase277 ACTLR + Phase276R DMA recorder V5',
+    'functional_change': 'none; diagnostic-only broad read-only cross-section',
+    'translation_state_changed': False,
+    'hardware_translation_request_issued': False,
+    'fault_status_cleared': False,
+    'tbu_driver_added': False,
+    'snapshot_points': {
+        '0': 'pre-kickoff: live Phase278 state + software IOVA translation/root + SMMU faults',
+        '1': 'post-kickoff: live Phase278 state + SMMU faults',
+        '2': 'DMA timeout: live Phase278 state + SMMU faults before DSI status handling',
+    },
+    'hardware_question': (
+        'For the exact DSI command DMA that times out with DMA_DONE=0, correlate in '
+        'one boot: software first/last-byte IOVA translation, cached versus live '
+        'TTBR0/TCR, context fault FSR/FSYNR0/FAR/CBFRSYNRA, global fault '
+        'sGFSR/sGFSYNR0/1/2, existing live ACTLR/SCTLR/S2CR/SMR/CBAR, and existing '
+        'DSI DMA/controller/clock/error readback.'
+    ),
+    'interpretation': {
+        'mapping': 'p0/p1 zero or inconsistent => software mapping defect',
+        'root': 'live TTBR0/TCR differs from cached => context programming/root drift',
+        'context_fault': 'new FSR/FSYNR0/FAR after kickoff => translating CB rejected/faulted DMA',
+        'global_fault': 'new sGFSR/sGFSYNR values => stream/global SMMU fault path',
+        'downstream': 'mapping/root/fault state clean while DMA_DONE stays zero => move beyond software SMMU mapping/root into fetch/coherency/interconnect/controller path',
+    },
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn, indent=2, sort_keys=True) + '\n')
+files = [
+    'compile/Image', 'config/final.config', 'package/Image.gz', 'package/boot.img',
+    'package/repack-report.json', 'audit/phase278-final.config',
+    'audit/arm-smmu-before.c', 'audit/dsi-ctrl-before.c',
+    'audit/279_apply_live_dsi_iova_translation.py',
+    'audit/279_check_live_dsi_iova_translation.py',
+    'source/arm-smmu.c', 'source/dsi_ctrl.c',
+]
+with (r/'SHA256SUMS').open('w') as f:
+    for n in files:
+        f.write(hashlib.sha256((r/n).read_bytes()).hexdigest() + '  ./' + n + '\n')
+PY
+
+(cd phase279-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r = Path('phase279-out')
+smmu = (r/'source/arm-smmu.c').read_text()
+dsi = (r/'source/dsi_ctrl.c').read_text()
+img = (r/'compile/Image').read_bytes()
+required_source = [
+    'A52_PHASE279_BROAD_DISPLAY_FAILURE_SNAPSHOT_V1',
+    'ops->iova_to_phys(ops, iova)',
+    'ops->iova_to_phys(ops, end)',
+    'ARM_SMMU_CB_FSYNR0', 'ARM_SMMU_CB_FAR', 'ARM_SMMU_GR0_sGFSR',
+    'a52_p279_display_iova_snapshot(0, cmd_mem->offset,',
+    'a52_p279_display_fault_snapshot(0);',
+    'a52_p279_display_fault_snapshot(1);',
+    'a52_p279_display_fault_snapshot(2);',
+    'a52_p278_display_smmu_snapshot(0);',
+    'a52_p278_display_smmu_snapshot(1);',
+    'a52_p278_display_smmu_snapshot(2);',
+]
+for marker in required_source:
+    if marker not in smmu + dsi:
+        raise SystemExit('Phase279 source marker missing: ' + marker)
+runtime = [
+    'SMMU P279 I p=%u sid=%x cb=%u i=%llx l=%u e=%llx p0=%llx p1=%llx',
+    'SMMU P279 T p=%u sid=%x r=%d ht=%llx ct=%llx hr=%x cr=%x',
+    'SMMU P279 F p=%u sid=%x cb=%u fs=%x sy=%x far=%llx cfr=%x',
+    'SMMU P279 G p=%u gf=%x g0=%x g1=%x g2=%x',
+    'SMMU P278 C p=%u sid=%x sme=%d cb=%u a=%x sc=%x m=%u f=%x',
+    'P276 H K o=%llx l=%u h=%x',
+    'P276 H R c=%x s=%x d=%x i=%x k=%x q=%x o=%x l=%x',
+]
+for marker in runtime:
+    if marker.encode() not in img:
+        raise SystemExit('Phase279 Image runtime marker missing: ' + marker)
+print('Phase279 broad display failure snapshot Image audit: PASS')
+PY
+
+python3 scripts/279_check_live_dsi_iova_translation.py --root "$ROOT"
+
+trap - EXIT
+echo 'Phase279 broad display failure cross-section build/repack: PASS'


### PR DESCRIPTION
## What changed

Phase279 adds a recorder-only cross-section around the hardware-proven DSI command DMA failure window. It preserves the Phase278 behavior and captures the exact command IOVA mapping, live/cached context-bank root state, context fault registers, and global SMMU fault syndrome before kickoff, immediately after kickoff, and at timeout.

## Why

Phase278 narrowed the visible failure to a correctly programmed DSI DMA command with no DMA completion. A broader read-only recorder can distinguish missing/wrong IOVA mappings, stale/wrong TTBR/TCR roots, context-bank faults, global stream faults, and a clean SMMU path that would move the frontier downstream toward DSI/interconnect/coherency.

## Safety

No mapping/unmapping, TLB flush, SMMU stream policy change, fault clear, ATS1PR request, or DSI control-flow change is introduced. Hardware translation is intentionally avoided; the IOVA probe uses the existing software io-pgtable walk.

## Validation

CI reconstructs the exact Phase278 candidate, applies Phase279 idempotently, asserts `.config` identity, compiles Image, repacks boot.img, checks source/runtime markers, and rejects write-side SMMU operations in the Phase279 helper.

Hardware validation remains pending.