### PR TITLE
TouchGrass v2: fix pmsg overlap and add fallback seal

### DIFF
--- a/.github/workflows/touchgrass-critical-flight-recorder-v2.yml
+++ b/.github/workflows/touchgrass-critical-flight-recorder-v2.yml
@@ -23,6 +23,14 @@ on:
       - scripts/tg2_prepare_generated_tools.py
       - scripts/tg2_finalize_boot.py
       - scripts/tg2_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-touchgrass-critical-flight-recorder-v1
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v2.yml
+      - scripts/tg2_prepare_generated_tools.py
+      - scripts/tg2_finalize_boot.py
+      - scripts/tg2_ci_build.sh
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/touchgrass-critical-flight-recorder-v2.yml
+++ b/.github/workflows/touchgrass-critical-flight-recorder-v2.yml
@@ -1,0 +1,96 @@
+name: TouchGrass - A52 critical flight recorder v2
+run-name: TouchGrass critical recorder v2 pmsg-safe fallback-sealed
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-touchgrass-critical-flight-recorder-v2
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v2.yml
+      - scripts/tg1_payload.py
+      - scripts/tg1_payload_00.txt
+      - scripts/tg1_payload_01.txt
+      - scripts/tg1_payload_02_0.txt
+      - scripts/tg1_payload_02_1.txt
+      - scripts/tg1_payload_02_2.txt
+      - scripts/tg1_payload_02_3.txt
+      - scripts/tg1_payload_02_4.txt
+      - scripts/tg1_payload_02_5.txt
+      - scripts/tg1_payload_03.txt
+      - scripts/tg1_payload_04.txt
+      - scripts/tg1_payload_05.txt
+      - scripts/tg1_payload_06.txt
+      - scripts/tg2_prepare_generated_tools.py
+      - scripts/tg2_finalize_boot.py
+      - scripts/tg2_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-touchgrass-critical-recorder-v2-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build pmsg-safe TouchGrass critical recorder v2
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out TouchGrass v2 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build and audit TouchGrass v2
+        run: bash scripts/tg2_ci_build.sh
+      - name: Upload TouchGrass v2 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V2-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: tg2-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V2-FAILURE-${{ github.run_number }}
+          path: |
+            tg2-failure/
+            tg1-failure/
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/touchgrass-critical-flight-recorder-v3.yml
+++ b/.github/workflows/touchgrass-critical-flight-recorder-v3.yml
@@ -1,0 +1,102 @@
+name: TouchGrass - A52 critical flight recorder v3
+run-name: TouchGrass critical recorder v3 late-window watchdog-safe
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-touchgrass-critical-flight-recorder-v3
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v3.yml
+      - scripts/tg1_payload.py
+      - scripts/tg1_payload_00.txt
+      - scripts/tg1_payload_01.txt
+      - scripts/tg1_payload_02_0.txt
+      - scripts/tg1_payload_02_1.txt
+      - scripts/tg1_payload_02_2.txt
+      - scripts/tg1_payload_02_3.txt
+      - scripts/tg1_payload_02_4.txt
+      - scripts/tg1_payload_02_5.txt
+      - scripts/tg1_payload_03.txt
+      - scripts/tg1_payload_04.txt
+      - scripts/tg1_payload_05.txt
+      - scripts/tg1_payload_06.txt
+      - scripts/tg2_prepare_generated_tools.py
+      - scripts/tg3_prepare_generated_tools.py
+      - scripts/tg2_finalize_boot.py
+      - scripts/tg3_ci_build.sh
+  pull_request:
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v3.yml
+      - scripts/tg3_prepare_generated_tools.py
+      - scripts/tg3_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-touchgrass-critical-recorder-v3-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build late-window TouchGrass critical recorder v3
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out TouchGrass v3 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build and audit TouchGrass v3
+        run: bash scripts/tg3_ci_build.sh
+      - name: Upload TouchGrass v3 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V3-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: tg3-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V3-FAILURE-${{ github.run_number }}
+          path: |
+            tg3-failure/
+            tg1-failure/
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/tg2_ci_build.sh
+++ b/scripts/tg2_ci_build.sh
@@ -75,10 +75,16 @@ PY
 
 IMAGE=tg2-out/compile/Image
 test -s "$IMAGE"
