### PR TITLE
Phase 279 CI harness

### DIFF
--- a/scripts/279_ci_build.sh
+++ b/scripts/279_ci_build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+# CI harness child branch: no kernel/source behavior change.
 ROOT="$PWD/gki/common"
 OUT="$PWD/workspace/gki-phase199-out"
 SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"


### PR DESCRIPTION
Temporary draft CI harness for the Phase279 branch. The only child-branch change is a comment in `scripts/279_ci_build.sh`; kernel source generation and recorder behavior are identical to the Phase279 base. This PR exists so the connected GitHub Actions API can expose the Phase279 build/run logs deterministically.