### PR TITLE
Phase 281: trace DSI DMA consumption and brightness payload

### DIFF
--- a/.github/workflows/281-a52-dsi-dma-brightness-trace.yml
+++ b/.github/workflows/281-a52-dsi-dma-brightness-trace.yml
@@ -1,0 +1,91 @@
+name: 281 - A52 DSI DMA consumption and brightness trace
+run-name: Phase 281 - trace DSI DMA consumption and A52 brightness payload
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase281-dsi-dma-brightness-trace-v1
+    paths:
+      - .github/workflows/281-a52-dsi-dma-brightness-trace.yml
+      - scripts/281_apply_dsi_dma_trace.py
+      - scripts/281_apply_brightness_trace.py
+      - scripts/281_check_dsi_dma_brightness_trace.py
+      - scripts/281_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase280-phase279-evidence-visible-v1
+    paths:
+      - .github/workflows/281-a52-dsi-dma-brightness-trace.yml
+      - scripts/281_apply_dsi_dma_trace.py
+      - scripts/281_apply_brightness_trace.py
+      - scripts/281_check_dsi_dma_brightness_trace.py
+      - scripts/281_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase281-dsi-dma-brightness-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase280 and build Phase281 DSI/brightness trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase281 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct exact Phase280 and build Phase281 candidate
+        run: bash scripts/281_ci_build.sh
+      - name: Upload Phase281 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase281-DSI-DMA-BRIGHTNESS-TRACE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase281-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase281-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/281_apply_brightness_trace.py
+++ b/scripts/281_apply_brightness_trace.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+COMMON = Path('drivers/a52_display/msm/samsung/ss_dsi_panel_common.c')
+PANEL = Path('drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c')
+MARK = 'A52_PHASE281_BRIGHTNESS_MAPPING_TRACE_V1'
+MARK_DIM = 'A52_PHASE281_EARLY_50PCT_BRIGHTNESS_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_common(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = replace_one(
+        text,
+        '#include "ss_dsi_panel_common.h"\n#include <linux/preempt.h>\n',
+        '#include "ss_dsi_panel_common.h"\n#include <linux/a52_ack_secure_flight_recorder.h>\n#include <linux/preempt.h>\n\n/* ' + MARK + ' */\n',
+        'Phase281 common include/marker')
+
+    start = text.index('int ss_brightness_dcs(struct samsung_display_driver_data *vdd, int level, int backlight_origin)')
+    end = text.index('int ss_brightness_dcs_hmt(', start)
+    region = text[start:end]
+
+    region = replace_one(region, '\tint ret = 0;\n', '\tint ret = 0;\n\tint tx_ret = 0;\n', 'Phase281 tx_ret')
+    region = replace_one(
+        region,
+        '\tstatic int backup_bl_level, backup_acl;\n',
+        '\tstatic int backup_bl_level, backup_acl;\n\n'
+        '\ta52_ackfr_record("P276 281BE l=%d c=%d o=%d", level,\n'
+        '\t\tvdd->br_info.common_br.bl_level, backlight_origin);\n',
+        'Phase281 brightness entry trace')
+
+    marker = '\n\tif (cmd_cnt > 0) {\n\t\t/* setting tx cmds cmt */\n'
+    insert = ('\n\ta52_ackfr_record("P276 281BM l=%d i=%d c=%d g=%x",\n'
+              '\t\tvdd->br_info.common_br.bl_level,\n'
+              '\t\tvdd->br_info.common_br.cd_idx,\n'
+              '\t\tvdd->br_info.common_br.cd_level,\n'
+              '\t\tvdd->br_info.common_br.gm2_wrdisbv);\n'
+              '\n\tif (cmd_cnt > 0) {\n\t\t/* setting tx cmds cmt */\n')
+    region = replace_one(region, marker, insert, 'Phase281 brightness mapped trace')
+
+    call = '\t\t\t\tss_send_cmd(vdd, TX_BRIGHT_CTRL);\n'
+    repl = ('\t\t\t\ttx_ret = ss_send_cmd(vdd, TX_BRIGHT_CTRL);\n'
+            '\t\t\t\ta52_ackfr_record("P276 281BT r=%d l=%d g=%x", tx_ret,\n'
+            '\t\t\t\t\tvdd->br_info.common_br.bl_level,\n'
+            '\t\t\t\t\tvdd->br_info.common_br.gm2_wrdisbv);\n')
+    if region.count(call) != 2:
+        raise SystemExit(f'Phase281 TX_BRIGHT_CTRL calls: expected 2, found {region.count(call)}')
+    region = region.replace(call, repl)
+    text = text[:start] + region + text[end:]
+
+    old = '''\t\tif (bd && vdd->br_info.common_br.bl_level != bd->props.brightness) {\n\t\t\tLCD_INFO(vdd, "update bl_level: %d -> %d\\n",\n\t\t\t\tvdd->br_info.common_br.bl_level, bd->props.brightness);\n\t\t\tvdd->br_info.common_br.bl_level = bd->props.brightness;\n\t\t}\n'''
+    new = '''\t\tif (bd && vdd->br_info.common_br.bl_level != bd->props.brightness) {\n\t\t\tLCD_INFO(vdd, "update bl_level: %d -> %d\\n",\n\t\t\t\tvdd->br_info.common_br.bl_level, bd->props.brightness);\n\t\t\ta52_ackfr_record("P276 281BO f=%d t=%d",\n\t\t\t\tvdd->br_info.common_br.bl_level, bd->props.brightness);\n\t\t\tvdd->br_info.common_br.bl_level = bd->props.brightness;\n\t\t}\n'''
+    text = replace_one(text, old, new, 'Phase281 brightness override trace')
+    return text
+
+
+def patch_panel(text: str) -> str:
+    if MARK in text and MARK_DIM in text:
+        return text
+
+    text = replace_one(
+        text,
+        '#include "ss_dsi_panel_S6E3FC3_AMS646YD01.h"\n#include "ss_dsi_mdnie_S6E3FC3_AMS646YD01.h"\n',
+        '#include "ss_dsi_panel_S6E3FC3_AMS646YD01.h"\n#include "ss_dsi_mdnie_S6E3FC3_AMS646YD01.h"\n#include <linux/a52_ack_secure_flight_recorder.h>\n\n/* ' + MARK + ' */\n',
+        'Phase281 panel include/marker')
+
+    start = text.index('static struct dsi_panel_cmd_set *ss_brightness_gamma_mode2_normal')
+    end = text.index('static struct dsi_panel_cmd_set *ss_brightness_gamma_mode2_hbm', start)
+    region = text[start:end]
+    region = replace_one(
+        region,
+        '\tint finger_mask_update_delay;\n',
+        '\tint finger_mask_update_delay;\n\tint a52_p281_wrdisbv_idx = -1;\n',
+        'Phase281 WRDISBV index declaration')
+
+    replacements = [
+        ('\t\tpcmds->cmds[5].ss_txbuf[2] = get_bit(vdd->br_info.common_br.gm2_wrdisbv, 0, 8);\n',
+         '\t\tpcmds->cmds[5].ss_txbuf[2] = get_bit(vdd->br_info.common_br.gm2_wrdisbv, 0, 8);\n\t\ta52_p281_wrdisbv_idx = 5;\n'),
+        ('\t\tpcmds->cmds[2].ss_txbuf[2] = get_bit(vdd->br_info.common_br.gm2_wrdisbv, 0, 8);\n',
+         '\t\tpcmds->cmds[2].ss_txbuf[2] = get_bit(vdd->br_info.common_br.gm2_wrdisbv, 0, 8);\n\t\ta52_p281_wrdisbv_idx = 2;\n'),
+        ('\t\tpcmds->cmds[3].ss_txbuf[2] = get_bit(vdd->br_info.common_br.gm2_wrdisbv, 0, 8);\n',
+         '\t\tpcmds->cmds[3].ss_txbuf[2] = get_bit(vdd->br_info.common_br.gm2_wrdisbv, 0, 8);\n\t\ta52_p281_wrdisbv_idx = 3;\n'),
+    ]
+    for old, new in replacements:
+        region = replace_one(region, old, new, 'Phase281 WRDISBV command index')
+
+    old = '\t*level_key = LEVEL_KEY_NONE;\n'
+    new = '''\tif (a52_p281_wrdisbv_idx >= 0 &&\n\t\t\tpcmds->cmds[a52_p281_wrdisbv_idx].ss_txbuf &&\n\t\t\tpcmds->cmds[a52_p281_wrdisbv_idx].msg.tx_len >= 3)\n\t\ta52_ackfr_record("P276 281BV i=%d g=%x %02x%02x%02x",\n\t\t\ta52_p281_wrdisbv_idx, vdd->br_info.common_br.gm2_wrdisbv,\n\t\t\tpcmds->cmds[a52_p281_wrdisbv_idx].ss_txbuf[0],\n\t\t\tpcmds->cmds[a52_p281_wrdisbv_idx].ss_txbuf[1],\n\t\t\tpcmds->cmds[a52_p281_wrdisbv_idx].ss_txbuf[2]);\n\n\t*level_key = LEVEL_KEY_NONE;\n'''
+    region = replace_one(region, old, new, 'Phase281 WRDISBV payload trace')
+    text = text[:start] + region + text[end:]
+
+    old = '''\t/* default brightness */\n\tvdd->br_info.common_br.bl_level = 255;\n'''
+    new = '''\t/* default brightness */\n\t/* A52_PHASE281_EARLY_50PCT_BRIGHTNESS_V1: logical 128/255 boot default. */\n\tvdd->br_info.common_br.bl_level = 128;\n\ta52_ackfr_record("P276 281BI l=%d", vdd->br_info.common_br.bl_level);\n'''
+    text = replace_one(text, old, new, 'Phase281 early brightness default')
+    return text
+
+
+def validate_common(text: str) -> None:
+    required = [MARK, 'P276 281BE l=%d c=%d o=%d', 'P276 281BM l=%d i=%d c=%d g=%x',
+                'P276 281BT r=%d l=%d g=%x', 'P276 281BO f=%d t=%d',
+                'int tx_ret = 0;']
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase281 common brightness marker missing: ' + token)
+    if text.count('tx_ret = ss_send_cmd(vdd, TX_BRIGHT_CTRL);') != 2:
+        raise SystemExit('Phase281 brightness tx result capture count mismatch')
+
+
+def validate_panel(text: str) -> None:
+    required = [MARK, MARK_DIM, 'vdd->br_info.common_br.bl_level = 128;',
+                'P276 281BI l=%d', 'P276 281BV i=%d g=%x %02x%02x%02x',
+                'a52_p281_wrdisbv_idx = 5;', 'a52_p281_wrdisbv_idx = 2;',
+                'a52_p281_wrdisbv_idx = 3;']
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase281 panel brightness marker missing: ' + token)
+    if 'vdd->br_info.common_br.bl_level = 255;' in text:
+        raise SystemExit('Phase281 panel still contains old 255 default brightness')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    common = args.root / COMMON
+    panel = args.root / PANEL
+    if not common.is_file():
+        raise SystemExit(f'missing source: {common}')
+    if not panel.is_file():
+        raise SystemExit(f'missing source: {panel}')
+    ctext = common.read_text()
+    ptext = panel.read_text()
+    if not args.check_only:
+        ctext = patch_common(ctext)
+        ptext = patch_panel(ptext)
+        common.write_text(ctext)
+        panel.write_text(ptext)
+    validate_common(ctext)
+    validate_panel(ptext)
+    print('Phase281 Samsung brightness mapping + early 50% trace: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/281_apply_dsi_dma_trace.py
+++ b/scripts/281_apply_dsi_dma_trace.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' not in text:
+        raise SystemExit('Phase280 retention marker missing')
+
+    anchor = 'static DEFINE_MUTEX(dsi_ctrl_list_lock);\n\n'
+    helper = r'''static DEFINE_MUTEX(dsi_ctrl_list_lock);
+
+/* A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1
+ * Read-only snapshots around the already-proven command-DMA failure boundary.
+ * R0 positional fields: DSI_STATUS, DSI_FIFO_STATUS,
+ * DSI_COMMAND_MODE_DMA_CTRL, DSI_DMA_FIFO_CTRL,
+ * DSI_CMD_MODE_DMA_SW_TRIGGER, DSI_INT_CTRL.
+ * R1 positional fields: DSI_ACK_ERR_STATUS, DSI_TIMEOUT_STATUS,
+ * DSI_LANE_STATUS, DSI_DLN0_PHY_ERR, DSI_AXI2AHB_CTRL, DSI_VBIF_CTRL.
+ * R2 (timeout only): DSI_DMA_CMD_OFFSET, DSI_DMA_CMD_LENGTH,
+ * DSI_CLK_CTRL, DSI_CLK_STATUS.
+ * No DSI register is written and no control-flow decision is changed.
+ */
+static void a52_p281_dsi_dma_snapshot(struct dsi_ctrl *dsi_ctrl,
+		unsigned int point)
+{
+	void __iomem *base;
+
+	if (!a52_p276r_deep_active() || !dsi_ctrl || !dsi_ctrl->hw.base)
+		return;
+
+	base = dsi_ctrl->hw.base;
+	a52_ackfr_record("P276 281R0 q=%u %x %x %x %x %x %x", point,
+		readl_relaxed(base + DSI_STATUS),
+		readl_relaxed(base + DSI_FIFO_STATUS),
+		readl_relaxed(base + DSI_COMMAND_MODE_DMA_CTRL),
+		readl_relaxed(base + DSI_DMA_FIFO_CTRL),
+		readl_relaxed(base + DSI_CMD_MODE_DMA_SW_TRIGGER),
+		readl_relaxed(base + DSI_INT_CTRL));
+	a52_ackfr_record("P276 281R1 q=%u %x %x %x %x %x %x", point,
+		readl_relaxed(base + DSI_ACK_ERR_STATUS),
+		readl_relaxed(base + DSI_TIMEOUT_STATUS),
+		readl_relaxed(base + DSI_LANE_STATUS),
+		readl_relaxed(base + DSI_DLN0_PHY_ERR),
+		readl_relaxed(base + DSI_AXI2AHB_CTRL),
+		readl_relaxed(base + DSI_VBIF_CTRL));
+
+	if (point == 2)
+		a52_ackfr_record("P276 281R2 q=2 %x %x %x %x",
+			readl_relaxed(base + DSI_DMA_CMD_OFFSET),
+			readl_relaxed(base + DSI_DMA_CMD_LENGTH),
+			readl_relaxed(base + DSI_CLK_CTRL),
+			readl_relaxed(base + DSI_CLK_STATUS));
+}
+
+'''
+    text = replace_one(text, anchor, helper, 'Phase281 DSI helper insertion')
+
+    old = '''\t\tif (a52_p276r_deep_active())\n\t\t\ta52_p279_display_fault_snapshot(2);\n\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n'''
+    new = '''\t\tif (a52_p276r_deep_active())\n\t\t\ta52_p279_display_fault_snapshot(2);\n\t\ta52_p281_dsi_dma_snapshot(dsi_ctrl, 2);\n\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n'''
+    text = replace_one(text, old, new, 'Phase281 q2 snapshot')
+
+    old = '''\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p279_display_fault_snapshot(0);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_ackfr_record("P276 H K o=%llx l=%u h=%x",\n'''
+    new = '''\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p279_display_fault_snapshot(0);\n\t\t\t\ta52_p281_dsi_dma_snapshot(dsi_ctrl, 0);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_ackfr_record("P276 H K o=%llx l=%u h=%x",\n'''
+    text = replace_one(text, old, new, 'Phase281 q0 snapshot')
+
+    old = '''\t\t\t\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D K s=4 p=1");\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p278_display_smmu_snapshot(1);\n'''
+    new = '''\t\t\t\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D K s=4 p=1");\n\t\t\t\ta52_p281_dsi_dma_snapshot(dsi_ctrl, 1);\n\t\t\t\tif (a52_p276r_deep_active())\n\t\t\t\t\ta52_p278_display_smmu_snapshot(1);\n'''
+    text = replace_one(text, old, new, 'Phase281 q1 snapshot')
+    return text
+
+
+def validate(text: str) -> None:
+    required = [
+        MARK,
+        'P276 281R0 q=%u %x %x %x %x %x %x',
+        'P276 281R1 q=%u %x %x %x %x %x %x',
+        'P276 281R2 q=2 %x %x %x %x',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 0);',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 1);',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);',
+        'P276 280Z q=2',
+        'a52_ackfr_retain_timeout_snapshot();',
+    ]
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase281 DSI marker missing: ' + token)
+    if text.index('a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);') > text.index('P276 280Z q=2'):
+        raise SystemExit('Phase281 q2 DSI snapshot occurs after retention latch')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    path = args.root / DSI
+    if not path.is_file():
+        raise SystemExit(f'missing source: {path}')
+    text = path.read_text()
+    if not args.check_only:
+        text = patch(text)
+        path.write_text(text)
+    validate(text)
+    print('Phase281 DSI DMA consumption trace: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/281_check_dsi_dma_brightness_trace.py
+++ b/scripts/281_check_dsi_dma_brightness_trace.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import difflib
+from pathlib import Path
+
+
+def read(p: Path) -> str:
+    if not p.is_file():
+        raise SystemExit(f'missing audit input: {p}')
+    return p.read_text()
+
+
+def added_lines(before: str, after: str) -> list[str]:
+    out = []
+    for line in difflib.ndiff(before.splitlines(), after.splitlines()):
+        if line.startswith('+ '):
+            out.append(line[2:])
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    for name in ['before_dsi','after_dsi','before_common','after_common','before_panel','after_panel',
+                 'before_smmu','after_smmu','before_recorder','after_recorder']:
+        ap.add_argument('--' + name.replace('_','-'), dest=name, type=Path, required=True)
+    args = ap.parse_args()
+
+    bd, ad = read(args.before_dsi), read(args.after_dsi)
+    bc, ac = read(args.before_common), read(args.after_common)
+    bp, apanel = read(args.before_panel), read(args.after_panel)
+    bs, ass = read(args.before_smmu), read(args.after_smmu)
+    br, ar = read(args.before_recorder), read(args.after_recorder)
+
+    if bs != ass:
+        raise SystemExit('Phase281 audit: arm-smmu.c changed unexpectedly')
+    if br != ar:
+        raise SystemExit('Phase281 audit: persistent recorder changed unexpectedly')
+    if bd == ad or bc == ac or bp == apanel:
+        raise SystemExit('Phase281 audit: an intended source did not change')
+
+    for line in added_lines(bd, ad):
+        for forbidden in ['writel(', 'writel_relaxed(', 'iowrite', 'writeq(', 'writeb(', 'DSI_W32(']:
+            if forbidden in line:
+                raise SystemExit('Phase281 DSI audit: register write added: ' + line.strip())
+
+    required_dsi = [
+        'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1',
+        'P276 281R0 q=%u %x %x %x %x %x %x',
+        'P276 281R1 q=%u %x %x %x %x %x %x',
+        'P276 281R2 q=2 %x %x %x %x',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 0);',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 1);',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);',
+    ]
+    required_common = [
+        'A52_PHASE281_BRIGHTNESS_MAPPING_TRACE_V1',
+        'P276 281BE l=%d c=%d o=%d',
+        'P276 281BM l=%d i=%d c=%d g=%x',
+        'P276 281BT r=%d l=%d g=%x',
+        'P276 281BO f=%d t=%d',
+    ]
+    required_panel = [
+        'A52_PHASE281_EARLY_50PCT_BRIGHTNESS_V1',
+        'vdd->br_info.common_br.bl_level = 128;',
+        'P276 281BI l=%d',
+        'P276 281BV i=%d g=%x %02x%02x%02x',
+    ]
+    for token in required_dsi:
+        if token not in ad:
+            raise SystemExit('Phase281 audit missing DSI token: ' + token)
+    for token in required_common:
+        if token not in ac:
+            raise SystemExit('Phase281 audit missing common brightness token: ' + token)
+    for token in required_panel:
+        if token not in apanel:
+            raise SystemExit('Phase281 audit missing panel brightness token: ' + token)
+
+    if 'vdd->br_info.common_br.bl_level = 255;' not in bp:
+        raise SystemExit('Phase281 audit: expected Phase280 default 255 not present before patch')
+    if 'vdd->br_info.common_br.bl_level = 255;' in apanel:
+        raise SystemExit('Phase281 audit: old 255 default survived')
+
+    q2 = ad.index('a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);')
+    latch = ad.index('P276 280Z q=2')
+    if q2 > latch:
+        raise SystemExit('Phase281 audit: q2 raw DSI snapshot is after retention latch')
+
+    print('Phase281 non-perturbation + brightness-scope audit: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/281_ci_build.sh
+++ b/scripts/281_ci_build.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+COMMON="$ROOT/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"
+PANEL="$ROOT/drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c"
+
+fail_report(){
+  set +e
+  rm -rf phase281-failure
+  mkdir -p phase281-failure/{source,logs,audit}
+  cp phase281-compile.log phase281-failure/logs/ 2>/dev/null || true
+  for f in "$SMMU" "$DSI" "$REC" "$COMMON" "$PANEL"; do
+    [ -f "$f" ] && cp "$f" phase281-failure/source/ || true
+  done
+  cp scripts/281_*.py phase281-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact hardware-validated Phase280 source first. Phase281
+# keeps all Phase280 SMMU evidence and timeout retention, adds only read-only
+# DSI controller snapshots, and separately changes the A52 panel's initial
+# logical brightness from 255 to 128 while tracing the complete mapping/TX path.
+bash scripts/280_ci_build.sh
+test -s phase280-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$SMMU" "$DSI" "$REC" "$COMMON" "$PANEL"; do test -s "$f"; done
+
+cp "$OUT/.config" /tmp/p281-base.config
+cp "$SMMU" /tmp/p281-smmu-before.c
+cp "$DSI" /tmp/p281-dsi-before.c
+cp "$REC" /tmp/p281-rec-before.c
+cp "$COMMON" /tmp/p281-common-before.c
+cp "$PANEL" /tmp/p281-panel-before.c
+
+python3 -m py_compile \
+  scripts/281_apply_dsi_dma_trace.py \
+  scripts/281_apply_brightness_trace.py \
+  scripts/281_check_dsi_dma_brightness_trace.py
+
+python3 scripts/281_apply_dsi_dma_trace.py --root "$ROOT"
+python3 scripts/281_apply_dsi_dma_trace.py --root "$ROOT" --check-only
+python3 scripts/281_apply_brightness_trace.py --root "$ROOT"
+python3 scripts/281_apply_brightness_trace.py --root "$ROOT" --check-only
+python3 scripts/281_check_dsi_dma_brightness_trace.py \
+  --before-dsi /tmp/p281-dsi-before.c --after-dsi "$DSI" \
+  --before-common /tmp/p281-common-before.c --after-common "$COMMON" \
+  --before-panel /tmp/p281-panel-before.c --after-panel "$PANEL" \
+  --before-smmu /tmp/p281-smmu-before.c --after-smmu "$SMMU" \
+  --before-recorder /tmp/p281-rec-before.c --after-recorder "$REC"
+
+# Preserve the Phase280 kernel configuration exactly.
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p281-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase281-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase281-out
+mkdir -p phase281-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase281-out/compile/Image
+cp "$OUT/.config" phase281-out/config/final.config
+cp /tmp/p281-base.config phase281-out/audit/phase280-final.config
+cp /tmp/p281-smmu-before.c phase281-out/audit/arm-smmu-before.c
+cp /tmp/p281-dsi-before.c phase281-out/audit/dsi-ctrl-before.c
+cp /tmp/p281-rec-before.c phase281-out/audit/recorder-before.c
+cp /tmp/p281-common-before.c phase281-out/audit/ss-dsi-panel-common-before.c
+cp /tmp/p281-panel-before.c phase281-out/audit/ss-dsi-panel-a52-before.c
+cp phase281-compile.log phase281-out/audit/
+cp scripts/281_apply_dsi_dma_trace.py phase281-out/audit/
+cp scripts/281_apply_brightness_trace.py phase281-out/audit/
+cp scripts/281_check_dsi_dma_brightness_trace.py phase281-out/audit/
+cp "$SMMU" phase281-out/source/arm-smmu.c
+cp "$DSI" phase281-out/source/dsi_ctrl.c
+cp "$REC" phase281-out/source/a52_ack_secure_flight_recorder.c
+cp "$COMMON" phase281-out/source/ss_dsi_panel_common.c
+cp "$PANEL" phase281-out/source/ss_dsi_panel_S6E3FC3_AMS646YD01.c
+
+gzip -n -c "$IMAGE" > phase281-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase280-out/package/boot.img \
+  --kernel phase281-out/package/Image.gz \
+  --output phase281-out/package/boot.img \
+  --report phase281-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase281-out')
+idn={
+ 'phase':'281',
+ 'name':'DSI-DMA-CONSUMPTION-BRIGHTNESS-TRACE',
+ 'git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,
+ 'base':'exact hardware-validated Phase280 retained SMMU timeout evidence',
+ 'smmu_state_changed':False,
+ 'mapping_or_tlb_changed':False,
+ 'timeout_recovery_changed':False,
+ 'dsi_register_writes_added':False,
+ 'display_behavior_change':'A52 panel initial logical brightness 255 -> 128 only',
+ 'brightness_note':'128 is 50% of the prior logical 255 default; panel luminance is table-mapped and need not be linear',
+ 'dsi_snapshot_points':{
+   '0':'immediately before high-level kickoff_command call',
+   '1':'immediately after kickoff_command returns, after its DMA programming/SW trigger path',
+   '2':'DMA timeout, before interrupt/error handling and before Phase280 retention latch'
+ },
+ 'record_schema':{
+   '281R0':'q then DSI_STATUS,FIFO_STATUS,COMMAND_MODE_DMA_CTRL,DMA_FIFO_CTRL,DMA_SW_TRIGGER,INT_CTRL',
+   '281R1':'q then ACK_ERR_STATUS,TIMEOUT_STATUS,LANE_STATUS,DLN0_PHY_ERR,AXI2AHB_CTRL,VBIF_CTRL',
+   '281R2':'q=2 then DMA_CMD_OFFSET,DMA_CMD_LENGTH,CLK_CTRL,CLK_STATUS',
+   '281BE':'brightness entry: requested level,current logical level,origin',
+   '281BM':'mapped brightness: logical level,cd_idx,cd_level,gm2_wrdisbv',
+   '281BV':'A52 panel WRDISBV command index,gm2_wrdisbv,and exact first 3 tx bytes',
+   '281BT':'ss_send_cmd return code plus logical level and gm2_wrdisbv',
+   '281BO':'backlight-device override from/to',
+   '281BI':'A52 panel initialized logical brightness'
+ },
+ 'hardware_question':'Does the DSI controller show evidence of command-DMA consumption/progress between trigger and timeout, and does the A52 0x51 brightness payload get built and transmitted at logical 128 or get overridden/fail in the same DMA path?',
+ 'interpretation':{
+   'programming':'q1 core/FIFO state differs from q0 as expected => low-level kickoff programmed the controller',
+   'consumption':'FIFO/status transition q1->q2 without DMA_DONE may indicate partial controller progress; no transition strengthens fetch/start stall',
+   'controller_error':'ACK/TIMEOUT/LANE/PHY fields becoming nonzero identify controller/link-side failure',
+   'interconnect':'stable clean link/error state with no consumption keeps AXI/VBIF/interconnect/coherency/controller-fetch path high priority',
+   'brightness':'281BV shows exact command byte and WRDISBV bytes; 281BT gives Samsung send return; 281BO reveals later logical override'
+ }
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=[
+ 'compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json',
+ 'audit/phase280-final.config','audit/arm-smmu-before.c','audit/dsi-ctrl-before.c','audit/recorder-before.c',
+ 'audit/ss-dsi-panel-common-before.c','audit/ss-dsi-panel-a52-before.c','audit/phase281-compile.log',
+ 'audit/281_apply_dsi_dma_trace.py','audit/281_apply_brightness_trace.py','audit/281_check_dsi_dma_brightness_trace.py',
+ 'source/arm-smmu.c','source/dsi_ctrl.c','source/a52_ack_secure_flight_recorder.c',
+ 'source/ss_dsi_panel_common.c','source/ss_dsi_panel_S6E3FC3_AMS646YD01.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files: f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase281-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r=Path('phase281-out')
+d=(r/'source/dsi_ctrl.c').read_text()
+c=(r/'source/ss_dsi_panel_common.c').read_text()
+p=(r/'source/ss_dsi_panel_S6E3FC3_AMS646YD01.c').read_text()
+img=(r/'compile/Image').read_bytes()
+source_required=[
+ 'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1','A52_PHASE281_BRIGHTNESS_MAPPING_TRACE_V1',
+ 'A52_PHASE281_EARLY_50PCT_BRIGHTNESS_V1','vdd->br_info.common_br.bl_level = 128;',
+ 'a52_p281_dsi_dma_snapshot(dsi_ctrl, 0);','a52_p281_dsi_dma_snapshot(dsi_ctrl, 1);',
+ 'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);']
+for m in source_required:
+ if m not in d+c+p: raise SystemExit('Phase281 source marker missing: '+m)
+runtime=[
+ 'P276 281R0 q=%u %x %x %x %x %x %x','P276 281R1 q=%u %x %x %x %x %x %x',
+ 'P276 281R2 q=2 %x %x %x %x','P276 281BE l=%d c=%d o=%d',
+ 'P276 281BM l=%d i=%d c=%d g=%x','P276 281BT r=%d l=%d g=%x',
+ 'P276 281BO f=%d t=%d','P276 281BI l=%d','P276 281BV i=%d g=%x %02x%02x%02x',
+ 'P276 280Z q=2']
+for m in runtime:
+ if m.encode() not in img: raise SystemExit('Phase281 runtime marker missing from Image: '+m)
+print('Phase281 compiled DSI + brightness marker audit: PASS')
+PY
+
+python3 scripts/281_apply_dsi_dma_trace.py --root "$ROOT" --check-only
+python3 scripts/281_apply_brightness_trace.py --root "$ROOT" --check-only
+python3 scripts/281_check_dsi_dma_brightness_trace.py \
+  --before-dsi /tmp/p281-dsi-before.c --after-dsi "$DSI" \
+  --before-common /tmp/p281-common-before.c --after-common "$COMMON" \
+  --before-panel /tmp/p281-panel-before.c --after-panel "$PANEL" \
+  --before-smmu /tmp/p281-smmu-before.c --after-smmu "$SMMU" \
+  --before-recorder /tmp/p281-rec-before.c --after-recorder "$REC"
+
+trap - EXIT
+echo 'Phase281 DSI DMA consumption + brightness trace build/repack: PASS'


### PR DESCRIPTION
## What changed
- Retains the exact hardware-validated Phase 280 SMMU and timeout-retention evidence.
- Adds compact, read-only DSI command-DMA register snapshots at q=0 pre-kickoff, q=1 post-kickoff, and q=2 timeout.
- Captures FIFO/DMA state, interrupt state, ACK/timeout state, lane/PHY state, AXI2AHB/VBIF state, and timeout-time DMA offset/length + clocks.
- Traces Samsung brightness entry, logical mapping, `gm2_wrdisbv`, exact first three WRDISBV command bytes, `ss_send_cmd()` return code, and backlight-device overrides.
- Changes only the A52 panel's initial logical brightness from 255 to 128 to reduce repeated boot-logo exposure. This is a logical 50% default, not a claim of linear 50% panel luminance.

## Why
Phase 280 proved the failing DSI command IOVA range translates contiguously under the live TTBR0/TCR and does not generate a new SMMU fault, yet command DMA never completes. Phase 281 moves the diagnostic boundary downstream into controller consumption/progress while also determining whether the requested lower brightness is actually mapped into a DCS brightness payload and whether that send fails in the same DSI path.

## Non-perturbation scope
- No SMMU, mapping, TLB, stream-routing, timeout-recovery, or persistent-recorder change.
- No DSI register writes are added by the Phase 281 trace.
- The only intended display behavior change is the initial logical brightness 255 -> 128.

## Validation
- Phase 281 Python scripts compile locally.
- Build script passes `bash -n` locally.
- Workflow YAML parses locally.
- The DSI patch applies and passes its checker against the exact compiled Phase 280 `dsi_ctrl.c` from the successful Phase 280 artifact.
- GitHub Actions performs full Phase 280 reconstruction, Phase 281 source-scope audit, kernel compile, repack, runtime-marker audit, and SHA256 verification.