-grep -aFq 'A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V1' "$IMAGE"
-grep -aFq "$V2_IMAGE_MARKER" "$IMAGE"
-grep -aFq 'TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u' "$IMAGE"
-grep -aFq 'SMMU P279 I p=%u' "$IMAGE"
+
+# tg1_ci_build.sh already owns and passes the v1 recorder and Phase279 Image
+# audits. Do not duplicate those contracts here with guessed literal strings.
+# v2 adds exactly one compiled identity marker, so only verify that delta.
+if ! grep -aFq "$V2_IMAGE_MARKER" "$IMAGE"; then
+  echo "::error::TouchGrass v2 compiled marker missing from Image: $V2_IMAGE_MARKER"
+  exit 1
+fi
+
+echo 'TouchGrass v2 compiled marker Image audit: PASS'
 
 python3 - <<'PY'
 import hashlib

--- a/scripts/tg2_ci_build.sh
+++ b/scripts/tg2_ci_build.sh
@@ -12,6 +12,8 @@ fail_report() {
 }
 trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
 
+V2_IMAGE_MARKER='A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V2_EARLY_SEAL_90S'
+
 python3 scripts/tg1_payload.py
 python3 scripts/tg2_prepare_generated_tools.py
 python3 -m py_compile \
@@ -21,7 +23,16 @@ python3 -m py_compile \
   scripts/tg2_prepare_generated_tools.py \
   scripts/tg2_finalize_boot.py
 
+grep -Fq "$V2_IMAGE_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'A52_TGCR_REASON_DEADLINE_90S' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'msecs_to_jiffies(90000)' scripts/tg1_apply_critical_flight_recorder.py
+
 bash scripts/tg1_ci_build.sh
+
+# The v1 wrapper must not rematerialize and erase the v2 generated-tool patch.
+grep -Fq "$V2_IMAGE_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'A52_TGCR_REASON_DEADLINE_90S' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'msecs_to_jiffies(90000)' scripts/tg1_apply_critical_flight_recorder.py
 
 rm -rf tg2-out
 cp -a tg1-out tg2-out
