### PR TITLE
Phase 282: Golden FIFO vs memory DSI DMA A/B

### DIFF
--- a/.github/workflows/282-a52-golden-fifo-ab.yml
+++ b/.github/workflows/282-a52-golden-fifo-ab.yml
@@ -1,0 +1,87 @@
+name: 282 - A52 Golden FIFO vs memory DMA A/B
+run-name: Phase 282 - Golden FIFO vs memory DMA A/B
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase282-golden-fifo-ab-v1
+    paths:
+      - .github/workflows/282-a52-golden-fifo-ab.yml
+      - scripts/282_apply_golden_fifo_ab.py
+      - scripts/282_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase281-dsi-dma-brightness-trace-v1
+    paths:
+      - .github/workflows/282-a52-golden-fifo-ab.yml
+      - scripts/282_apply_golden_fifo_ab.py
+      - scripts/282_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase282-golden-fifo-ab-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase281 and build Golden FIFO A/B probe
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase282 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct exact Phase281 and build Phase282 candidate
+        run: bash scripts/282_ci_build.sh
+      - name: Upload Phase282 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase282-GOLDEN-FIFO-AB-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase282-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase282-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/282_apply_golden_fifo_ab.py
+++ b/scripts/282_apply_golden_fifo_ab.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_PHASE282_GOLDEN_FIFO_AB_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    for required in [
+        'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1',
+        'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1',
+        'P276 281R0 q=%u %x %x %x %x %x %x',
+        'P276 280Z q=2',
+    ]:
+        if required not in text:
+            raise SystemExit('Phase282 prerequisite missing: ' + required)
+
+    text = replace_one(
+        text,
+        'static DEFINE_MUTEX(dsi_ctrl_list_lock);\n',
+        'static DEFINE_MUTEX(dsi_ctrl_list_lock);\n'
+        '\n/* ' + MARK + '\n'
+        ' * Golden TouchGrass uses the controller FIFO/TPG path as a supported\n'
+        ' * alternative to system-memory command fetch (for example in secure\n'
+        ' * mode). Phase282 redirects exactly one deep-window 0x29 Generic Long\n'
+        ' * Write with tx_len=3 to FIFO_STORE, then all later commands use the\n'
+        ' * untouched normal policy. This creates an in-boot FIFO-vs-memory-DMA\n'
+        ' * A/B test while preserving the Phase281 q0/q1/q2 snapshots.\n'
+        ' */\n'
+        'static atomic_t a52_p282_fifo_once = ATOMIC_INIT(0);\n'
+        'static atomic_t a52_p282_fifo_inflight = ATOMIC_INIT(0);\n',
+        'Phase282 globals')
+
+    old = '''\tif (a52_p276r_deep_active())\n\t\ta52_ackfr_record("P276 D M s=0 f=%x mt=%u l=%u", flags ? *flags : 0, (unsigned int)msg->type, (unsigned int)msg->tx_len);\n\n\t/* Select the tx mode to transfer the command */\n\tdsi_message_setup_tx_mode(dsi_ctrl, msg->tx_len, flags);\n\n\t/* Validate the mode before sending the command */\n'''
+    new = '''\tif (a52_p276r_deep_active())\n\t\ta52_ackfr_record("P276 D M s=0 f=%x mt=%u l=%u", flags ? *flags : 0, (unsigned int)msg->type, (unsigned int)msg->tx_len);\n\tif (a52_p276r_deep_active() && msg->tx_buf && msg->tx_len == 3) {\n\t\tconst u8 *a52_p282_tx = msg->tx_buf;\n\t\ta52_ackfr_record("P276 282P t=%02x f=%x b=%02x%02x%02x",\n\t\t\tmsg->type, flags ? *flags : 0, a52_p282_tx[0],\n\t\t\ta52_p282_tx[1], a52_p282_tx[2]);\n\t}\n\n\t/* Select the tx mode to transfer the command */\n\tdsi_message_setup_tx_mode(dsi_ctrl, msg->tx_len, flags);\n\n\t/*\n\t * One-shot Golden A/B probe. 0x29 == MIPI_DSI_GENERIC_LONG_WRITE.\n\t * Keep the same packet construction, trigger and completion machinery;\n\t * only bypass external command-buffer memory fetch for this one command.\n\t */\n\tif (a52_p276r_deep_active() && msg->type == 0x29 &&\n\t\t\tmsg->tx_len == 3 && (*flags & DSI_CTRL_CMD_FETCH_MEMORY) &&\n\t\t\tatomic_cmpxchg(&a52_p282_fifo_once, 0, 1) == 0) {\n\t\t*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY;\n\t\t*flags |= DSI_CTRL_CMD_FIFO_STORE;\n\t\tatomic_set(&a52_p282_fifo_inflight, 1);\n\t\ta52_ackfr_record("P276 282A m=fifo f=%x", *flags);\n\t}\n\n\t/* Validate the mode before sending the command */\n'''
+    text = replace_one(text, old, new, 'Phase282 payload + one-shot mode override')
+
+    old = '''\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D M s=3 p=1 r=%d", rc);\n\tif (rc) {\n\t\tDSI_CTRL_ERR(dsi_ctrl, "failed to copy message, rc=%d\\n", rc);\n\t\tgoto error;\n\t}\n\n\tif ((msg->flags & MIPI_DSI_MSG_LASTCOMMAND))\n'''
+    new = '''\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D M s=3 p=1 r=%d", rc);\n\tif (rc) {\n\t\tDSI_CTRL_ERR(dsi_ctrl, "failed to copy message, rc=%d\\n", rc);\n\t\tgoto error;\n\t}\n\tif (a52_p276r_deep_active() && buffer && length == 8)\n\t\ta52_ackfr_record("P276 282E %02x%02x%02x%02x%02x%02x%02x%02x",\n\t\t\tbuffer[0], buffer[1], buffer[2], buffer[3],\n\t\t\tbuffer[4], buffer[5], buffer[6], buffer[7]);\n\n\tif ((msg->flags & MIPI_DSI_MSG_LASTCOMMAND))\n'''
+    text = replace_one(text, old, new, 'Phase282 encoded packet trace')
+
+    old = '''\t\tif (a52_p276r_deep_active() && dsi_hw_ops.get_error_status)\n\t\t\ta52_ackfr_record("P276 H E e=%llx",\n\t\t\t\t(unsigned long long)dsi_hw_ops.get_error_status(&dsi_ctrl->hw));\n\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n'''
+    new = '''\t\tif (a52_p276r_deep_active() && dsi_hw_ops.get_error_status)\n\t\t\ta52_ackfr_record("P276 H E e=%llx",\n\t\t\t\t(unsigned long long)dsi_hw_ops.get_error_status(&dsi_ctrl->hw));\n\t\tif (a52_p276r_deep_active() &&\n\t\t\t\tatomic_read(&a52_p282_fifo_inflight))\n\t\t\ta52_ackfr_record("P276 282F a=0 t=1");\n\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_ackfr_record("P276 282Z q=2");\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n'''
+    text = replace_one(text, old, new, 'Phase282 timeout result before retention')
+
+    old = '''\t\t\tdsi_ctrl_dma_cmd_wait_for_done(&dsi_ctrl->dma_cmd_wait);\n\t\t\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D K w=1");\n\t\t}\n\n\t\tdsi_ctrl_mask_overflow(dsi_ctrl, false);\n'''
+    new = '''\t\t\tdsi_ctrl_dma_cmd_wait_for_done(&dsi_ctrl->dma_cmd_wait);\n\t\t\tif (a52_p276r_deep_active() &&\n\t\t\t\t\tatomic_xchg(&a52_p282_fifo_inflight, 0))\n\t\t\t\ta52_ackfr_record("P276 282F a=%d t=0",\n\t\t\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\t\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D K w=1");\n\t\t}\n\n\t\tdsi_ctrl_mask_overflow(dsi_ctrl, false);\n'''
+    text = replace_one(text, old, new, 'Phase282 FIFO success result')
+    return text
+
+
+def validate(text: str) -> None:
+    required = [
+        MARK,
+        'static atomic_t a52_p282_fifo_once = ATOMIC_INIT(0);',
+        'P276 282P t=%02x f=%x b=%02x%02x%02x',
+        'msg->type == 0x29',
+        '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY;',
+        '*flags |= DSI_CTRL_CMD_FIFO_STORE;',
+        'P276 282A m=fifo f=%x',
+        'P276 282E %02x%02x%02x%02x%02x%02x%02x%02x',
+        'P276 282F a=0 t=1',
+        'P276 282F a=%d t=0',
+        'P276 282Z q=2',
+        'P276 280Z q=2',
+        'a52_ackfr_retain_timeout_snapshot();',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);',
+    ]
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase282 marker missing: ' + token)
+    if text.index('P276 282Z q=2') > text.index('P276 280Z q=2'):
+        raise SystemExit('Phase282 marker must precede inherited Phase280 freeze marker')
+    if text.index('a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);') > text.index('P276 282Z q=2'):
+        raise SystemExit('Phase281 pristine q2 snapshot must precede Phase282 timeout marker')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    path = args.root / DSI
+    if not path.is_file():
+        raise SystemExit(f'missing source: {path}')
+    text = path.read_text()
+    if not args.check_only:
+        text = patch(text)
+        path.write_text(text)
+    validate(text)
+    print('Phase282 Golden FIFO-vs-memory DMA A/B probe: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/282_ci_build.sh
+++ b/scripts/282_ci_build.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+COMMON="$ROOT/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"
+PANEL="$ROOT/drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c"
+
+fail_report(){
+  set +e
+  rm -rf phase282-failure
+  mkdir -p phase282-failure/{source,logs,audit}
+  cp phase282-compile.log phase282-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$SMMU" "$REC" "$COMMON" "$PANEL"; do
+    [ -f "$f" ] && cp "$f" phase282-failure/source/ || true
+  done
+  cp scripts/282_apply_golden_fifo_ab.py phase282-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct exact Phase281 first. Phase282 changes only dsi_ctrl.c and uses
+# the existing TouchGrass FIFO/TPG command transport for one diagnostic packet.
+bash scripts/281_ci_build.sh
+test -s phase281-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DSI" "$SMMU" "$REC" "$COMMON" "$PANEL"; do test -s "$f"; done
+
+cp "$OUT/.config" /tmp/p282-base.config
+cp "$DSI" /tmp/p282-dsi-before.c
+cp "$SMMU" /tmp/p282-smmu-before.c
+cp "$REC" /tmp/p282-rec-before.c
+cp "$COMMON" /tmp/p282-common-before.c
+cp "$PANEL" /tmp/p282-panel-before.c
+
+python3 -m py_compile scripts/282_apply_golden_fifo_ab.py
+python3 scripts/282_apply_golden_fifo_ab.py --root "$ROOT"
+python3 scripts/282_apply_golden_fifo_ab.py --root "$ROOT" --check-only
+
+# This phase must not alter SMMU, recorder implementation, Samsung brightness
+# mapping, panel source, kernel config, DT, or any unrelated subsystem.
+cmp -s /tmp/p282-smmu-before.c "$SMMU"
+cmp -s /tmp/p282-rec-before.c "$REC"
+cmp -s /tmp/p282-common-before.c "$COMMON"
+cmp -s /tmp/p282-panel-before.c "$PANEL"
+! cmp -s /tmp/p282-dsi-before.c "$DSI"
+
+grep -Fq 'A52_PHASE282_GOLDEN_FIFO_AB_V1' "$DSI"
+grep -Fq 'msg->type == 0x29' "$DSI"
+grep -Fq '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY;' "$DSI"
+grep -Fq '*flags |= DSI_CTRL_CMD_FIFO_STORE;' "$DSI"
+grep -Fq 'P276 282P t=%02x f=%x b=%02x%02x%02x' "$DSI"
+grep -Fq 'P276 282E %02x%02x%02x%02x%02x%02x%02x%02x' "$DSI"
+grep -Fq 'P276 282F a=0 t=1' "$DSI"
+grep -Fq 'P276 282F a=%d t=0' "$DSI"
+grep -Fq 'P276 282Z q=2' "$DSI"
+grep -Fq 'P276 280Z q=2' "$DSI"
+grep -Fq 'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);' "$DSI"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p282-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase282-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase282-out
+mkdir -p phase282-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase282-out/compile/Image
+cp "$OUT/.config" phase282-out/config/final.config
+cp /tmp/p282-base.config phase282-out/audit/phase281-final.config
+cp /tmp/p282-dsi-before.c phase282-out/audit/dsi-ctrl-before.c
+cp /tmp/p282-smmu-before.c phase282-out/audit/arm-smmu-before.c
+cp /tmp/p282-rec-before.c phase282-out/audit/recorder-before.c
+cp /tmp/p282-common-before.c phase282-out/audit/ss-dsi-panel-common-before.c
+cp /tmp/p282-panel-before.c phase282-out/audit/ss-dsi-panel-a52-before.c
+cp phase282-compile.log phase282-out/audit/
+cp scripts/282_apply_golden_fifo_ab.py phase282-out/audit/
+cp "$DSI" phase282-out/source/dsi_ctrl.c
+cp "$SMMU" phase282-out/source/arm-smmu.c
+cp "$REC" phase282-out/source/a52_ack_secure_flight_recorder.c
+cp "$COMMON" phase282-out/source/ss_dsi_panel_common.c
+cp "$PANEL" phase282-out/source/ss_dsi_panel_S6E3FC3_AMS646YD01.c
+
+gzip -n -c "$IMAGE" > phase282-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase281-out/package/boot.img \
+  --kernel phase282-out/package/Image.gz \
+  --output phase282-out/package/boot.img \
+  --report phase282-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase282-out')
+idn={
+ 'phase':'282',
+ 'name':'GOLDEN-FIFO-VS-MEMORY-DMA-AB',
+ 'git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,
+ 'base':'exact Phase281 DSI DMA consumption + brightness trace',
+ 'golden_runtime_evidence':'TouchGrass completes Samsung brightness writes, including logical 128 -> gm2_wrdisbv 422 (0x01a6)',
+ 'golden_source_evidence':'TouchGrass supports FIFO/TPG command transport and selects FIFO_STORE instead of FETCH_MEMORY in secure mode',
+ 'phase281_hardware_evidence':'first retained stalled message: type decimal 41 = 0x29 Generic Long Write, tx_len=3; memory DMA enters persistent non-completing state',
+ 'functional_change':'one-shot diagnostic: first deep-window 0x29 tx_len=3 memory command is routed through existing FIFO_STORE transport; all later commands retain normal policy',
+ 'smmu_state_changed':False,
+ 'mapping_or_tlb_changed':False,
+ 'recorder_implementation_changed':False,
+ 'brightness_mapping_changed_from_phase281':False,
+ 'timeout_recovery_changed':False,
+ 'phase281_q2_snapshot_preserved':True,
+ 'record_schema':{
+   '282P':'3-byte message identity: type, pre-policy flags, raw payload bytes',
+   '282A':'one-shot FIFO A/B selection and resulting flags',
+   '282E':'exact 8-byte encoded packet after MIPI packet construction/padding',
+   '282F':'FIFO outcome: a=DMA IRQ/completion atomic, t=timeout boolean',
+   '282Z':'Phase282 timeout boundary immediately before inherited Phase280 freeze'
+ },
+ 'decision':{
+   'fifo_success_then_memory_timeout':'DSI core/trigger/completion/link can progress without external command-memory fetch; isolate external DMA fetch/interconnect/coherency path',
+   'fifo_timeout':'failure is downstream/shared with FIFO path; prioritize DSI core clocks/power/state machine/PHY rather than external memory fetch',
+   'fifo_success_and_boot_progress':'the bypassed first generic command identifies the memory-DMA transport as causal; inspect subsequent behavior and retained payloads'
+ }
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=[
+ 'compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json',
+ 'audit/phase281-final.config','audit/dsi-ctrl-before.c','audit/arm-smmu-before.c','audit/recorder-before.c',
+ 'audit/ss-dsi-panel-common-before.c','audit/ss-dsi-panel-a52-before.c','audit/phase282-compile.log',
+ 'audit/282_apply_golden_fifo_ab.py','source/dsi_ctrl.c','source/arm-smmu.c',
+ 'source/a52_ack_secure_flight_recorder.c','source/ss_dsi_panel_common.c',
+ 'source/ss_dsi_panel_S6E3FC3_AMS646YD01.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files: f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase282-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r=Path('phase282-out')
+d=(r/'source/dsi_ctrl.c').read_text(); img=(r/'compile/Image').read_bytes()
+for m in [
+ 'A52_PHASE282_GOLDEN_FIFO_AB_V1','msg->type == 0x29',
+ '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY;','*flags |= DSI_CTRL_CMD_FIFO_STORE;',
+ 'a52_p281_dsi_dma_snapshot(dsi_ctrl, 0);','a52_p281_dsi_dma_snapshot(dsi_ctrl, 1);',
+ 'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);','P276 280Z q=2']:
+ if m not in d: raise SystemExit('Phase282 source marker missing: '+m)
+for m in [
+ 'P276 282P t=%02x f=%x b=%02x%02x%02x','P276 282A m=fifo f=%x',
+ 'P276 282E %02x%02x%02x%02x%02x%02x%02x%02x',
+ 'P276 282F a=0 t=1','P276 282F a=%d t=0','P276 282Z q=2','P276 280Z q=2']:
+ if m.encode() not in img: raise SystemExit('Phase282 runtime marker missing from Image: '+m)
+print('Phase282 compiled Golden FIFO A/B marker audit: PASS')
+PY
+
+python3 scripts/282_apply_golden_fifo_ab.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase282 Golden FIFO-vs-memory DMA A/B build/repack: PASS'


### PR DESCRIPTION
## Purpose

Use the now-narrow Phase281 failure point and the working TouchGrass Golden implementation to distinguish external command-memory fetch failure from a downstream DSI controller/link failure in one hardware boot.

## Evidence entering Phase282

Phase281 shows the first retained failing transfer is a 3-byte Generic Long Write (`msg->type` decimal 41 = `0x29`, `tx_len=3`). The controller state changes immediately after kickoff and remains non-completing until the ~200 ms timeout. Phase280/281 SMMU translation/root/fault evidence remains clean and stable.

The TouchGrass Golden source already contains a supported FIFO/TPG command path. In secure mode it deliberately replaces `DSI_CTRL_CMD_FETCH_MEMORY` with `DSI_CTRL_CMD_FIFO_STORE`; that path writes the encoded packet into the DSI controller FIFO/TPG registers, then uses the same command engine, SW trigger, and completion machinery.

## Phase282 experiment

For exactly one deep-window `0x29` Generic Long Write with `tx_len=3` that would normally use memory fetch:

- record its raw 3-byte payload;
- run normal MIPI packet construction and record the exact 8-byte encoded packet;
- replace `FETCH_MEMORY` with the existing Golden `FIFO_STORE` transport for that command only;
- return all subsequent commands to the untouched normal transport policy;
- preserve Phase281 q0/q1/q2 controller snapshots and the Phase280 timeout retention latch.

No SMMU, mapping/TLB, recorder implementation, Samsung brightness mapping, panel source, DT, kernel config, timeout recovery, or vendor-blob trust policy is changed.

## Decision rule

- FIFO command completes, then a subsequent memory-backed command times out: isolate the problem to external DSI command-memory fetch / interconnect / coherency before the internal FIFO path.
- FIFO command also times out: move downstream/shared toward DSI core state, clocks/power, command engine, PHY/link, or completion generation.
- FIFO command completes and boot progresses substantially: the normal memory-backed DSI command transport is likely causal; use the retained raw/encoded command evidence to continue.

## Recorder markers

- `P276 282P`: raw 3-byte message type/flags/payload
- `P276 282A`: one-shot FIFO transport selected
- `P276 282E`: exact encoded 8-byte packet
- `P276 282F`: FIFO result, including timeout vs completion state
- `P276 282Z`: Phase282 timeout boundary before inherited `P276 280Z` retention freeze
