### PR TITLE
CANCELLED: incorrect watchdog-based Phase 280

### DIFF
--- a/.github/workflows/phase280-secure-watchdog-runtime-validation.yml
+++ b/.github/workflows/phase280-secure-watchdog-runtime-validation.yml
@@ -1,0 +1,86 @@
+name: Phase 280 - secure watchdog runtime validation
+run-name: Phase 280 secure-watchdog runtime candidate
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase280-secure-watchdog-runtime-validation-v1
+    paths:
+      - .github/workflows/phase280-secure-watchdog-runtime-validation.yml
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase280-secure-watchdog-runtime-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Rebuild exact v3 secure-watchdog candidate as Phase 280
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase 280 branch
+        uses: actions/checkout@v4
+      - name: Verify zero-kernel-diff phase boundary
+        run: |
+          set -Eeuo pipefail
+          test "$(git rev-parse HEAD^)" = "6e1ef23f02caa6d5d7385e4c7b1a1d7ced6581b5"
+          git diff --name-only HEAD^ HEAD | grep -qx '.github/workflows/phase280-secure-watchdog-runtime-validation.yml'
+          test "$(git diff --name-only HEAD^ HEAD | wc -l)" -eq 1
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build and audit exact secure-watchdog candidate
+        run: bash scripts/tg3_secure_ci_build.sh
+      - name: Upload Phase 280 hardware-test candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-PHASE280-SECURE-WATCHDOG-RUNTIME-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: tg3s-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload Phase 280 failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-PHASE280-SECURE-WATCHDOG-RUNTIME-FAILURE-${{ github.run_number }}
+          path: |
+            tg3s-failure/
+            tg1-failure/
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/phase280-secure-watchdog-runtime-validation.yml
+++ b/.github/workflows/phase280-secure-watchdog-runtime-validation.yml
@@ -7,6 +7,9 @@ on:
       - agent/a52-phase280-secure-watchdog-runtime-validation-v1
     paths:
       - .github/workflows/phase280-secure-watchdog-runtime-validation.yml
+  pull_request:
+    paths:
+      - .github/workflows/phase280-secure-watchdog-runtime-validation.yml
 permissions:
   contents: read
   actions: read
@@ -18,6 +21,7 @@ env:
   TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
   TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
   PHASE227_SEED_ARTIFACT_ID: '9160764832'
+  PHASE280_BASE_SHA: 6e1ef23f02caa6d5d7385e4c7b1a1d7ced6581b5
 jobs:
   build:
     name: Rebuild exact v3 secure-watchdog candidate as Phase 280
@@ -28,12 +32,15 @@ jobs:
     steps:
       - name: Check out Phase 280 branch
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Verify zero-kernel-diff phase boundary
         run: |
           set -Eeuo pipefail
-          test "$(git rev-parse HEAD^)" = "6e1ef23f02caa6d5d7385e4c7b1a1d7ced6581b5"
-          git diff --name-only HEAD^ HEAD | grep -qx '.github/workflows/phase280-secure-watchdog-runtime-validation.yml'
-          test "$(git diff --name-only HEAD^ HEAD | wc -l)" -eq 1
+          git cat-file -e "$PHASE280_BASE_SHA^{commit}"
+          changed="$(git diff --name-only "$PHASE280_BASE_SHA"..HEAD)"
+          printf '%s\n' "$changed"
+          test "$changed" = '.github/workflows/phase280-secure-watchdog-runtime-validation.yml'
       - name: Prepare runner
         run: |
           set -Eeuo pipefail


### PR DESCRIPTION
## Purpose

Phase 280 is a zero-kernel-diff hardware-validation phase for the exact TouchGrass critical-recorder v3 secure-watchdog candidate at parent commit `6e1ef23f02caa6d5d7385e4c7b1a1d7ced6581b5`.

## Why

The prior v3 hardware capture still reset at about 98 seconds after disabling only the local qcom watchdog path. The latest v3 head adds the downstream-equivalent secure-world watchdog deactivation call through SCM boot service command `0x07`, argument `1`, then disables local `WDT_EN` and returns before watchdog registration/re-arm. Both CI workflows on that exact head passed, but the secure-watchdog extension has not yet been hardware validated.

## Phase 280 change

No kernel, DT, ramdisk, boot configuration, recorder, display, SMMU, watchdog implementation, or runtime behavior is changed relative to the parent. This PR adds only a phase-specific GitHub Actions workflow that rebuilds the existing secure-watchdog candidate and publishes it under a Phase 280 artifact label.

The workflow explicitly asserts that its commit parent is the exact v3 secure-watchdog head and that the workflow file is the only branch diff before building.

## Validation target

Flash the Phase 280 `boot.img`, allow the diagnostic boot to run beyond the previous ~100 s reset boundary, then recover the untouched 1 MiB RAMOOPS reservation. The expected evidence is secure/local watchdog state continuing through the intended late window and either a sealed critical bank or a later, concrete runtime boundary.

This remains diagnostic-only and must not be interpreted as a behavioral display/SMMU fix until hardware evidence proves the next boundary.