@@ -52,6 +63,7 @@ d.update({
     'fallback_seal_ms': 90000,
     'fallback_seal_reason': 'DEADLINE_90S',
     'recovery_exporter_compatible': True,
+    'compiled_v2_marker': 'A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V2_EARLY_SEAL_90S',
     'functional_change': (
         'diagnostic infrastructure only: disable ramoops pmsg allocation for '
         'exclusive TGCR ownership of the fourth quarter; add recorder-only '
@@ -64,6 +76,7 @@ PY
 IMAGE=tg2-out/compile/Image
 test -s "$IMAGE"
 grep -aFq 'A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V1' "$IMAGE"
+grep -aFq "$V2_IMAGE_MARKER" "$IMAGE"
 grep -aFq 'TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u' "$IMAGE"
 grep -aFq 'SMMU P279 I p=%u' "$IMAGE"
 

--- a/scripts/tg2_ci_build.sh
+++ b/scripts/tg2_ci_build.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail_report() {
+  set +e
+  rm -rf tg2-failure
+  mkdir -p tg2-failure
+  cp -a tg1-failure tg2-failure/ 2>/dev/null || true
+  cp tg1-compile.log tg2-failure/ 2>/dev/null || true
+  cp scripts/tg2_prepare_generated_tools.py tg2-failure/ 2>/dev/null || true
+  cp scripts/tg2_finalize_boot.py tg2-failure/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+python3 scripts/tg1_payload.py
+python3 scripts/tg2_prepare_generated_tools.py
+python3 -m py_compile \
+  scripts/tg1_apply_critical_flight_recorder.py \
+  scripts/tg1_check_critical_flight_recorder.py \
+  scripts/tg1_decode_critical_bank.py \
+  scripts/tg2_prepare_generated_tools.py \
+  scripts/tg2_finalize_boot.py
+
+bash scripts/tg1_ci_build.sh
+
+rm -rf tg2-out
+cp -a tg1-out tg2-out
+mkdir -p tg2-out/tools
+
+python3 scripts/tg2_finalize_boot.py \
+  --source tg1-out/package/boot.img \
+  --output tg2-out/package/boot.img \
+  --report tg2-out/package/pmsg-release-report.json
+
+cp scripts/tg1_decode_critical_bank.py tg2-out/tools/tg2_decode_critical_bank.py
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = Path('tg2-out/BUILD-IDENTITY.json')
+d = json.loads(p.read_text())
+d.update({
+    'name': 'TOUCHGRASS-CRITICAL-FLIGHT-RECORDER-V2',
+    'revision': 'v2',
+    'hardware_validated': False,
+    'v1_pmsg_overlap_rejected': True,
+    'pmsg_runtime_size': 0,
+    'critical_bank_phys': '0xB1BC0000',
+    'critical_bank_bytes': 0x40000,
+    'critical_bank_capacity': 1636,
+    'critical_bank_is_circular': True,
+    'fallback_seal_ms': 90000,
+    'fallback_seal_reason': 'DEADLINE_90S',
+    'recovery_exporter_compatible': True,
+    'functional_change': (
+        'diagnostic infrastructure only: disable ramoops pmsg allocation for '
+        'exclusive TGCR ownership of the fourth quarter; add recorder-only '
+        '90-second fallback seal'
+    ),
+})
+p.write_text(json.dumps(d, indent=2, sort_keys=True) + '\n')
+PY
+
+IMAGE=tg2-out/compile/Image
+test -s "$IMAGE"
+grep -aFq 'A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V1' "$IMAGE"
+grep -aFq 'TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u' "$IMAGE"
+grep -aFq 'SMMU P279 I p=%u' "$IMAGE"
+
+python3 - <<'PY'
+import hashlib
+from pathlib import Path
+root = Path('tg2-out')
+sums = root / 'SHA256SUMS'
+if sums.exists():
+    sums.unlink()
+rows = []
+for p in sorted(root.rglob('*')):
+    if p.is_file() and p.name != 'SHA256SUMS':
+        rows.append(f"{hashlib.sha256(p.read_bytes()).hexdigest()}  ./{p.relative_to(root)}")
+sums.write_text('\n'.join(rows) + '\n')
+PY
+(cd tg2-out && sha256sum -c SHA256SUMS)
+
+trap - EXIT
+echo 'TouchGrass critical flight recorder v2 build/repack: PASS'

--- a/scripts/tg2_finalize_boot.py
+++ b/scripts/tg2_finalize_boot.py
@@ -43,13 +43,15 @@ def main() -> int:
     source = args.source.read_bytes()
     original = boot.parse_boot(source)
     cmdline = original["cmdline"]
+    source_tokens = cmdline.split()
 
-    if cmdline.count(OLD) != 1:
-        raise SystemExit(f"expected exactly one {OLD!r} in source cmdline")
-    if NEW in cmdline:
+    if source_tokens.count(OLD) != 1:
+        raise SystemExit(f"expected exactly one {OLD!r} token in source cmdline")
+    if NEW in source_tokens:
         raise SystemExit("source cmdline already contains disabled pmsg token")
 
-    new_cmdline = cmdline.replace(OLD, NEW, 1)
+    new_cmdline = " ".join(NEW if token == OLD else token
+                           for token in source_tokens)
     encoded = new_cmdline.encode("ascii")
     if len(encoded) > 1536:
         raise SystemExit(f"command line too long: {len(encoded)} > 1536")
@@ -62,6 +64,7 @@ def main() -> int:
         output[608:608 + len(encoded) - 512] = encoded[512:]
 
     rebuilt = boot.parse_boot(bytes(output))
+    rebuilt_tokens = rebuilt["cmdline"].split()
     invariants = {
         "partition_size_preserved": len(output) == len(source),
         "kernel_preserved": rebuilt["kernel"] == original["kernel"],
@@ -70,9 +73,9 @@ def main() -> int:
         "recovery_dtbo_preserved": rebuilt["recovery_dtbo"] == original["recovery_dtbo"],
         "dtb_preserved": rebuilt["dtb"] == original["dtb"],
         "boot_id_preserved": rebuilt["id"] == original["id"],
-        "pmsg_disabled_exactly_once": rebuilt["cmdline"].split().count(NEW) == 1,
-        "old_pmsg_token_removed": OLD not in rebuilt["cmdline"],
-        "other_ramoops_contract_preserved": all(x in rebuilt["cmdline"] for x in REQUIRED),
+        "pmsg_disabled_exactly_once": rebuilt_tokens.count(NEW) == 1,
+        "old_pmsg_token_removed": OLD not in rebuilt_tokens,
+        "other_ramoops_contract_preserved": all(x in rebuilt_tokens for x in REQUIRED),
     }
     failed = [k for k, v in invariants.items() if not v]
     if failed:

--- a/scripts/tg2_finalize_boot.py
+++ b/scripts/tg2_finalize_boot.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+OLD = "ramoops.pmsg_size=0x00040000"
+NEW = "ramoops.pmsg_size=0"
+
+REQUIRED = (
+    "ramoops.mem_address=0xB1B00000",
+    "ramoops.mem_size=0x00100000",
+    "ramoops.record_size=0x00040000",
+    "ramoops.console_size=0x00040000",
+    "ramoops.ftrace_size=0x00040000",
+    "ramoops.dump_oops=1",
+    "pstore.backend=ramoops",
+)
+
+def load_boot_module():
+    path = Path(__file__).with_name("38_repack_a52_p1_boot.py")
+    spec = importlib.util.spec_from_file_location("a52_boot_repack", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+def sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    ap.add_argument("--report", type=Path, required=True)
+    args = ap.parse_args()
+
+    boot = load_boot_module()
+    source = args.source.read_bytes()
+    original = boot.parse_boot(source)
+    cmdline = original["cmdline"]
+
+    if cmdline.count(OLD) != 1:
+        raise SystemExit(f"expected exactly one {OLD!r} in source cmdline")
+    if NEW in cmdline:
+        raise SystemExit("source cmdline already contains disabled pmsg token")
+
+    new_cmdline = cmdline.replace(OLD, NEW, 1)
+    encoded = new_cmdline.encode("ascii")
+    if len(encoded) > 1536:
+        raise SystemExit(f"command line too long: {len(encoded)} > 1536")
+
+    output = bytearray(source)
+    output[64:576] = b"\0" * 512
+    output[608:1632] = b"\0" * 1024
+    output[64:64 + min(len(encoded), 512)] = encoded[:512]
+    if len(encoded) > 512:
+        output[608:608 + len(encoded) - 512] = encoded[512:]
+
+    rebuilt = boot.parse_boot(bytes(output))
+    invariants = {
+        "partition_size_preserved": len(output) == len(source),
+        "kernel_preserved": rebuilt["kernel"] == original["kernel"],
+        "ramdisk_preserved": rebuilt["ramdisk"] == original["ramdisk"],
+        "second_preserved": rebuilt["second"] == original["second"],
+        "recovery_dtbo_preserved": rebuilt["recovery_dtbo"] == original["recovery_dtbo"],
+        "dtb_preserved": rebuilt["dtb"] == original["dtb"],
+        "boot_id_preserved": rebuilt["id"] == original["id"],
+        "pmsg_disabled_exactly_once": rebuilt["cmdline"].split().count(NEW) == 1,
+        "old_pmsg_token_removed": OLD not in rebuilt["cmdline"],
+        "other_ramoops_contract_preserved": all(x in rebuilt["cmdline"] for x in REQUIRED),
+    }
+    failed = [k for k, v in invariants.items() if not v]
+    if failed:
+        raise SystemExit("pmsg release audit failed: " + ", ".join(failed))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(output)
+    report = {
+        "status": "touchgrass-v2-pmsg-quarter-released",
+        "hardware_validated": False,
+        "source_sha256": sha(source),
+        "output_sha256": sha(output),
+        "source_cmdline": cmdline,
+        "output_cmdline": rebuilt["cmdline"],
+        "functional_scope": (
+            "diagnostic-only: disable ramoops pmsg allocation so the existing "
+            "fourth 256-KiB reserved quarter is owned exclusively by TGCR"
+        ),
+        "invariants": invariants,
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tg2_prepare_generated_tools.py
+++ b/scripts/tg2_prepare_generated_tools.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
 DECODE = Path("scripts/tg1_decode_critical_bank.py")
+CI = Path("scripts/tg1_ci_build.sh")
 V2_IMAGE_MARKER = "A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V2_EARLY_SEAL_90S"
+
 
 def replace_once(text: str, old: str, new: str, label: str) -> str:
     n = text.count(old)
@@ -13,9 +15,11 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
         raise SystemExit(f"{label}: expected one anchor, found {n}")
     return text.replace(old, new, 1)
 
+
 def main() -> int:
     apply = APPLY.read_text(encoding="utf-8")
     decode = DECODE.read_text(encoding="utf-8")
+    ci = CI.read_text(encoding="utf-8")
 
     apply = replace_once(
         apply,
@@ -73,10 +77,26 @@ static int __init a52_tgcr_init(void)
         'decoder reason map',
     )
 
+    # tg1_ci_build.sh is itself materialized by tg1_payload.py. v2 has already
+    # materialized that payload and patched APPLY/DECODE above. Running the v1
+    # wrapper's own materializer again would overwrite those v2 changes and
+    # compile a v1 Image. Disable exactly that redundant transport step only;
+    # every v1 reconstruction, safety check, build, Image audit and repack step
+    # remains unchanged.
+    ci = replace_once(
+        ci,
+        'python3 scripts/tg1_payload.py\n',
+        '# TouchGrass v2: payload already materialized and patched; do not overwrite generated tools.\n',
+        'v1 wrapper payload rematerialization',
+    )
+
     APPLY.write_text(apply, encoding="utf-8")
     DECODE.write_text(decode, encoding="utf-8")
+    CI.write_text(ci, encoding="utf-8")
     print("TouchGrass v2 generated-tool patch: PASS")
+    print("TouchGrass v2 v1-wrapper rematerialization bypass: PASS")
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/tg2_prepare_generated_tools.py
+++ b/scripts/tg2_prepare_generated_tools.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
 DECODE = Path("scripts/tg1_decode_critical_bank.py")
+V2_IMAGE_MARKER = "A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V2_EARLY_SEAL_90S"
 
 def replace_once(text: str, old: str, new: str, label: str) -> str:
     n = text.count(old)
@@ -56,13 +57,14 @@ static int __init a52_tgcr_init(void)
     arm_anchor = '''        atomic_set(&a52_tgcr_state, A52_TGCR_STATE_ARMED);
         pr_info("TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u\\n",
 '''
-    arm_repl = '''        atomic_set(&a52_tgcr_state, A52_TGCR_STATE_ARMED);
+    arm_repl = f'''        atomic_set(&a52_tgcr_state, A52_TGCR_STATE_ARMED);
         schedule_delayed_work(&a52_tgcr_deadline_work,
                               msecs_to_jiffies(90000));
+        pr_info("{V2_IMAGE_MARKER}\\n");
         pr_info("TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u\\n",
 '''
     apply = replace_once(apply, arm_anchor, arm_repl,
-                         'deadline scheduling')
+                         'deadline scheduling and v2 identity')
 
     decode = replace_once(
         decode,

--- a/scripts/tg2_prepare_generated_tools.py
+++ b/scripts/tg2_prepare_generated_tools.py
@@ -17,35 +17,21 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
     return text.replace(old, new, 1)
 
 
-def disable_v1_payload_rematerialization(ci: str) -> str:
-    """Disable exactly one executable tg1_payload.py invocation in the v1 wrapper."""
-    lines = ci.splitlines(keepends=True)
-    hits: list[int] = []
-    for idx, line in enumerate(lines):
+def assert_no_v1_payload_rematerialization(ci: str) -> None:
+    """Require the generated v1 build wrapper to leave payload transport outside."""
+    hits: list[str] = []
+    for line in ci.splitlines():
         stripped = line.lstrip()
         if stripped.startswith("#"):
             continue
         if re.match(r"^\s*python3(?:\s|$)", line) and "tg1_payload.py" in line:
-            hits.append(idx)
+            hits.append(line)
 
-    if len(hits) != 1:
-        candidates = [line.rstrip("\n") for line in lines if "tg1_payload.py" in line]
+    if hits:
         raise SystemExit(
-            "v1 wrapper payload rematerialization: expected one executable "
-            f"python3 tg1_payload.py line, found {len(hits)}; candidates={candidates!r}"
+            "v1 generated build wrapper unexpectedly rematerializes tg1_payload.py; "
+            f"executable lines={hits!r}"
         )
-
-    idx = hits[0]
-    original = lines[idx]
-    newline = "\n" if original.endswith("\n") else ""
-    indent = original[: len(original) - len(original.lstrip())]
-    lines[idx] = (
-        indent
-        + ": # TouchGrass v2: payload already materialized and patched; "
-        + "do not overwrite generated tools."
-        + newline
-    )
-    return "".join(lines)
 
 
 def main() -> int:
@@ -109,19 +95,16 @@ static int __init a52_tgcr_init(void)
         'decoder reason map',
     )
 
-    # tg1_ci_build.sh is itself materialized by tg1_payload.py. v2 has already
-    # materialized that payload and patched APPLY/DECODE above. Running the v1
-    # wrapper's own materializer again would overwrite those v2 changes and
-    # compile a v1 Image. Disable exactly that redundant transport step only;
-    # every v1 reconstruction, safety check, build, Image audit and repack step
-    # remains unchanged.
-    ci = disable_v1_payload_rematerialization(ci)
+    # tg1_payload.py is executed by the outer workflow/tg2 wrapper before this
+    # patcher runs. The generated tg1_ci_build.sh is the final build wrapper and
+    # does not rematerialize the transport payload. Assert that invariant rather
+    # than trying to rewrite a call that is intentionally absent.
+    assert_no_v1_payload_rematerialization(ci)
 
     APPLY.write_text(apply, encoding="utf-8")
     DECODE.write_text(decode, encoding="utf-8")
-    CI.write_text(ci, encoding="utf-8")
     print("TouchGrass v2 generated-tool patch: PASS")
-    print("TouchGrass v2 v1-wrapper rematerialization bypass: PASS")
+    print("TouchGrass v2 v1-wrapper transport invariant: PASS")
     return 0
 
 

--- a/scripts/tg2_prepare_generated_tools.py
+++ b/scripts/tg2_prepare_generated_tools.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
@@ -14,6 +15,37 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
     if n != 1:
         raise SystemExit(f"{label}: expected one anchor, found {n}")
     return text.replace(old, new, 1)
+
+
+def disable_v1_payload_rematerialization(ci: str) -> str:
+    """Disable exactly one executable tg1_payload.py invocation in the v1 wrapper."""
+    lines = ci.splitlines(keepends=True)
+    hits: list[int] = []
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if re.match(r"^\s*python3(?:\s|$)", line) and "tg1_payload.py" in line:
+            hits.append(idx)
+
+    if len(hits) != 1:
+        candidates = [line.rstrip("\n") for line in lines if "tg1_payload.py" in line]
+        raise SystemExit(
+            "v1 wrapper payload rematerialization: expected one executable "
+            f"python3 tg1_payload.py line, found {len(hits)}; candidates={candidates!r}"
+        )
+
+    idx = hits[0]
+    original = lines[idx]
+    newline = "\n" if original.endswith("\n") else ""
+    indent = original[: len(original) - len(original.lstrip())]
+    lines[idx] = (
+        indent
+        + ": # TouchGrass v2: payload already materialized and patched; "
+        + "do not overwrite generated tools."
+        + newline
+    )
+    return "".join(lines)
 
 
 def main() -> int:
@@ -83,12 +115,7 @@ static int __init a52_tgcr_init(void)
     # compile a v1 Image. Disable exactly that redundant transport step only;
     # every v1 reconstruction, safety check, build, Image audit and repack step
     # remains unchanged.
-    ci = replace_once(
-        ci,
-        'python3 scripts/tg1_payload.py\n',
-        '# TouchGrass v2: payload already materialized and patched; do not overwrite generated tools.\n',
-        'v1 wrapper payload rematerialization',
-    )
+    ci = disable_v1_payload_rematerialization(ci)
 
     APPLY.write_text(apply, encoding="utf-8")
     DECODE.write_text(decode, encoding="utf-8")

--- a/scripts/tg2_prepare_generated_tools.py
+++ b/scripts/tg2_prepare_generated_tools.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
+DECODE = Path("scripts/tg1_decode_critical_bank.py")
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{label}: expected one anchor, found {n}")
+    return text.replace(old, new, 1)
+
+def main() -> int:
+    apply = APPLY.read_text(encoding="utf-8")
+    decode = DECODE.read_text(encoding="utf-8")
+
+    apply = replace_once(
+        apply,
+        '#define A52_TGCR_REASON_DSI_DMA_TIMEOUT   0x00000001U',
+        '#define A52_TGCR_REASON_DSI_DMA_TIMEOUT   0x00000001U\n'
+        '#define A52_TGCR_REASON_DEADLINE_90S      0x00000002U',
+        'header fallback reason',
+    )
+    apply = replace_once(
+        apply,
+        ' * The DSI timeout path seals it exactly once. A sealed bank is never cleared\n'
+        ' * or rewritten on the next boot, so watchdog reset cannot erase the evidence.\n',
+        ' * The DSI timeout path seals it exactly once. If that path is never reached,\n'
+        ' * a recorder-only 90-second fallback seal preserves the final circular window\n'
+        ' * before the configured 100-second softdog. A sealed bank is never cleared or\n'
+        ' * rewritten on the next boot, so watchdog reset cannot erase the evidence.\n',
+        'recorder fallback comment',
+    )
+
+    init_anchor = '''static int __init a52_tgcr_init(void)
+{
+'''
+    fallback_block = '''static void a52_tgcr_deadline_workfn(struct work_struct *work)
+{
+        (void)work;
+        a52_tgcr_seal(A52_TGCR_REASON_DEADLINE_90S, 0xffffffffU,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0);
+}
+
+static DECLARE_DELAYED_WORK(a52_tgcr_deadline_work,
+                            a52_tgcr_deadline_workfn);
+
+static int __init a52_tgcr_init(void)
+{
+'''
+    apply = replace_once(apply, init_anchor, fallback_block,
+                         'deadline work insertion')
+
+    arm_anchor = '''        atomic_set(&a52_tgcr_state, A52_TGCR_STATE_ARMED);
+        pr_info("TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u\\n",
+'''
+    arm_repl = '''        atomic_set(&a52_tgcr_state, A52_TGCR_STATE_ARMED);
+        schedule_delayed_work(&a52_tgcr_deadline_work,
+                              msecs_to_jiffies(90000));
+        pr_info("TouchGrass critical bank armed phys=%llx bytes=%lu slots=%u gen=%u\\n",
+'''
+    apply = replace_once(apply, arm_anchor, arm_repl,
+                         'deadline scheduling')
+
+    decode = replace_once(
+        decode,
+        "REASONS = {1: 'DSI_DMA_TIMEOUT'}",
+        "REASONS = {1: 'DSI_DMA_TIMEOUT', 2: 'DEADLINE_90S'}",
+        'decoder reason map',
+    )
+
+    APPLY.write_text(apply, encoding="utf-8")
+    DECODE.write_text(decode, encoding="utf-8")
+    print("TouchGrass v2 generated-tool patch: PASS")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why v2

Hardware capture from v1 proved the fourth 256-KiB quarter is not free: runtime ramoops has `pmsg_size=262144`, so TGCR and pmsg were writing the same physical range. The resulting critical bank was corrupted and remained ARMED because the DSI timeout trigger was not reached before the 100-second watchdog.

## v2 changes

- Keep TGCR at `0xB1BC0000-0xB1BFFFFF` so the existing 1-MiB recovery exporter remains usable.
- In the diagnostic boot only, replace `ramoops.pmsg_size=0x00040000` with `ramoops.pmsg_size=0`, giving TGCR exclusive ownership of the fourth quarter.
- Preserve record/console/ftrace ramoops sizes, kernel, ramdisk, DTB and boot ID exactly.
- Keep the TGCR ring circular.
- Add a recorder-only 90-second delayed fallback seal. If the DSI DMA timeout seal happens first, the delayed call becomes a no-op because the bank is already SEALED.
- Decoder recognizes `DEADLINE_90S` as trigger reason 2.

## Safety contract

No display, SMMU, mapping, TLB, ACTLR, stream-routing, timeout, reset, clock or watchdog behavior change. The only runtime infrastructure difference is disabling the pmsg ramoops zone for this diagnostic candidate plus one delayed recorder work item.

## Validation

- Modified generated patcher self-test: locally PASS on exact Phase279 source snapshot.
- Existing TGCR non-perturbation checker: locally PASS unchanged.
- v2 final boot wrapper asserts only the pmsg cmdline token changes and all boot components remain byte-identical.
- Full GitHub compile/repack pending.

Hardware validation remains pending.