### PR TITLE
TouchGrass v3: preserve late boot window for critical recorder

### DIFF
--- a/.github/workflows/touchgrass-critical-flight-recorder-v3-secure.yml
+++ b/.github/workflows/touchgrass-critical-flight-recorder-v3-secure.yml
@@ -1,0 +1,103 @@
+name: TouchGrass - A52 critical flight recorder v3 secure watchdog
+run-name: TouchGrass critical recorder v3 secure+local watchdog-off
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-touchgrass-critical-flight-recorder-v3
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v3-secure.yml
+      - scripts/tg1_payload.py
+      - scripts/tg1_payload_00.txt
+      - scripts/tg1_payload_01.txt
+      - scripts/tg1_payload_02_0.txt
+      - scripts/tg1_payload_02_1.txt
+      - scripts/tg1_payload_02_2.txt
+      - scripts/tg1_payload_02_3.txt
+      - scripts/tg1_payload_02_4.txt
+      - scripts/tg1_payload_02_5.txt
+      - scripts/tg1_payload_03.txt
+      - scripts/tg1_payload_04.txt
+      - scripts/tg1_payload_05.txt
+      - scripts/tg1_payload_06.txt
+      - scripts/tg2_prepare_generated_tools.py
+      - scripts/tg3_prepare_generated_tools.py
+      - scripts/tg3_secure_wdt_prepare.py
+      - scripts/tg2_finalize_boot.py
+      - scripts/tg3_secure_ci_build.sh
+  pull_request:
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v3-secure.yml
+      - scripts/tg3_secure_wdt_prepare.py
+      - scripts/tg3_secure_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-touchgrass-critical-recorder-v3-secure-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build secure-watchdog TouchGrass critical recorder v3
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out TouchGrass v3 secure branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build and audit secure-watchdog TouchGrass v3
+        run: bash scripts/tg3_secure_ci_build.sh
+      - name: Upload secure-watchdog TouchGrass v3 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V3-SECURE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: tg3s-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload secure-watchdog failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V3-SECURE-FAILURE-${{ github.run_number }}
+          path: |
+            tg3s-failure/
+            tg1-failure/
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/touchgrass-critical-flight-recorder-v3.yml
+++ b/.github/workflows/touchgrass-critical-flight-recorder-v3.yml
@@ -1,0 +1,102 @@
+name: TouchGrass - A52 critical flight recorder v3
+run-name: TouchGrass critical recorder v3 late-window watchdog-safe
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-touchgrass-critical-flight-recorder-v3
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v3.yml
+      - scripts/tg1_payload.py
+      - scripts/tg1_payload_00.txt
+      - scripts/tg1_payload_01.txt
+      - scripts/tg1_payload_02_0.txt
+      - scripts/tg1_payload_02_1.txt
+      - scripts/tg1_payload_02_2.txt
+      - scripts/tg1_payload_02_3.txt
+      - scripts/tg1_payload_02_4.txt
+      - scripts/tg1_payload_02_5.txt
+      - scripts/tg1_payload_03.txt
+      - scripts/tg1_payload_04.txt
+      - scripts/tg1_payload_05.txt
+      - scripts/tg1_payload_06.txt
+      - scripts/tg2_prepare_generated_tools.py
+      - scripts/tg3_prepare_generated_tools.py
+      - scripts/tg2_finalize_boot.py
+      - scripts/tg3_ci_build.sh
+  pull_request:
+    paths:
+      - .github/workflows/touchgrass-critical-flight-recorder-v3.yml
+      - scripts/tg3_prepare_generated_tools.py
+      - scripts/tg3_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-touchgrass-critical-recorder-v3-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build late-window TouchGrass critical recorder v3
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out TouchGrass v3 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build and audit TouchGrass v3
+        run: bash scripts/tg3_ci_build.sh
+      - name: Upload TouchGrass v3 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V3-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: tg3-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-TOUCHGRASS-CRITICAL-RECORDER-V3-FAILURE-${{ github.run_number }}
+          path: |
+            tg3-failure/
+            tg1-failure/
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/tg3_ci_build.sh
+++ b/scripts/tg3_ci_build.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail_report() {
+  set +e
+  rm -rf tg3-failure
+  mkdir -p tg3-failure
+  cp -a tg1-failure tg3-failure/ 2>/dev/null || true
+  cp tg1-compile.log tg3-failure/ 2>/dev/null || true
+  cp scripts/tg2_prepare_generated_tools.py tg3-failure/ 2>/dev/null || true
+  cp scripts/tg3_prepare_generated_tools.py tg3-failure/ 2>/dev/null || true
+  cp scripts/tg2_finalize_boot.py tg3-failure/ 2>/dev/null || true
+  cp scripts/tg1_apply_critical_flight_recorder.py tg3-failure/ 2>/dev/null || true
+  cp scripts/tg1_decode_critical_bank.py tg3-failure/ 2>/dev/null || true
+  cp gki/common/drivers/watchdog/qcom-wdt.c tg3-failure/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+V3_IMAGE_MARKER='A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S'
+WDT_MARKER='A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF'
+WDT_LOG='A52 TouchGrass v3: QCOM watchdog disabled for late recorder'
+
+python3 scripts/tg1_payload.py
+python3 scripts/tg2_prepare_generated_tools.py
+python3 scripts/tg3_prepare_generated_tools.py
+python3 -m py_compile \
+  scripts/tg1_apply_critical_flight_recorder.py \
+  scripts/tg1_check_critical_flight_recorder.py \
+  scripts/tg1_decode_critical_bank.py \
+  scripts/tg2_prepare_generated_tools.py \
+  scripts/tg3_prepare_generated_tools.py \
+  scripts/tg2_finalize_boot.py
+
+grep -Fq "$V3_IMAGE_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "$WDT_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'A52_TGCR_EVT_SEAL' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'A52_TGCR_REASON_DEADLINE_210S' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'msecs_to_jiffies(210000)' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "0x0002: 'SEAL'" scripts/tg1_decode_critical_bank.py
+grep -Fq "3: 'DEADLINE_210S'" scripts/tg1_decode_critical_bank.py
+
+bash scripts/tg1_ci_build.sh
+
+# The v1 wrapper must leave the v2/v3 generated-tool overlays intact.
+grep -Fq "$V3_IMAGE_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "$WDT_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'msecs_to_jiffies(210000)' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "$WDT_MARKER" gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq 'qcom_wdt_stop(&wdt->wdd)' gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq 'do not register/re-arm' gki/common/drivers/watchdog/qcom-wdt.c
+
+rm -rf tg3-out
+cp -a tg1-out tg3-out
+mkdir -p tg3-out/tools tg3-out/source
+
+python3 scripts/tg2_finalize_boot.py \
+  --source tg1-out/package/boot.img \
+  --output tg3-out/package/boot.img \
+  --report tg3-out/package/pmsg-release-report.json
+
+cp scripts/tg1_decode_critical_bank.py tg3-out/tools/tg3_decode_critical_bank.py
+cp gki/common/drivers/watchdog/qcom-wdt.c tg3-out/source/qcom-wdt.c
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = Path('tg3-out/BUILD-IDENTITY.json')
+d = json.loads(p.read_text())
+d.update({
+    'name': 'TOUCHGRASS-CRITICAL-FLIGHT-RECORDER-V3',
+    'revision': 'v3',
+    'hardware_validated': False,
+    'v2_hardware_result': 'did-not-reach-late-android-window',
+    'v2_last_crc_valid_r48_ms': 106140.059,
+    'pmsg_runtime_size': 0,
+    'critical_bank_phys': '0xB1BC0000',
+    'critical_bank_bytes': 0x40000,
+    'critical_bank_capacity': 1636,
+    'critical_bank_is_circular': True,
+    'fallback_seal_ms': 210000,
+    'fallback_seal_reason': 'DEADLINE_210S',
+    'fallback_seal_event': 'SEAL',
+    'qcom_watchdog_handoff': 'diagnostic-stop-and-no-register',
+    'recovery_exporter_compatible': True,
+    'compiled_v3_marker': 'A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S',
+    'functional_change': (
+        'diagnostic infrastructure only: keep ramoops pmsg disabled for exclusive '
+        'TGCR ownership; restore the previously proven Phase261 qcom watchdog stop '
+        'so the boot can reach the late composer window; type fallback seals as SEAL; '
+        'move recorder fallback seal to 210 seconds'
+    ),
+})
+p.write_text(json.dumps(d, indent=2, sort_keys=True) + '\n')
+PY
+
+IMAGE=tg3-out/compile/Image
+test -s "$IMAGE"
+grep -aFq "$V3_IMAGE_MARKER" "$IMAGE" || {
+  echo "TouchGrass v3 audit: compiled v3 marker missing from Image" >&2
+  exit 1
+}
+grep -aFq "$WDT_LOG" "$IMAGE" || {
+  echo "TouchGrass v3 audit: watchdog-stop marker missing from Image" >&2
+  exit 1
+}
+grep -aFq 'F261 c4' "$IMAGE" || {
+  echo "TouchGrass v3 audit: cumulative Phase261 trace missing from Image" >&2
+  exit 1
+}
+
+grep -Fxq 'CONFIG_CHR_DEV_SG=y' tg3-out/config/final.config
+grep -Fxq 'CONFIG_QCOM_WDT=y' tg3-out/config/final.config
+
+python3 - <<'PY'
+import hashlib
+from pathlib import Path
+root = Path('tg3-out')
+sums = root / 'SHA256SUMS'
+if sums.exists():
+    sums.unlink()
+rows = []
+for p in sorted(root.rglob('*')):
+    if p.is_file() and p.name != 'SHA256SUMS':
+        rows.append(f"{hashlib.sha256(p.read_bytes()).hexdigest()}  ./{p.relative_to(root)}")
+sums.write_text('\n'.join(rows) + '\n')
+PY
+(cd tg3-out && sha256sum -c SHA256SUMS)
+
+trap - EXIT
+echo 'TouchGrass critical flight recorder v3 build/repack: PASS'

--- a/scripts/tg3_ci_build.sh
+++ b/scripts/tg3_ci_build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+# v3 PR workflow synchronization trigger
 
 fail_report() {
   set +e

--- a/scripts/tg3_prepare_generated_tools.py
+++ b/scripts/tg3_prepare_generated_tools.py
@@ -157,6 +157,15 @@ def main() -> int:
         expected_loop,
         'for rel in [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL]:',
     )
+    apply = replace_once(
+        apply,
+        '            if text.count(MARKER) != 1:\n'
+        '                raise RuntimeError(f"self-test marker count for {rel}")',
+        f'            expected_marker = "{WDT_MARKER}" if rel == WDT_REL else MARKER\n'
+        '            if text.count(expected_marker) != 1:\n'
+        '                raise RuntimeError(f"self-test marker count for {rel}: {expected_marker}")',
+        'self-test per-file marker',
+    )
 
     decode = replace_once(
         decode,

--- a/scripts/tg3_prepare_generated_tools.py
+++ b/scripts/tg3_prepare_generated_tools.py
@@ -73,9 +73,10 @@ def main() -> int:
         'fallback comment',
     )
 
-    # Reapply the proven Phase261 diagnostic watchdog handoff to the final
-    # reconstructed Phase279 tree. Later cumulative reconstruction retained the
-    # F261 trace points but no longer retained the qcom-wdt stop itself.
+    # Tag the watchdog handoff already present in the reconstructed Phase279
+    # tree as the v3 diagnostic contract. Phase279 already stops qcom-wdt and
+    # returns before watchdog registration, so v3 must preserve that proven
+    # disarm instead of anchoring on the pre-Phase279 probe layout.
     apply = replace_once(
         apply,
         'SMMU_REL = Path("drivers/iommu/arm/arm-smmu/arm-smmu.c")',
@@ -84,7 +85,45 @@ def main() -> int:
         'watchdog path',
     )
 
-    watchdog_fn = f'''\n\ndef patch_watchdog(text: str) -> str:\n    marker = "{WDT_MARKER}"\n    if marker in text:\n        return text\n    old = (\n        "\\tif (running) {{\\n"\n        "\\t\\tqcom_wdt_start(&wdt->wdd);\\n"\n        "\\t\\tset_bit(WDOG_HW_RUNNING, &wdt->wdd.status);\\n"\n        "\\t}}\\n\\n"\n        "\\tret = devm_watchdog_register_device(dev, &wdt->wdd);\\n"\n    )\n    new = (\n        f"\\t/* {{marker}}: diagnostic boot only */\\n"\n        "\\tif (running)\\n"\n        "\\t\\tqcom_wdt_stop(&wdt->wdd);\\n"\n        "\\tdev_warn(dev, \\\"A52 TouchGrass v3: QCOM watchdog disabled for late recorder\\\\n\\\");\\n"\n        "\\tret = 0; /* diagnostic only: do not register/re-arm */\\n"\n    )\n    return replace_once(text, old, new, "watchdog handoff")\n'''
+    watchdog_fn = f'''\n\ndef patch_watchdog(text: str) -> str:
+    marker = "{WDT_MARKER}"
+    if marker in text:
+        return text
+    old = (
+        "\\t\\t/* A52_FAILURE_WINDOW_WATCHDOG_DISARM */\\n"
+        "\\t\\t{{\\n"
+        "\\t\\t\\tu32 a52_wdt_before;\\n"
+        "\\t\\t\\tu32 a52_wdt_after;\\n\\n"
+        "\\t\\t\\ta52_wdt_before = readl(wdt_addr(wdt, WDT_STS));\\n"
+        "\\t\\t\\tqcom_wdt_stop(&wdt->wdd);\\n"
+        "\\t\\t\\ta52_wdt_after = readl(wdt_addr(wdt, WDT_STS));\\n"
+        "\\t\\t\\ta52_ackfr_record(\\\"WDT disarm before=%u after=%u\\\",\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_before & 1),\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n"
+        "\\t\\t\\tdev_warn(&pdev->dev,\\n"
+        "\\t\\t\\t\\t \\\"A52 diagnostic: watchdog disabled for manual recovery\\\\n\\\");\\n"
+        "\\t\\t\\treturn 0;\\n"
+        "\\t\\t}}\\n"
+    )
+    new = (
+        "\\t\\t/* A52_FAILURE_WINDOW_WATCHDOG_DISARM */\\n"
+        f"\\t\\t/* {{marker}}: diagnostic boot only */\\n"
+        "\\t\\t{{\\n"
+        "\\t\\t\\tu32 a52_wdt_before;\\n"
+        "\\t\\t\\tu32 a52_wdt_after;\\n\\n"
+        "\\t\\t\\ta52_wdt_before = readl(wdt_addr(wdt, WDT_STS));\\n"
+        "\\t\\t\\tqcom_wdt_stop(&wdt->wdd);\\n"
+        "\\t\\t\\ta52_wdt_after = readl(wdt_addr(wdt, WDT_STS));\\n"
+        "\\t\\t\\ta52_ackfr_record(\\\"WDT disarm before=%u after=%u\\\",\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_before & 1),\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n"
+        "\\t\\t\\tdev_warn(&pdev->dev,\\n"
+        "\\t\\t\\t\\t \\\"A52 TouchGrass v3: QCOM watchdog disabled for late recorder\\\\n\\\");\\n"
+        "\\t\\t\\treturn 0; /* diagnostic only: do not register/re-arm */\\n"
+        "\\t\\t}}\\n"
+    )
+    return replace_once(text, old, new, "Phase279 watchdog handoff")
+'''
     apply = replace_once(apply, '\n\ndef apply(root: Path) -> None:\n', watchdog_fn + '\n\ndef apply(root: Path) -> None:\n', 'watchdog patch function')
 
     apply = replace_once(

--- a/scripts/tg3_prepare_generated_tools.py
+++ b/scripts/tg3_prepare_generated_tools.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
+DECODE = Path("scripts/tg1_decode_critical_bank.py")
+V2_MARKER = "A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V2_EARLY_SEAL_90S"
+V3_MARKER = "A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S"
+WDT_MARKER = "A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF"
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{label}: expected one anchor, found {n}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    apply = APPLY.read_text(encoding="utf-8")
+    decode = DECODE.read_text(encoding="utf-8")
+
+    if V2_MARKER not in apply:
+        raise SystemExit("v3 requires the v2 generated-tool patch first")
+
+    # Give fallback seals their own event type. v2 used DSI_DMA_TIMEOUT for every
+    # seal record, which made a timer seal look like a real DSI timeout.
+    apply = replace_once(
+        apply,
+        '#define A52_TGCR_EVT_TEXT                 0x0001U',
+        '#define A52_TGCR_EVT_TEXT                 0x0001U\n'
+        '#define A52_TGCR_EVT_SEAL                 0x0002U',
+        'typed seal event',
+    )
+    apply = replace_once(
+        apply,
+        '#define A52_TGCR_REASON_DEADLINE_90S      0x00000002U',
+        '#define A52_TGCR_REASON_DEADLINE_90S      0x00000002U\n'
+        '#define A52_TGCR_REASON_DEADLINE_210S     0x00000003U',
+        '210-second fallback reason',
+    )
+    apply = replace_once(
+        apply,
+        'a52_tgcr_write_slot_locked(A52_TGCR_EVT_DSI_DMA_TIMEOUT,\n                point,',
+        'a52_tgcr_write_slot_locked(A52_TGCR_EVT_SEAL,\n                point,',
+        'seal event type',
+    )
+    apply = replace_once(
+        apply,
+        'a52_tgcr_seal(A52_TGCR_REASON_DEADLINE_90S, 0xffffffffU,',
+        'a52_tgcr_seal(A52_TGCR_REASON_DEADLINE_210S, 0xffffffffU,',
+        'fallback seal reason',
+    )
+    apply = replace_once(
+        apply,
+        'msecs_to_jiffies(90000)',
+        'msecs_to_jiffies(210000)',
+        'fallback deadline',
+    )
+    apply = replace_once(
+        apply,
+        V2_MARKER,
+        V3_MARKER,
+        'compiled v3 marker',
+    )
+    apply = replace_once(
+        apply,
+        'a recorder-only 90-second fallback seal preserves the final circular window\n'
+        ' * before the configured 100-second softdog.',
+        'a recorder-only 210-second fallback seal preserves the late circular window\n'
+        ' * after SurfaceFlinger/composer have had time to start.',
+        'fallback comment',
+    )
+
+    # Reapply the proven Phase261 diagnostic watchdog handoff to the final
+    # reconstructed Phase279 tree. Later cumulative reconstruction retained the
+    # F261 trace points but no longer retained the qcom-wdt stop itself.
+    apply = replace_once(
+        apply,
+        'SMMU_REL = Path("drivers/iommu/arm/arm-smmu/arm-smmu.c")',
+        'SMMU_REL = Path("drivers/iommu/arm/arm-smmu/arm-smmu.c")\n'
+        'WDT_REL = Path("drivers/watchdog/qcom-wdt.c")',
+        'watchdog path',
+    )
+
+    watchdog_fn = f'''\n\ndef patch_watchdog(text: str) -> str:\n    marker = "{WDT_MARKER}"\n    if marker in text:\n        return text\n    old = (\n        "\\tif (running) {{\\n"\n        "\\t\\tqcom_wdt_start(&wdt->wdd);\\n"\n        "\\t\\tset_bit(WDOG_HW_RUNNING, &wdt->wdd.status);\\n"\n        "\\t}}\\n\\n"\n        "\\tret = devm_watchdog_register_device(dev, &wdt->wdd);\\n"\n    )\n    new = (\n        f"\\t/* {{marker}}: diagnostic boot only */\\n"\n        "\\tif (running)\\n"\n        "\\t\\tqcom_wdt_stop(&wdt->wdd);\\n"\n        "\\tdev_warn(dev, \\\"A52 TouchGrass v3: QCOM watchdog disabled for late recorder\\\\n\\\");\\n"\n        "\\tret = 0; /* diagnostic only: do not register/re-arm */\\n"\n    )\n    return replace_once(text, old, new, "watchdog handoff")\n'''
+    apply = replace_once(apply, '\n\ndef apply(root: Path) -> None:\n', watchdog_fn + '\n\ndef apply(root: Path) -> None:\n', 'watchdog patch function')
+
+    apply = replace_once(
+        apply,
+        'paths = [REC_REL, HDR_REL, DSI_REL, SMMU_REL]',
+        'paths = [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL]',
+        'apply source list',
+    )
+    apply = replace_once(
+        apply,
+        '        SMMU_REL: patch_smmu,\n    }',
+        '        SMMU_REL: patch_smmu,\n        WDT_REL: patch_watchdog,\n    }',
+        'apply function map',
+    )
+    apply = replace_once(
+        apply,
+        'if changed not in (0, 4):',
+        'if changed not in (0, 5):',
+        'apply changed count',
+    )
+    apply = replace_once(
+        apply,
+        'partial application: changed {changed}/4 files',
+        'partial application: changed {changed}/5 files',
+        'apply count message',
+    )
+    expected_loop = 'for rel in [REC_REL, HDR_REL, DSI_REL, SMMU_REL]:'
+    if apply.count(expected_loop) != 3:
+        raise SystemExit(f"self-test source lists: expected 3 anchors, found {apply.count(expected_loop)}")
+    apply = apply.replace(
+        expected_loop,
+        'for rel in [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL]:',
+    )
+
+    decode = replace_once(
+        decode,
+        "EVENT_NAMES = {\n    0x0001: 'TEXT',",
+        "EVENT_NAMES = {\n    0x0001: 'TEXT',\n    0x0002: 'SEAL',",
+        'decoder typed seal',
+    )
+    decode = replace_once(
+        decode,
+        "REASONS = {1: 'DSI_DMA_TIMEOUT', 2: 'DEADLINE_90S'}",
+        "REASONS = {1: 'DSI_DMA_TIMEOUT', 2: 'DEADLINE_90S', 3: 'DEADLINE_210S'}",
+        'decoder 210-second reason',
+    )
+
+    APPLY.write_text(apply, encoding="utf-8")
+    DECODE.write_text(decode, encoding="utf-8")
+    print("TouchGrass v3 generated-tool patch: PASS")
+    print("TouchGrass v3 typed seal: PASS")
+    print("TouchGrass v3 Phase261 watchdog-stop restoration: staged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tg3_secure_ci_build.sh
+++ b/scripts/tg3_secure_ci_build.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail_report() {
+  set +e
+  rm -rf tg3s-failure
+  mkdir -p tg3s-failure
+  cp -a tg1-failure tg3s-failure/ 2>/dev/null || true
+  cp tg1-compile.log tg3s-failure/ 2>/dev/null || true
+  cp scripts/tg2_prepare_generated_tools.py tg3s-failure/ 2>/dev/null || true
+  cp scripts/tg3_prepare_generated_tools.py tg3s-failure/ 2>/dev/null || true
+  cp scripts/tg3_secure_wdt_prepare.py tg3s-failure/ 2>/dev/null || true
+  cp scripts/tg2_finalize_boot.py tg3s-failure/ 2>/dev/null || true
+  cp scripts/tg1_apply_critical_flight_recorder.py tg3s-failure/ 2>/dev/null || true
+  cp scripts/tg1_decode_critical_bank.py tg3s-failure/ 2>/dev/null || true
+  cp gki/common/drivers/watchdog/qcom-wdt.c tg3s-failure/ 2>/dev/null || true
+  cp gki/common/drivers/firmware/qcom_scm.c tg3s-failure/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+V3_IMAGE_MARKER='A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S'
+WDT_MARKER='A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF'
+SECURE_WDT_MARKER='A52_TOUCHGRASS_V3_SECURE_AND_LOCAL_WDOG_OFF'
+SCM_MARKER='A52_TOUCHGRASS_V3_SECURE_WDOG_SCM_OFF'
+WDT_LOG='A52 TouchGrass v3: secure watchdog attempted; local watchdog disabled'
+WDT_RECORD='WDT secure rc=%d local before=%u after=%u'
+
+python3 scripts/tg1_payload.py
+python3 scripts/tg2_prepare_generated_tools.py
+python3 scripts/tg3_prepare_generated_tools.py
+python3 scripts/tg3_secure_wdt_prepare.py
+python3 -m py_compile \
+  scripts/tg1_apply_critical_flight_recorder.py \
+  scripts/tg1_check_critical_flight_recorder.py \
+  scripts/tg1_decode_critical_bank.py \
+  scripts/tg2_prepare_generated_tools.py \
+  scripts/tg3_prepare_generated_tools.py \
+  scripts/tg3_secure_wdt_prepare.py \
+  scripts/tg2_finalize_boot.py
+
+grep -Fq "$V3_IMAGE_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "$WDT_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "$SECURE_WDT_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "$SCM_MARKER" scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq '.cmd = 0x07' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'A52_TGCR_EVT_SEAL' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'A52_TGCR_REASON_DEADLINE_210S' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq 'msecs_to_jiffies(210000)' scripts/tg1_apply_critical_flight_recorder.py
+grep -Fq "0x0002: 'SEAL'" scripts/tg1_decode_critical_bank.py
+grep -Fq "3: 'DEADLINE_210S'" scripts/tg1_decode_critical_bank.py
+
+bash scripts/tg1_ci_build.sh
+
+# Audit the exact reconstructed sources that produced the Image.
+grep -Fq "$WDT_MARKER" gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq "$SECURE_WDT_MARKER" gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq 'a52_qcom_scm_disable_secure_wdog()' gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq "$WDT_RECORD" gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq 'qcom_wdt_stop(&wdt->wdd)' gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq 'do not register/re-arm' gki/common/drivers/watchdog/qcom-wdt.c
+grep -Fq "$SCM_MARKER" gki/common/drivers/firmware/qcom_scm.c
+grep -Fq 'int a52_qcom_scm_disable_secure_wdog(void)' gki/common/drivers/firmware/qcom_scm.c
+grep -Fq '.svc = QCOM_SCM_SVC_BOOT' gki/common/drivers/firmware/qcom_scm.c
+grep -Fq '.cmd = 0x07' gki/common/drivers/firmware/qcom_scm.c
+grep -Fq '.args[0] = 1' gki/common/drivers/firmware/qcom_scm.c
+
+rm -rf tg3s-out
+cp -a tg1-out tg3s-out
+mkdir -p tg3s-out/tools tg3s-out/source tg3s-out/audit
+
+python3 scripts/tg2_finalize_boot.py \
+  --source tg1-out/package/boot.img \
+  --output tg3s-out/package/boot.img \
+  --report tg3s-out/package/pmsg-release-report.json
+
+cp scripts/tg1_decode_critical_bank.py tg3s-out/tools/tg3_secure_decode_critical_bank.py
+cp scripts/tg1_apply_critical_flight_recorder.py tg3s-out/audit/tg1_apply_critical_flight_recorder.py
+cp scripts/tg3_secure_wdt_prepare.py tg3s-out/audit/tg3_secure_wdt_prepare.py
+cp gki/common/drivers/watchdog/qcom-wdt.c tg3s-out/source/qcom-wdt.c
+cp gki/common/drivers/firmware/qcom_scm.c tg3s-out/source/qcom_scm.c
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = Path('tg3s-out/BUILD-IDENTITY.json')
+d = json.loads(p.read_text())
+d.update({
+    'name': 'TOUCHGRASS-CRITICAL-FLIGHT-RECORDER-V3-SECURE-WDT',
+    'revision': 'v3-secure-wdt-r1',
+    'hardware_validated': False,
+    'v3_run9_hardware_result': 'reset-before-late-android-window',
+    'v3_run9_last_crc_valid_r48_ms': 97980.737,
+    'pmsg_runtime_size': 0,
+    'critical_bank_phys': '0xB1BC0000',
+    'critical_bank_bytes': 0x40000,
+    'critical_bank_capacity': 1636,
+    'critical_bank_is_circular': True,
+    'fallback_seal_ms': 210000,
+    'fallback_seal_reason': 'DEADLINE_210S',
+    'fallback_seal_event': 'SEAL',
+    'qcom_watchdog_handoff': 'diagnostic-secure-scm-then-local-stop-and-no-register',
+    'qcom_secure_watchdog_scm': {
+        'service': 'QCOM_SCM_SVC_BOOT',
+        'command': '0x07',
+        'arg0': 1,
+        'result_record': 'WDT secure rc=%d local before=%u after=%u',
+    },
+    'recovery_exporter_compatible': True,
+    'compiled_v3_marker': 'A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S',
+    'compiled_secure_wdt_marker': 'A52_TOUCHGRASS_V3_SECURE_AND_LOCAL_WDOG_OFF',
+    'functional_change': (
+        'diagnostic infrastructure only: issue Qualcomm SCM boot-service command 0x07 '
+        'with arg0=1 to request secure-watchdog disable, record the SCM return code, '
+        'then stop the local qcom watchdog and return before watchdog registration; '
+        'retain the v3 210-second typed SEAL fallback and pmsg release'
+    ),
+})
+p.write_text(json.dumps(d, indent=2, sort_keys=True) + '\n')
+PY
+
+IMAGE=tg3s-out/compile/Image
+test -s "$IMAGE"
+grep -aFq "$V3_IMAGE_MARKER" "$IMAGE" || {
+  echo "TouchGrass v3-secure audit: v3 recorder marker missing from Image" >&2
+  exit 1
+}
+grep -aFq "$WDT_LOG" "$IMAGE" || {
+  echo "TouchGrass v3-secure audit: secure/local watchdog log missing from Image" >&2
+  exit 1
+}
+grep -aFq "$WDT_RECORD" "$IMAGE" || {
+  echo "TouchGrass v3-secure audit: secure watchdog recorder format missing from Image" >&2
+  exit 1
+}
+grep -aFq 'F261 c4' "$IMAGE" || {
+  echo "TouchGrass v3-secure audit: cumulative Phase261 trace missing from Image" >&2
+  exit 1
+}
+
+grep -Fxq 'CONFIG_CHR_DEV_SG=y' tg3s-out/config/final.config
+grep -Fxq 'CONFIG_QCOM_WDT=y' tg3s-out/config/final.config
+grep -Fxq 'CONFIG_QCOM_SCM=y' tg3s-out/config/final.config
+
+python3 - <<'PY'
+import hashlib
+from pathlib import Path
+root = Path('tg3s-out')
+sums = root / 'SHA256SUMS'
+if sums.exists():
+    sums.unlink()
+rows = []
+for p in sorted(root.rglob('*')):
+    if p.is_file() and p.name != 'SHA256SUMS':
+        rows.append(f"{hashlib.sha256(p.read_bytes()).hexdigest()}  ./{p.relative_to(root)}")
+sums.write_text('\n'.join(rows) + '\n')
+PY
+(cd tg3s-out && sha256sum -c SHA256SUMS)
+
+trap - EXIT
+echo 'TouchGrass critical flight recorder v3 secure-watchdog build/repack: PASS'

--- a/scripts/tg3_secure_wdt_prepare.py
+++ b/scripts/tg3_secure_wdt_prepare.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
+SCM_MARKER = "A52_TOUCHGRASS_V3_SECURE_WDOG_SCM_OFF"
+WDT_SECURE_MARKER = "A52_TOUCHGRASS_V3_SECURE_AND_LOCAL_WDOG_OFF"
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{label}: expected one anchor, found {n}")
+    return text.replace(old, new, 1)
+
+
+def main() -> int:
+    apply = APPLY.read_text(encoding="utf-8")
+    if "A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S" not in apply:
+        raise SystemExit("secure-WDT extension requires the v3 generated-tool patch first")
+    if SCM_MARKER in apply and WDT_SECURE_MARKER in apply:
+        print("TouchGrass v3 secure-WDT generated-tool patch: already applied")
+        return 0
+
+    apply = replace_once(
+        apply,
+        'WDT_REL = Path("drivers/watchdog/qcom-wdt.c")',
+        'WDT_REL = Path("drivers/watchdog/qcom-wdt.c")\n'
+        'SCM_REL = Path("drivers/firmware/qcom_scm.c")',
+        "SCM source path",
+    )
+
+    secure_patchers = f'''\n\ndef patch_secure_scm(text: str) -> str:
+    marker = "{SCM_MARKER}"
+    if marker in text:
+        return text
+    anchor = "int qcom_scm_set_remote_state(u32 state, u32 id)\\n{{"
+    helper = """/* {SCM_MARKER}: diagnostic boot only */
+int a52_qcom_scm_disable_secure_wdog(void)
+{{
+\tstruct qcom_scm_desc desc = {{
+\t\t.svc = QCOM_SCM_SVC_BOOT,
+\t\t.cmd = 0x07, /* Qualcomm secure watchdog disable */
+\t\t.arginfo = QCOM_SCM_ARGS(1),
+\t\t.args[0] = 1,
+\t\t.owner = ARM_SMCCC_OWNER_SIP,
+\t}};
+\tstruct qcom_scm_res res;
+\tint ret;
+
+\tif (!__scm)
+\t\treturn -ENODEV;
+
+\tret = qcom_scm_call(__scm->dev, &desc, &res);
+\treturn ret ? : res.result[0];
+}}
+EXPORT_SYMBOL(a52_qcom_scm_disable_secure_wdog);
+
+"""
+    return replace_once(text, anchor, helper + anchor, "secure watchdog SCM helper")
+
+
+def patch_secure_watchdog(text: str) -> str:
+    text = patch_watchdog(text)
+    marker = "{WDT_SECURE_MARKER}"
+    if marker in text:
+        return text
+    text = replace_once(
+        text,
+        "#include <linux/a52_ack_secure_flight_recorder.h>\\n",
+        "#include <linux/a52_ack_secure_flight_recorder.h>\\n\\n"
+        "extern int a52_qcom_scm_disable_secure_wdog(void);\\n",
+        "secure watchdog SCM declaration",
+    )
+    text = replace_once(
+        text,
+        "\\t\\t/* A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF: diagnostic boot only */\\n",
+        "\\t\\t/* A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF: diagnostic boot only */\\n"
+        f"\\t\\t/* {{marker}}: secure SCM + local WDT_EN disarm */\\n",
+        "secure/local watchdog marker",
+    )
+    text = replace_once(
+        text,
+        "\\t\\t\\tu32 a52_wdt_before;\\n"
+        "\\t\\t\\tu32 a52_wdt_after;\\n\\n"
+        "\\t\\t\\ta52_wdt_before = readl(wdt_addr(wdt, WDT_STS));\\n",
+        "\\t\\t\\tu32 a52_wdt_before;\\n"
+        "\\t\\t\\tu32 a52_wdt_after;\\n"
+        "\\t\\t\\tint a52_secure_wdt_rc;\\n\\n"
+        "\\t\\t\\ta52_secure_wdt_rc = a52_qcom_scm_disable_secure_wdog();\\n"
+        "\\t\\t\\ta52_wdt_before = readl(wdt_addr(wdt, WDT_STS));\\n",
+        "secure watchdog call",
+    )
+    text = replace_once(
+        text,
+        "\\t\\t\\ta52_ackfr_record(\\\"WDT disarm before=%u after=%u\\\",\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_before & 1),\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n",
+        "\\t\\t\\ta52_ackfr_record(\\\"WDT secure rc=%d local before=%u after=%u\\\",\\n"
+        "\\t\\t\\t\\t\\t  a52_secure_wdt_rc,\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_before & 1),\\n"
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n",
+        "watchdog recorder result",
+    )
+    text = replace_once(
+        text,
+        "A52 TouchGrass v3: QCOM watchdog disabled for late recorder\\\\n",
+        "A52 TouchGrass v3: secure watchdog attempted; local watchdog disabled\\\\n",
+        "watchdog diagnostic log",
+    )
+    return text
+'''
+    apply = replace_once(
+        apply,
+        "\n\ndef apply(root: Path) -> None:\n",
+        secure_patchers + "\n\ndef apply(root: Path) -> None:\n",
+        "secure watchdog patch functions",
+    )
+
+    apply = replace_once(
+        apply,
+        "paths = [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL]",
+        "paths = [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL, SCM_REL]",
+        "apply source list",
+    )
+    apply = replace_once(
+        apply,
+        "        WDT_REL: patch_watchdog,\n    }",
+        "        WDT_REL: patch_secure_watchdog,\n        SCM_REL: patch_secure_scm,\n    }",
+        "apply function map",
+    )
+    apply = replace_once(
+        apply,
+        "if changed not in (0, 5):",
+        "if changed not in (0, 6):",
+        "apply changed count",
+    )
+    apply = replace_once(
+        apply,
+        "partial application: changed {changed}/5 files",
+        "partial application: changed {changed}/6 files",
+        "apply count message",
+    )
+
+    old_loop = "for rel in [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL]:"
+    if apply.count(old_loop) != 3:
+        raise SystemExit(f"secure-WDT self-test source lists: expected 3 anchors, found {apply.count(old_loop)}")
+    apply = apply.replace(
+        old_loop,
+        "for rel in [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL, SCM_REL]:",
+    )
+    apply = replace_once(
+        apply,
+        '            expected_marker = "A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF" if rel == WDT_REL else MARKER\n',
+        f'            if rel == WDT_REL:\n'
+        f'                expected_marker = "{WDT_SECURE_MARKER}"\n'
+        f'            elif rel == SCM_REL:\n'
+        f'                expected_marker = "{SCM_MARKER}"\n'
+        f'            else:\n'
+        f'                expected_marker = MARKER\n',
+        "self-test secure marker selection",
+    )
+
+    APPLY.write_text(apply, encoding="utf-8")
+    print("TouchGrass v3 secure-WDT generated-tool patch: PASS")
+    print("TouchGrass v3 secure watchdog SCM command 0x07: staged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tg3_secure_wdt_prepare.py
+++ b/scripts/tg3_secure_wdt_prepare.py
@@ -6,6 +6,7 @@ from pathlib import Path
 APPLY = Path("scripts/tg1_apply_critical_flight_recorder.py")
 SCM_MARKER = "A52_TOUCHGRASS_V3_SECURE_WDOG_SCM_OFF"
 WDT_SECURE_MARKER = "A52_TOUCHGRASS_V3_SECURE_AND_LOCAL_WDOG_OFF"
+WDT_PROOF_MARKER = "A52_TOUCHGRASS_V3_WDOG_LATE_PROOF_15S"
 
 
 def replace_once(text: str, old: str, new: str, label: str) -> str:
@@ -19,7 +20,7 @@ def main() -> int:
     apply = APPLY.read_text(encoding="utf-8")
     if "A52_TOUCHGRASS_CRITICAL_FLIGHT_RECORDER_V3_WDT_OFF_TYPED_SEAL_210S" not in apply:
         raise SystemExit("secure-WDT extension requires the v3 generated-tool patch first")
-    if SCM_MARKER in apply and WDT_SECURE_MARKER in apply:
+    if SCM_MARKER in apply and WDT_SECURE_MARKER in apply and WDT_PROOF_MARKER in apply:
         print("TouchGrass v3 secure-WDT generated-tool patch: already applied")
         return 0
 
@@ -64,15 +65,59 @@ EXPORT_SYMBOL(a52_qcom_scm_disable_secure_wdog);
 def patch_secure_watchdog(text: str) -> str:
     text = patch_watchdog(text)
     marker = "{WDT_SECURE_MARKER}"
-    if marker in text:
+    proof_marker = "{WDT_PROOF_MARKER}"
+    if marker in text and proof_marker in text:
         return text
+
     text = replace_once(
         text,
         "#include <linux/a52_ack_secure_flight_recorder.h>\\n",
-        "#include <linux/a52_ack_secure_flight_recorder.h>\\n\\n"
+        "#include <linux/a52_ack_secure_flight_recorder.h>\\n"
+        "#include <linux/jiffies.h>\\n"
+        "#include <linux/workqueue.h>\\n\\n"
         "extern int a52_qcom_scm_disable_secure_wdog(void);\\n",
         "secure watchdog SCM declaration",
     )
+    text = replace_once(
+        text,
+        "\\tconst u32\\t\\t*layout;\\n}};\\n",
+        "\\tconst u32\\t\\t*layout;\\n"
+        "\\tstruct delayed_work\\ta52_diag_work;\\n"
+        "\\tint\\t\\t\\ta52_secure_wdt_rc;\\n"
+        "\\tunsigned int\\t\\ta52_diag_samples;\\n"
+        "}};\\n",
+        "watchdog diagnostic state",
+    )
+
+    worker_anchor = "static int qcom_wdt_ping(struct watchdog_device *wdd)\\n{{"
+    worker = """/* {WDT_PROOF_MARKER}: retain watchdog state near the late failure window */
+static void a52_qcom_wdt_diag_workfn(struct work_struct *work)
+{{
+\tstruct qcom_wdt *wdt = container_of(to_delayed_work(work),
+\t\t\t\t\t    struct qcom_wdt, a52_diag_work);
+\tu32 en;
+\tu32 sts;
+
+\tif (wdt->a52_secure_wdt_rc)
+\t\twdt->a52_secure_wdt_rc = a52_qcom_scm_disable_secure_wdog();
+
+\ten = readl(wdt_addr(wdt, WDT_EN));
+\tsts = readl(wdt_addr(wdt, WDT_STS));
+\twdt->a52_diag_samples++;
+\ta52_ackfr_record("WDT late sec=%d en=%u sts=%u sample=%u",
+\t\t\t  wdt->a52_secure_wdt_rc,
+\t\t\t  !!(en & QCOM_WDT_ENABLE), !!(sts & 1),
+\t\t\t  wdt->a52_diag_samples);
+
+\tif (wdt->a52_diag_samples < 14)
+\t\tschedule_delayed_work(&wdt->a52_diag_work,
+\t\t\t\t      msecs_to_jiffies(15000));
+}}
+
+"""
+    text = replace_once(text, worker_anchor, worker + worker_anchor,
+                        "late watchdog proof worker")
+
     text = replace_once(
         text,
         "\\t\\t/* A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF: diagnostic boot only */\\n",
@@ -86,9 +131,8 @@ def patch_secure_watchdog(text: str) -> str:
         "\\t\\t\\tu32 a52_wdt_after;\\n\\n"
         "\\t\\t\\ta52_wdt_before = readl(wdt_addr(wdt, WDT_STS));\\n",
         "\\t\\t\\tu32 a52_wdt_before;\\n"
-        "\\t\\t\\tu32 a52_wdt_after;\\n"
-        "\\t\\t\\tint a52_secure_wdt_rc;\\n\\n"
-        "\\t\\t\\ta52_secure_wdt_rc = a52_qcom_scm_disable_secure_wdog();\\n"
+        "\\t\\t\\tu32 a52_wdt_after;\\n\\n"
+        "\\t\\t\\twdt->a52_secure_wdt_rc = a52_qcom_scm_disable_secure_wdog();\\n"
         "\\t\\t\\ta52_wdt_before = readl(wdt_addr(wdt, WDT_STS));\\n",
         "secure watchdog call",
     )
@@ -98,10 +142,14 @@ def patch_secure_watchdog(text: str) -> str:
         "\\t\\t\\t\\t\\t  !!(a52_wdt_before & 1),\\n"
         "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n",
         "\\t\\t\\ta52_ackfr_record(\\\"WDT secure rc=%d local before=%u after=%u\\\",\\n"
-        "\\t\\t\\t\\t\\t  a52_secure_wdt_rc,\\n"
+        "\\t\\t\\t\\t\\t  wdt->a52_secure_wdt_rc,\\n"
         "\\t\\t\\t\\t\\t  !!(a52_wdt_before & 1),\\n"
-        "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n",
-        "watchdog recorder result",
+        "\\t\\t\\t\\t\\t  !!(a52_wdt_after & 1));\\n"
+        "\\t\\t\\tINIT_DELAYED_WORK(&wdt->a52_diag_work, a52_qcom_wdt_diag_workfn);\\n"
+        "\\t\\t\\twdt->a52_diag_samples = 0;\\n"
+        "\\t\\t\\tschedule_delayed_work(&wdt->a52_diag_work, msecs_to_jiffies(15000));\\n"
+        "\\t\\t\\tplatform_set_drvdata(pdev, wdt);\\n",
+        "watchdog recorder result and late proof",
     )
     text = replace_once(
         text,
@@ -111,13 +159,13 @@ def patch_secure_watchdog(text: str) -> str:
     )
     return text
 '''
+
     apply = replace_once(
         apply,
         "\n\ndef apply(root: Path) -> None:\n",
         secure_patchers + "\n\ndef apply(root: Path) -> None:\n",
         "secure watchdog patch functions",
     )
-
     apply = replace_once(
         apply,
         "paths = [REC_REL, HDR_REL, DSI_REL, SMMU_REL, WDT_REL]",
@@ -155,6 +203,8 @@ def patch_secure_watchdog(text: str) -> str:
         '            expected_marker = "A52_TOUCHGRASS_V3_DIAGNOSTIC_QCOM_WDT_OFF" if rel == WDT_REL else MARKER\n',
         f'            if rel == WDT_REL:\n'
         f'                expected_marker = "{WDT_SECURE_MARKER}"\n'
+        f'                if text.count("{WDT_PROOF_MARKER}") != 1:\n'
+        f'                    raise RuntimeError("self-test late watchdog proof marker count")\n'
         f'            elif rel == SCM_REL:\n'
         f'                expected_marker = "{SCM_MARKER}"\n'
         f'            else:\n'
@@ -165,6 +215,7 @@ def patch_secure_watchdog(text: str) -> str:
     APPLY.write_text(apply, encoding="utf-8")
     print("TouchGrass v3 secure-WDT generated-tool patch: PASS")
     print("TouchGrass v3 secure watchdog SCM command 0x07: staged")
+    print("TouchGrass v3 15-second watchdog proof recorder: staged")
     return 0
 
 


### PR DESCRIPTION
## Hardware evidence

v2 hardware capture `A52_RAW_RAMOOPS_20260818_202323.zip` reached display/KGSL probe but its CRC-valid R48/RS48 timeline ended at about 106.14 s. At 90 s zygote, SurfaceFlinger, system_server, SystemUI and bootanimation were still absent while odsign/odrefresh were alive.

The hardware capture from the successfully audited v3 run #9 behaves the same way: its CRC-valid R48/RS48 timeline ends at 97,980.737 ms. At 90 s the same five late Android processes are absent and odsign/odrefresh are still alive. This proves that stopping only the upstream `qcom-wdt` handoff did not preserve the intended 210 s late window.

`CONFIG_CHR_DEV_SG=y` is present, so this is not the prior SG regression.

## v3 recorder changes

- Keep `CONFIG_QCOM_WDT=y`, but stop the diagnostic local qcom watchdog handoff and return before watchdog registration/re-arm.
- Keep the v2 pmsg release so TGCR retains exclusive ownership of the fourth quarter.
- Move fallback sealing from 90 s to 210 s so the recorder can retain the late composer window.
- Give fallback/explicit seals a distinct `SEAL` event type instead of encoding every seal as `DSI_DMA_TIMEOUT`.
- Preserve `CONFIG_CHR_DEV_SG=y` and audit it in CI.

## Secure-watchdog follow-up

Qualcomm's downstream `watchdog_v2` disable path does two operations: it first calls secure world through SCM boot service command `0x07` with argument 1 to deactivate the secure watchdog, and only then disables the Apps watchdog registers. The v3 run #9 diagnostic only performed the second operation.

The secure-watchdog extension therefore:

- adds a diagnostic `qcom_scm.c` helper for boot-service command `0x07`, arg0=1;
- records the SCM return code;
- then disables local `WDT_EN` and still returns before watchdog registration/re-arm;
- records secure/local watchdog state every 15 s through the 210 s diagnostic window, so another ~100 s reset still leaves late proof in the circular R48 transport;
- preserves the existing 210 s typed-SEAL recorder behavior and pmsg release.

Hardware validation remains pending. Do not merge this PR as a behavioral fix; these watchdog changes are diagnostic infrastructure only.