### PR TITLE
Phase 283: trace shared DSI engine clocks and PHY

### DIFF
--- a/.github/workflows/283-a52-dsi-shared-engine-phy-trace.yml
+++ b/.github/workflows/283-a52-dsi-shared-engine-phy-trace.yml
@@ -1,0 +1,87 @@
+name: 283 - A52 DSI shared engine clock PHY trace
+run-name: Phase 283 - DSI shared engine clock PHY trace
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase283-dsi-shared-engine-clock-trace-v1
+    paths:
+      - .github/workflows/283-a52-dsi-shared-engine-phy-trace.yml
+      - scripts/283_apply_shared_engine_phy_trace.py
+      - scripts/283_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase282-golden-fifo-ab-v1
+    paths:
+      - .github/workflows/283-a52-dsi-shared-engine-phy-trace.yml
+      - scripts/283_apply_shared_engine_phy_trace.py
+      - scripts/283_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase283-dsi-shared-engine-phy-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase282 and build shared DSI engine PHY trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase283 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct exact Phase282 and build Phase283 candidate
+        run: bash scripts/283_ci_build.sh
+      - name: Upload Phase283 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase283-DSI-SHARED-ENGINE-PHY-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase283-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase283-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/283b-a52-golden-handoff-complete-trace.yml
+++ b/.github/workflows/283b-a52-golden-handoff-complete-trace.yml
@@ -1,0 +1,88 @@
+name: 283B - A52 Golden handoff complete DSI trace
+run-name: Phase 283 - Golden handoff complete DSI shared-path trace
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase283-dsi-shared-engine-clock-trace-v1
+    paths:
+      - .github/workflows/283b-a52-golden-handoff-complete-trace.yml
+      - scripts/283_apply_shared_engine_phy_trace.py
+      - scripts/283b_apply_golden_handoff_trace.py
+      - scripts/283b_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase282-golden-fifo-ab-v1
+    paths:
+      - .github/workflows/283b-a52-golden-handoff-complete-trace.yml
+      - scripts/283_apply_shared_engine_phy_trace.py
+      - scripts/283b_apply_golden_handoff_trace.py
+      - scripts/283b_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase283b-golden-handoff-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase282 and build Golden handoff-complete trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase283 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct exact Phase282 and build Phase283 handoff-complete candidate
+        run: bash scripts/283b_ci_build.sh
+      - name: Upload Phase283 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase283-GOLDEN-HANDOFF-COMPLETE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase283b-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase283-GOLDEN-HANDOFF-FAILURE-${{ github.run_number }}
+          path: phase283b-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/283c-a52-golden-handoff-clock-header-fix.yml
+++ b/.github/workflows/283c-a52-golden-handoff-clock-header-fix.yml
@@ -1,0 +1,84 @@
+name: 283C - A52 Golden handoff complete trace
+run-name: Phase 283 - Golden handoff complete trace with clock-header fix
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase283-dsi-shared-engine-clock-trace-v1
+    paths:
+      - .github/workflows/283c-a52-golden-handoff-clock-header-fix.yml
+      - scripts/283c_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase282-golden-fifo-ab-v1
+    paths:
+      - .github/workflows/283c-a52-golden-handoff-clock-header-fix.yml
+      - scripts/283c_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase283c-golden-handoff-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase282 and build corrected Golden handoff trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase283 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct Phase282 and build corrected Phase283 candidate
+        run: bash scripts/283c_ci_build.sh
+      - name: Upload corrected Phase283 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase283-GOLDEN-HANDOFF-COMPLETE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase283b-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase283C-GOLDEN-HANDOFF-FAILURE-${{ github.run_number }}
+          path: phase283b-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/283_apply_shared_engine_phy_trace.py
+++ b/scripts/283_apply_shared_engine_phy_trace.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+PHY = Path('drivers/a52_display/msm/dsi/dsi_phy.c')
+MARK = 'A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_phy(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = replace_one(
+        text,
+        '#include "dsi_phy.h"\n',
+        '#include "dsi_phy.h"\n'
+        '#include <linux/a52_ack_secure_flight_recorder.h>\n'
+        'extern bool a52_p276r_deep_active(void);\n',
+        'Phase283 PHY recorder include')
+
+    anchor = 'static DEFINE_MUTEX(dsi_phy_list_lock);\n'
+    helper = r'''static DEFINE_MUTEX(dsi_phy_list_lock);
+
+/* A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1
+ * Read-only shared-path snapshot after Phase282 proved that both system-memory
+ * command fetch and the Golden FIFO/TPG transport time out. The v4.x register
+ * offsets below are taken directly from TouchGrass dsi_phy_hw_v4_0.c. No PHY
+ * or DSI register is written.
+ */
+#define A52_P283_PHY_CLK_CFG0       0x010
+#define A52_P283_PHY_CLK_CFG1       0x014
+#define A52_P283_PHY_GLBL_CTRL      0x018
+#define A52_P283_PHY_VREG_CTRL0     0x020
+#define A52_P283_PHY_CTRL0          0x024
+#define A52_P283_PHY_CTRL1          0x028
+#define A52_P283_PHY_CTRL2          0x02c
+#define A52_P283_PHY_CTRL3          0x030
+#define A52_P283_PHY_PLL_CTRL       0x03c
+#define A52_P283_PHY_LANE_CTRL0     0x0a0
+#define A52_P283_PHY_LANE_CTRL1     0x0a4
+#define A52_P283_PHY_LANE_CTRL2     0x0a8
+#define A52_P283_PHY_LANE_CTRL3     0x0ac
+#define A52_P283_PHY_LANE_CTRL4     0x0b0
+#define A52_P283_PHY_VREG_CTRL1     0x110
+#define A52_P283_PHY_CTRL4          0x114
+#define A52_P283_PHY_STATUS         0x140
+#define A52_P283_PHY_LANE_STATUS0   0x148
+#define A52_P283_PHY_LANE_STATUS1   0x14c
+
+void a52_p283_phy_snapshot(unsigned int index, unsigned int point)
+{
+	struct dsi_phy_list_item *item;
+	struct msm_dsi_phy *phy = NULL;
+	void __iomem *base;
+	u32 ver;
+
+	if (!a52_p276r_deep_active())
+		return;
+
+	mutex_lock(&dsi_phy_list_lock);
+	list_for_each_entry(item, &dsi_phy_list, list) {
+		if (item->phy && item->phy->index == index) {
+			phy = item->phy;
+			break;
+		}
+	}
+	mutex_unlock(&dsi_phy_list_lock);
+
+	if (!phy || !phy->ver_info || !phy->hw.base) {
+		a52_ackfr_record("P276 283PX q=%u i=%u x=0", point, index);
+		return;
+	}
+
+	ver = phy->ver_info->version;
+	if (ver != DSI_PHY_VERSION_4_0 && ver != DSI_PHY_VERSION_4_1) {
+		a52_ackfr_record("P276 283PX q=%u i=%u v=%u", point, index, ver);
+		return;
+	}
+
+	base = phy->hw.base;
+	a52_ackfr_record("P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x", point,
+		ver, phy->power_state, phy->dsi_phy_state,
+		readl_relaxed(base + A52_P283_PHY_PLL_CTRL),
+		readl_relaxed(base + A52_P283_PHY_STATUS),
+		readl_relaxed(base + A52_P283_PHY_LANE_STATUS0),
+		readl_relaxed(base + A52_P283_PHY_LANE_STATUS1));
+	a52_ackfr_record("P276 283P1 q=%u %x %x %x %x %x %x", point,
+		readl_relaxed(base + A52_P283_PHY_CLK_CFG0),
+		readl_relaxed(base + A52_P283_PHY_CLK_CFG1),
+		readl_relaxed(base + A52_P283_PHY_GLBL_CTRL),
+		readl_relaxed(base + A52_P283_PHY_VREG_CTRL0),
+		readl_relaxed(base + A52_P283_PHY_VREG_CTRL1),
+		readl_relaxed(base + A52_P283_PHY_CTRL0));
+	a52_ackfr_record("P276 283P2 q=%u %x %x %x %x %x", point,
+		readl_relaxed(base + A52_P283_PHY_CTRL1),
+		readl_relaxed(base + A52_P283_PHY_CTRL2),
+		readl_relaxed(base + A52_P283_PHY_CTRL3),
+		readl_relaxed(base + A52_P283_PHY_CTRL4),
+		readl_relaxed(base + A52_P283_PHY_LANE_CTRL0));
+	a52_ackfr_record("P276 283P3 q=%u %x %x %x %x", point,
+		readl_relaxed(base + A52_P283_PHY_LANE_CTRL1),
+		readl_relaxed(base + A52_P283_PHY_LANE_CTRL2),
+		readl_relaxed(base + A52_P283_PHY_LANE_CTRL3),
+		readl_relaxed(base + A52_P283_PHY_LANE_CTRL4));
+}
+
+'''
+    return replace_one(text, anchor, helper, 'Phase283 PHY helper insertion')
+
+
+def patch_dsi(text: str) -> str:
+    if MARK in text:
+        return text
+    for required in [
+        'A52_PHASE282_GOLDEN_FIFO_AB_V1',
+        'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1',
+        'P276 282A m=fifo f=%x',
+        'P276 D K s=6 p=0',
+        'P276 D K s=6 p=1',
+        'a52_p281_dsi_dma_snapshot(dsi_ctrl, 2);',
+    ]:
+        if required not in text:
+            raise SystemExit('Phase283 DSI prerequisite missing: ' + required)
+
+    text = replace_one(
+        text,
+        'static atomic_t a52_p282_fifo_inflight = ATOMIC_INIT(0);\n',
+        'static atomic_t a52_p282_fifo_inflight = ATOMIC_INIT(0);\n'
+        '\n/* ' + MARK + '\n'
+        ' * Phase282 proved the Golden FIFO transport times out too. Phase283\n'
+        ' * therefore traces only the shared controller/clock/PHY path.\n'
+        ' */\n'
+        'extern void a52_p283_phy_snapshot(unsigned int index, unsigned int point);\n'
+        '\nstatic unsigned int a52_p283_clk_enabled(struct clk *clk)\n'
+        '{\n'
+        '\treturn clk ? (__clk_is_enabled(clk) ? 1 : 0) : 2;\n'
+        '}\n'
+        '\nstatic unsigned long a52_p283_clk_rate(struct clk *clk)\n'
+        '{\n'
+        '\treturn clk ? clk_get_rate(clk) : 0;\n'
+        '}\n'
+        '\nstatic void a52_p283_shared_snapshot(struct dsi_ctrl *dsi_ctrl,\n'
+        '\t\tunsigned int point)\n'
+        '{\n'
+        '\tvoid __iomem *base;\n'
+        '\tstruct dsi_ctrl_state_info *s;\n'
+        '\tu32 ce = 0;\n'
+        '\n\tif (!a52_p276r_deep_active() || !dsi_ctrl || !dsi_ctrl->hw.base)\n'
+        '\t\treturn;\n'
+        '\n\tbase = dsi_ctrl->hw.base;\n'
+        '\ts = &dsi_ctrl->current_state;\n'
+        '\ta52_ackfr_record("P276 283S q=%u v=%u p=%u c=%u m=%u h=%u t=%u", point,\n'
+        '\t\tdsi_ctrl->version, s->power_state, s->controller_state,\n'
+        '\t\ts->cmd_engine_state, s->host_initialized, s->tpg_enabled);\n'
+        '\ta52_ackfr_record("P276 283R0 q=%u %x %x %x %x %x %x", point,\n'
+        '\t\treadl_relaxed(base + DSI_CTRL),\n'
+        '\t\treadl_relaxed(base + DSI_TRIG_CTRL),\n'
+        '\t\treadl_relaxed(base + DSI_TEST_PATTERN_GEN_CTRL),\n'
+        '\t\treadl_relaxed(base + DSI_TPG_DMA_FIFO_STATUS),\n'
+        '\t\treadl_relaxed(base + DSI_DMA_CMD_LENGTH),\n'
+        '\t\treadl_relaxed(base + DSI_INT_CTRL));\n'
+        '\ta52_ackfr_record("P276 283R1 q=%u %x %x %x %x %x %x", point,\n'
+        '\t\treadl_relaxed(base + DSI_STATUS),\n'
+        '\t\treadl_relaxed(base + DSI_FIFO_STATUS),\n'
+        '\t\treadl_relaxed(base + DSI_LANE_STATUS),\n'
+        '\t\treadl_relaxed(base + DSI_CLK_CTRL),\n'
+        '\t\treadl_relaxed(base + DSI_CLK_STATUS),\n'
+        '\t\treadl_relaxed(base + DSI_PHY_SW_RESET));\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.core_clks.mdp_core_clk) << 0;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.core_clks.iface_clk) << 2;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.core_clks.core_mmss_clk) << 4;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.core_clks.bus_clk) << 6;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.core_clks.mnoc_clk) << 8;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.hs_link_clks.byte_clk) << 10;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) << 12;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) << 14;\n'
+        '\tce |= a52_p283_clk_enabled(dsi_ctrl->clk_info.lp_link_clks.esc_clk) << 16;\n'
+        '\ta52_ackfr_record("P276 283C0 q=%u e=%x", point, ce);\n'
+        '\ta52_ackfr_record("P276 283C1 q=%u b=%lx p=%lx", point,\n'
+        '\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk),\n'
+        '\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk));\n'
+        '\ta52_ackfr_record("P276 283C2 q=%u i=%lx e=%lx", point,\n'
+        '\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk),\n'
+        '\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk));\n'
+        '\ta52_p283_phy_snapshot(dsi_ctrl->cell_index, point);\n'
+        '}\n',
+        'Phase283 DSI helper insertion')
+
+    text = replace_one(
+        text,
+        'if (a52_p276r_deep_active()) a52_ackfr_record("P276 D K s=6 p=0");',
+        'a52_p283_shared_snapshot(dsi_ctrl, 0);\n\t\t\tif (a52_p276r_deep_active()) a52_ackfr_record("P276 D K s=6 p=0");',
+        'Phase283 FIFO q0 shared snapshot')
+
+    text = replace_one(
+        text,
+        'if (a52_p276r_deep_active()) a52_ackfr_record("P276 D K s=6 p=1");',
+        'if (a52_p276r_deep_active()) a52_ackfr_record("P276 D K s=6 p=1");\n\t\t\ta52_p283_shared_snapshot(dsi_ctrl, 1);',
+        'Phase283 FIFO q1 shared snapshot')
+
+    text = replace_one(
+        text,
+        '\t\ta52_p281_dsi_dma_snapshot(dsi_ctrl, 2);\n',
+        '\t\ta52_p283_shared_snapshot(dsi_ctrl, 2);\n'
+        '\t\ta52_p281_dsi_dma_snapshot(dsi_ctrl, 2);\n',
+        'Phase283 q2 shared snapshot')
+    return text
+
+
+def validate(dsi: str, phy: str) -> None:
+    required_dsi = [
+        MARK,
+        'extern void a52_p283_phy_snapshot',
+        'P276 283S q=%u v=%u p=%u c=%u m=%u h=%u t=%u',
+        'P276 283R0 q=%u %x %x %x %x %x %x',
+        'P276 283R1 q=%u %x %x %x %x %x %x',
+        'P276 283C0 q=%u e=%x',
+        'P276 283C1 q=%u b=%lx p=%lx',
+        'P276 283C2 q=%u i=%lx e=%lx',
+        'a52_p283_shared_snapshot(dsi_ctrl, 0);',
+        'a52_p283_shared_snapshot(dsi_ctrl, 1);',
+        'a52_p283_shared_snapshot(dsi_ctrl, 2);',
+        'P276 282F a=0 t=1',
+        'P276 280Z q=2',
+    ]
+    required_phy = [
+        MARK,
+        'void a52_p283_phy_snapshot',
+        'P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x',
+        'P276 283P1 q=%u %x %x %x %x %x %x',
+        'P276 283P2 q=%u %x %x %x %x %x',
+        'P276 283P3 q=%u %x %x %x %x',
+        'DSI_PHY_VERSION_4_0',
+        'DSI_PHY_VERSION_4_1',
+    ]
+    for token in required_dsi:
+        if token not in dsi:
+            raise SystemExit('Phase283 DSI marker missing: ' + token)
+    for token in required_phy:
+        if token not in phy:
+            raise SystemExit('Phase283 PHY marker missing: ' + token)
+    if dsi.index('a52_p283_shared_snapshot(dsi_ctrl, 2);') > dsi.index('P276 282Z q=2'):
+        raise SystemExit('Phase283 q2 snapshot must precede Phase282/280 retention freeze')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    dsi_path = args.root / DSI
+    phy_path = args.root / PHY
+    if not dsi_path.is_file() or not phy_path.is_file():
+        raise SystemExit('Phase283 DSI/PHY source missing')
+    dsi = dsi_path.read_text()
+    phy = phy_path.read_text()
+    if not args.check_only:
+        dsi = patch_dsi(dsi)
+        phy = patch_phy(phy)
+        dsi_path.write_text(dsi)
+        phy_path.write_text(phy)
+    validate(dsi, phy)
+    print('Phase283 shared DSI engine/clock/PHY trace: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/283_apply_shared_engine_phy_trace.py
+++ b/scripts/283_apply_shared_engine_phy_trace.py
@@ -133,6 +133,12 @@ def patch_dsi(text: str) -> str:
 
     text = replace_one(
         text,
+        '#include <linux/clk.h>\n',
+        '#include <linux/clk.h>\n#include <linux/clk-provider.h>\n',
+        'Phase283 clock framework introspection include')
+
+    text = replace_one(
+        text,
         'static atomic_t a52_p282_fifo_inflight = ATOMIC_INIT(0);\n',
         'static atomic_t a52_p282_fifo_inflight = ATOMIC_INIT(0);\n'
         '\n/* ' + MARK + '\n'
@@ -219,6 +225,7 @@ def patch_dsi(text: str) -> str:
 def validate(dsi: str, phy: str) -> None:
     required_dsi = [
         MARK,
+        '#include <linux/clk-provider.h>',
         'extern void a52_p283_phy_snapshot',
         'P276 283S q=%u v=%u p=%u c=%u m=%u h=%u t=%u',
         'P276 283R0 q=%u %x %x %x %x %x %x',

--- a/scripts/283_ci_build.sh
+++ b/scripts/283_ci_build.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+COMMON="$ROOT/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"
+PANEL="$ROOT/drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c"
+
+fail_report(){
+  set +e
+  rm -rf phase283-failure
+  mkdir -p phase283-failure/{source,logs,audit}
+  cp phase283-compile.log phase283-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$PHY" "$SMMU" "$REC" "$COMMON" "$PANEL"; do
+    [ -f "$f" ] && cp "$f" phase283-failure/source/ || true
+  done
+  cp scripts/283_apply_shared_engine_phy_trace.py phase283-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the hardware-tested Phase282 source chain first. Phase283 keeps
+# the one-shot Golden FIFO probe and only adds read-only shared-path evidence.
+bash scripts/282_ci_build.sh
+test -s phase282-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DSI" "$PHY" "$SMMU" "$REC" "$COMMON" "$PANEL"; do test -s "$f"; done
+
+cp "$OUT/.config" /tmp/p283-base.config
+cp "$DSI" /tmp/p283-dsi-before.c
+cp "$PHY" /tmp/p283-phy-before.c
+cp "$SMMU" /tmp/p283-smmu-before.c
+cp "$REC" /tmp/p283-rec-before.c
+cp "$COMMON" /tmp/p283-common-before.c
+cp "$PANEL" /tmp/p283-panel-before.c
+
+python3 -m py_compile scripts/283_apply_shared_engine_phy_trace.py
+python3 scripts/283_apply_shared_engine_phy_trace.py --root "$ROOT"
+python3 scripts/283_apply_shared_engine_phy_trace.py --root "$ROOT" --check-only
+
+# No SMMU, recorder implementation, Samsung brightness mapping, panel source,
+# config, DT or unrelated subsystem may change in this phase.
+cmp -s /tmp/p283-smmu-before.c "$SMMU"
+cmp -s /tmp/p283-rec-before.c "$REC"
+cmp -s /tmp/p283-common-before.c "$COMMON"
+cmp -s /tmp/p283-panel-before.c "$PANEL"
+! cmp -s /tmp/p283-dsi-before.c "$DSI"
+! cmp -s /tmp/p283-phy-before.c "$PHY"
+
+grep -Fq 'A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1' "$DSI"
+grep -Fq 'A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1' "$PHY"
+grep -Fq 'P276 283R0 q=%u %x %x %x %x %x %x' "$DSI"
+grep -Fq 'P276 283C0 q=%u e=%x' "$DSI"
+grep -Fq 'P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x' "$PHY"
+grep -Fq 'a52_p283_shared_snapshot(dsi_ctrl, 0);' "$DSI"
+grep -Fq 'a52_p283_shared_snapshot(dsi_ctrl, 1);' "$DSI"
+grep -Fq 'a52_p283_shared_snapshot(dsi_ctrl, 2);' "$DSI"
+grep -Fq 'P276 282F a=0 t=1' "$DSI"
+grep -Fq 'P276 280Z q=2' "$DSI"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p283-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase283-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase283-out
+mkdir -p phase283-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase283-out/compile/Image
+cp "$OUT/.config" phase283-out/config/final.config
+cp /tmp/p283-base.config phase283-out/audit/phase282-final.config
+cp /tmp/p283-dsi-before.c phase283-out/audit/dsi-ctrl-before.c
+cp /tmp/p283-phy-before.c phase283-out/audit/dsi-phy-before.c
+cp phase283-compile.log phase283-out/audit/
+cp scripts/283_apply_shared_engine_phy_trace.py phase283-out/audit/
+cp "$DSI" phase283-out/source/dsi_ctrl.c
+cp "$PHY" phase283-out/source/dsi_phy.c
+
+# Preserve the exact Phase282 boot container and replace only the kernel.
+gzip -n -c "$IMAGE" > phase283-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase282-out/package/boot.img \
+  --kernel phase283-out/package/Image.gz \
+  --output phase283-out/package/boot.img \
+  --report phase283-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase283-out')
+idn={
+ 'phase':'283',
+ 'name':'DSI-SHARED-ENGINE-CLOCK-PHY-TRACE',
+ 'git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,
+ 'base':'hardware-tested Phase282 Golden FIFO-vs-memory A/B',
+ 'phase282_result':'FIFO/TPG command 0x29 payload f05a5a encoded 29030040f05a5aff timed out; external command-memory fetch is not the primary blocker',
+ 'behavior_change_from_phase282':False,
+ 'brightness_mapping_changed':False,
+ 'smmu_changed':False,
+ 'timeout_recovery_changed':False,
+ 'trace_points':'q0 immediately before Golden FIFO kickoff, q1 immediately after kickoff, q2 pristine timeout state before retention freeze',
+ 'records':{
+   '283S':'controller software state/version/power/controller/cmd-engine/host-init/tpg',
+   '283R0':'DSI_CTRL/TRIG_CTRL/TPG_CTRL/TPG_FIFO_STATUS/DMA_LENGTH/INT_CTRL',
+   '283R1':'DSI_STATUS/FIFO_STATUS/LANE_STATUS/CLK_CTRL/CLK_STATUS/PHY_SW_RESET',
+   '283C0':'actual clock handle enable-state ternary bitmap, 0=disabled 1=enabled 2=missing per two-bit slot',
+   '283C1':'actual byte and pixel clock rates',
+   '283C2':'actual byte-interface and escape clock rates',
+   '283P0':'PHY v4.x version/software power+engine/PLL/PHY status/lane status',
+   '283P1':'PHY CLK_CFG0/1/GLBL_CTRL/VREG_CTRL0/1/CTRL0',
+   '283P2':'PHY CTRL1/2/3/4/LANE_CTRL0',
+   '283P3':'PHY LANE_CTRL1/2/3/4'
+ }
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=['compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json','audit/phase282-final.config','audit/dsi-ctrl-before.c','audit/dsi-phy-before.c','audit/phase283-compile.log','audit/283_apply_shared_engine_phy_trace.py','source/dsi_ctrl.c','source/dsi_phy.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files: f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase283-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r=Path('phase283-out')
+d=(r/'source/dsi_ctrl.c').read_text(); p=(r/'source/dsi_phy.c').read_text(); img=(r/'compile/Image').read_bytes()
+for m in ['A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1','a52_p283_shared_snapshot(dsi_ctrl, 0);','a52_p283_shared_snapshot(dsi_ctrl, 1);','a52_p283_shared_snapshot(dsi_ctrl, 2);','P276 282F a=0 t=1','P276 280Z q=2']:
+ if m not in d: raise SystemExit('Phase283 DSI source marker missing: '+m)
+for m in ['A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1','void a52_p283_phy_snapshot','P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x']:
+ if m not in p: raise SystemExit('Phase283 PHY source marker missing: '+m)
+for m in ['P276 283S q=%u v=%u p=%u c=%u m=%u h=%u t=%u','P276 283R0 q=%u %x %x %x %x %x %x','P276 283C0 q=%u e=%x','P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x','P276 283P3 q=%u %x %x %x %x','P276 282F a=0 t=1','P276 280Z q=2']:
+ if m.encode() not in img: raise SystemExit('Phase283 runtime marker missing from Image: '+m)
+print('Phase283 compiled shared-path marker audit: PASS')
+PY
+
+python3 scripts/283_apply_shared_engine_phy_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase283 shared DSI engine/clock/PHY trace build/repack: PASS'

--- a/scripts/283b_apply_golden_handoff_trace.py
+++ b/scripts/283b_apply_golden_handoff_trace.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+DISPLAY = Path('drivers/a52_display/msm/dsi/dsi_display.c')
+MARK = 'A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_display(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = replace_one(
+        text,
+        '#include "dsi_pwr.h"\n',
+        '#include "dsi_pwr.h"\n'
+        '#include <linux/pm_runtime.h>\n'
+        '#include <linux/a52_ack_secure_flight_recorder.h>\n'
+        'extern bool a52_p276r_deep_active(void);\n',
+        'Phase283 handoff recorder include')
+
+    anchor = '''static const struct of_device_id dsi_display_dt_match[] = {\n\t{.compatible = "qcom,dsi-display"},\n\t{}\n};\n'''
+    helper = r'''static const struct of_device_id dsi_display_dt_match[] = {
+	{.compatible = "qcom,dsi-display"},
+	{}
+};
+
+/* A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1
+ * Golden continuous-splash setup marks splash ownership, configures the DSI
+ * ISR, votes all DSI clocks, and relies on the clock-manager callbacks to vote
+ * controller/PHY regulators before the first panel command. Phase283 records
+ * that ownership state without changing it.
+ */
+void a52_p283_display_handoff_snapshot(struct dsi_ctrl *target,
+		unsigned int point)
+{
+	struct dsi_display *display;
+	struct dsi_display_ctrl *dc;
+	struct regulator *ctrl_gdsc = NULL, *phy_gdsc = NULL;
+	int i, j, ctrl_en = -2, phy_en = -2;
+	u32 ctrl_ref = 0, phy_ref = 0;
+
+	if (!a52_p276r_deep_active() || !target)
+		return;
+
+	for (i = 0; i < MAX_DSI_ACTIVE_DISPLAY; i++) {
+		display = boot_displays[i].disp;
+		if (!display)
+			continue;
+
+		for (j = 0; j < display->ctrl_count; j++) {
+			dc = &display->ctrl[j];
+			if (!dc->ctrl || dc->ctrl != target)
+				continue;
+
+			ctrl_ref = target->pwr_info.digital.refcount;
+			if (target->pwr_info.digital.count &&
+					target->pwr_info.digital.vregs)
+				ctrl_gdsc = target->pwr_info.digital.vregs[0].vreg;
+			if (ctrl_gdsc)
+				ctrl_en = regulator_is_enabled(ctrl_gdsc);
+
+			if (dc->phy) {
+				phy_ref = dc->phy->pwr_info.digital.refcount;
+				if (dc->phy->pwr_info.digital.count &&
+						dc->phy->pwr_info.digital.vregs)
+					phy_gdsc = dc->phy->pwr_info.digital.vregs[0].vreg;
+				if (phy_gdsc)
+					phy_en = regulator_is_enabled(phy_gdsc);
+			}
+
+			a52_ackfr_record("P276 283D0 q=%u s=%u p=%u u=%u c=%u x=%u t=%u",
+				point, display->is_cont_splash_enabled, dc->phy_enabled,
+				display->ulps_enabled, display->clamp_enabled,
+				display->phy_idle_power_off, display->is_tpg_enabled);
+			a52_ackfr_record("P276 283D1 q=%u k=%u m=%u v=%u n=%u r=%u",
+				point, display->clk_master_idx, display->cmd_master_idx,
+				display->video_master_idx, display->ctrl_count,
+				display->cmd_engine_refcount);
+			a52_ackfr_record("P276 283D2 q=%u cg=%d/%u pg=%d/%u pm=%u",
+				point, ctrl_en, ctrl_ref, phy_en, phy_ref,
+				pm_runtime_active(&target->pdev->dev) ? 1 : 0);
+#if defined(CONFIG_DISPLAY_SAMSUNG)
+			if (display->panel && display->panel->panel_private) {
+				struct samsung_display_driver_data *vdd =
+					display->panel->panel_private;
+				a52_ackfr_record("P276 283D3 q=%u ss=%u",
+					point, vdd->samsung_splash_enabled ? 1 : 0);
+			}
+#endif
+			return;
+		}
+	}
+
+	a52_ackfr_record("P276 283DX q=%u i=%u", point, target->cell_index);
+}
+'''
+    return replace_one(text, anchor, helper, 'Phase283 handoff helper insertion')
+
+
+def patch_dsi(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1' not in text:
+        raise SystemExit('Phase283 shared-path prerequisite missing')
+
+    text = replace_one(
+        text,
+        'extern void a52_p283_phy_snapshot(unsigned int index, unsigned int point);\n',
+        'extern void a52_p283_phy_snapshot(unsigned int index, unsigned int point);\n'
+        'extern void a52_p283_display_handoff_snapshot(struct dsi_ctrl *target, unsigned int point);\n'
+        '/* ' + MARK + ' */\n',
+        'Phase283 handoff extern')
+
+    text = replace_one(
+        text,
+        '\ta52_p283_phy_snapshot(dsi_ctrl->cell_index, point);\n',
+        '\ta52_p283_phy_snapshot(dsi_ctrl->cell_index, point);\n'
+        '\ta52_p283_display_handoff_snapshot(dsi_ctrl, point);\n',
+        'Phase283 handoff snapshot call')
+    return text
+
+
+def validate(dsi: str, display: str) -> None:
+    for token in [
+        MARK,
+        'extern void a52_p283_display_handoff_snapshot',
+        'a52_p283_display_handoff_snapshot(dsi_ctrl, point);',
+        'a52_p283_shared_snapshot(dsi_ctrl, 0);',
+        'a52_p283_shared_snapshot(dsi_ctrl, 1);',
+        'a52_p283_shared_snapshot(dsi_ctrl, 2);',
+    ]:
+        if token not in dsi:
+            raise SystemExit('Phase283 handoff DSI marker missing: ' + token)
+
+    for token in [
+        MARK,
+        'void a52_p283_display_handoff_snapshot',
+        'P276 283D0 q=%u s=%u p=%u u=%u c=%u x=%u t=%u',
+        'P276 283D1 q=%u k=%u m=%u v=%u n=%u r=%u',
+        'P276 283D2 q=%u cg=%d/%u pg=%d/%u pm=%u',
+        'P276 283D3 q=%u ss=%u',
+        'regulator_is_enabled(ctrl_gdsc)',
+        'regulator_is_enabled(phy_gdsc)',
+        'pm_runtime_active(&target->pdev->dev)',
+    ]:
+        if token not in display:
+            raise SystemExit('Phase283 handoff display marker missing: ' + token)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    dsi_path = args.root / DSI
+    display_path = args.root / DISPLAY
+    if not dsi_path.is_file() or not display_path.is_file():
+        raise SystemExit('Phase283 handoff DSI/display source missing')
+
+    dsi = dsi_path.read_text()
+    display = display_path.read_text()
+    if not args.check_only:
+        display = patch_display(display)
+        dsi = patch_dsi(dsi)
+        display_path.write_text(display)
+        dsi_path.write_text(dsi)
+    validate(dsi, display)
+    print('Phase283 Golden continuous-splash handoff trace: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/283b_ci_build.sh
+++ b/scripts/283b_ci_build.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+DISPLAY="$ROOT/drivers/a52_display/msm/dsi/dsi_display.c"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+COMMON="$ROOT/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"
+PANEL="$ROOT/drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c"
+
+fail_report(){
+  set +e
+  rm -rf phase283b-failure
+  mkdir -p phase283b-failure/{source,logs,audit}
+  cp phase283b-compile.log phase283b-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$PHY" "$DISPLAY" "$SMMU" "$REC" "$COMMON" "$PANEL"; do
+    [ -f "$f" ] && cp "$f" phase283b-failure/source/ || true
+  done
+  cp scripts/283_apply_shared_engine_phy_trace.py phase283b-failure/audit/ 2>/dev/null || true
+  cp scripts/283b_apply_golden_handoff_trace.py phase283b-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the hardware-tested Phase282 source chain, then install both
+# read-only Phase283 layers: shared DSI/PHY state and Golden splash handoff state.
+bash scripts/282_ci_build.sh
+test -s phase282-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DSI" "$PHY" "$DISPLAY" "$SMMU" "$REC" "$COMMON" "$PANEL"; do test -s "$f"; done
+
+cp "$OUT/.config" /tmp/p283b-base.config
+cp "$DSI" /tmp/p283b-dsi-before.c
+cp "$PHY" /tmp/p283b-phy-before.c
+cp "$DISPLAY" /tmp/p283b-display-before.c
+cp "$SMMU" /tmp/p283b-smmu-before.c
+cp "$REC" /tmp/p283b-rec-before.c
+cp "$COMMON" /tmp/p283b-common-before.c
+cp "$PANEL" /tmp/p283b-panel-before.c
+
+python3 -m py_compile scripts/283_apply_shared_engine_phy_trace.py scripts/283b_apply_golden_handoff_trace.py
+python3 scripts/283_apply_shared_engine_phy_trace.py --root "$ROOT"
+python3 scripts/283b_apply_golden_handoff_trace.py --root "$ROOT"
+python3 scripts/283_apply_shared_engine_phy_trace.py --root "$ROOT" --check-only
+python3 scripts/283b_apply_golden_handoff_trace.py --root "$ROOT" --check-only
+
+# Preserve all previously-cleared subsystems. Only DSI ctrl, DSI PHY and DSI
+# display handoff source are diagnostic deltas over hardware-tested Phase282.
+cmp -s /tmp/p283b-smmu-before.c "$SMMU"
+cmp -s /tmp/p283b-rec-before.c "$REC"
+cmp -s /tmp/p283b-common-before.c "$COMMON"
+cmp -s /tmp/p283b-panel-before.c "$PANEL"
+! cmp -s /tmp/p283b-dsi-before.c "$DSI"
+! cmp -s /tmp/p283b-phy-before.c "$PHY"
+! cmp -s /tmp/p283b-display-before.c "$DISPLAY"
+
+grep -Fq 'A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1' "$DSI"
+grep -Fq 'A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1' "$DSI"
+grep -Fq 'A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1' "$DISPLAY"
+grep -Fq 'P276 283D0 q=%u s=%u p=%u u=%u c=%u x=%u t=%u' "$DISPLAY"
+grep -Fq 'P276 283D2 q=%u cg=%d/%u pg=%d/%u pm=%u' "$DISPLAY"
+grep -Fq 'a52_p283_display_handoff_snapshot(dsi_ctrl, point);' "$DSI"
+grep -Fq 'P276 282F a=0 t=1' "$DSI"
+grep -Fq 'P276 280Z q=2' "$DSI"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p283b-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase283b-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase283b-out
+mkdir -p phase283b-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase283b-out/compile/Image
+cp "$OUT/.config" phase283b-out/config/final.config
+cp /tmp/p283b-base.config phase283b-out/audit/phase282-final.config
+cp /tmp/p283b-dsi-before.c phase283b-out/audit/dsi-ctrl-before.c
+cp /tmp/p283b-phy-before.c phase283b-out/audit/dsi-phy-before.c
+cp /tmp/p283b-display-before.c phase283b-out/audit/dsi-display-before.c
+cp phase283b-compile.log phase283b-out/audit/
+cp scripts/283_apply_shared_engine_phy_trace.py phase283b-out/audit/
+cp scripts/283b_apply_golden_handoff_trace.py phase283b-out/audit/
+cp "$DSI" phase283b-out/source/dsi_ctrl.c
+cp "$PHY" phase283b-out/source/dsi_phy.c
+cp "$DISPLAY" phase283b-out/source/dsi_display.c
+
+gzip -n -c "$IMAGE" > phase283b-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase282-out/package/boot.img \
+  --kernel phase283b-out/package/Image.gz \
+  --output phase283b-out/package/boot.img \
+  --report phase283b-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase283b-out')
+idn={
+ 'phase':'283',
+ 'name':'DSI-SHARED-ENGINE-PHY-GOLDEN-HANDOFF-TRACE',
+ 'git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,
+ 'base':'hardware-tested Phase282 Golden FIFO-vs-memory A/B',
+ 'phase282_result':'FIFO and memory transports both timeout; shared DSI path is the frontier',
+ 'behavior_change_from_phase282':False,
+ 'brightness_mapping_changed':False,
+ 'smmu_changed':False,
+ 'timeout_recovery_changed':False,
+ 'golden_comparison':'working continuous splash enables DPHY, retains splash ownership, configures ISR, votes all DSI clocks/regulators, then completes initial panel read/unlock and ON-command traffic',
+ 'extra_handoff_records':{
+   '283D0':'continuous-splash, per-display PHY-enabled, ULPS, clamp, PHY-idle-poweroff and display TPG flags',
+   '283D1':'clock/cmd/video master indexes, ctrl count and command-engine refcount',
+   '283D2':'controller and PHY digital/GDSC regulator enabled state + refcount and controller runtime-PM active state',
+   '283D3':'Samsung splash ownership flag'
+ }
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=['compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json','audit/phase282-final.config','audit/dsi-ctrl-before.c','audit/dsi-phy-before.c','audit/dsi-display-before.c','audit/phase283b-compile.log','audit/283_apply_shared_engine_phy_trace.py','audit/283b_apply_golden_handoff_trace.py','source/dsi_ctrl.c','source/dsi_phy.c','source/dsi_display.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files: f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase283b-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r=Path('phase283b-out')
+d=(r/'source/dsi_ctrl.c').read_text(); p=(r/'source/dsi_phy.c').read_text(); x=(r/'source/dsi_display.c').read_text(); img=(r/'compile/Image').read_bytes()
+for m in ['A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1','A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1','a52_p283_display_handoff_snapshot(dsi_ctrl, point);','P276 282F a=0 t=1','P276 280Z q=2']:
+ if m not in d: raise SystemExit('Phase283 DSI marker missing: '+m)
+for m in ['A52_PHASE283_DSI_SHARED_ENGINE_PHY_TRACE_V1','P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x']:
+ if m not in p: raise SystemExit('Phase283 PHY marker missing: '+m)
+for m in ['A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1','P276 283D0 q=%u s=%u p=%u u=%u c=%u x=%u t=%u','P276 283D2 q=%u cg=%d/%u pg=%d/%u pm=%u','P276 283D3 q=%u ss=%u']:
+ if m not in x: raise SystemExit('Phase283 display marker missing: '+m)
+for m in ['P276 283S q=%u v=%u p=%u c=%u m=%u h=%u t=%u','P276 283P0 q=%u v=%u p=%u s=%u %x %x %x %x','P276 283D0 q=%u s=%u p=%u u=%u c=%u x=%u t=%u','P276 283D2 q=%u cg=%d/%u pg=%d/%u pm=%u','P276 282F a=0 t=1','P276 280Z q=2']:
+ if m.encode() not in img: raise SystemExit('Phase283 runtime marker missing from Image: '+m)
+print('Phase283 Golden handoff-complete marker audit: PASS')
+PY
+
+python3 scripts/283_apply_shared_engine_phy_trace.py --root "$ROOT" --check-only
+python3 scripts/283b_apply_golden_handoff_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase283 shared DSI/PHY + Golden handoff trace build/repack: PASS'

--- a/scripts/283c_ci_build.sh
+++ b/scripts/283c_ci_build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Phase283C build-only compatibility fix.
+# The read-only shared-path tracer calls __clk_is_enabled(), which is declared
+# by the common-clock provider header in this kernel lineage. Patch the
+# instrumentation generator deterministically, then run the unchanged full
+# Golden handoff-complete Phase283B reconstruction/build.
+python3 - <<'PY'
+from pathlib import Path
+
+p = Path('scripts/283_apply_shared_engine_phy_trace.py')
+s = p.read_text()
+
+if '#include <linux/clk-provider.h>' not in s:
+    anchor = (
+        "    text = replace_one(\n"
+        "        text,\n"
+        "        'static atomic_t a52_p282_fifo_inflight = ATOMIC_INIT(0);\\n',\n"
+    )
+    injection = (
+        "    text = replace_one(\n"
+        "        text,\n"
+        "        '#include <linux/clk.h>\\n',\n"
+        "        '#include <linux/clk.h>\\n#include <linux/clk-provider.h>\\n',\n"
+        "        'Phase283 clock framework introspection include')\n\n"
+    )
+    if anchor not in s:
+        raise SystemExit('Phase283C: shared tracer insertion anchor missing')
+    s = s.replace(anchor, injection + anchor, 1)
+
+    validate = "    required_dsi = [\n        MARK,\n"
+    if validate not in s:
+        raise SystemExit('Phase283C: validation anchor missing')
+    s = s.replace(
+        validate,
+        "    required_dsi = [\n        MARK,\n        '#include <linux/clk-provider.h>',\n",
+        1,
+    )
+    p.write_text(s)
+
+if '#include <linux/clk-provider.h>' not in p.read_text():
+    raise SystemExit('Phase283C: clock provider compatibility patch missing')
+
+print('Phase283C clock framework compatibility patch: PASS')
+PY
+
+bash scripts/283b_ci_build.sh


### PR DESCRIPTION
## Hardware evidence entering Phase283

Phase282 hardware capture proved that the one-shot Golden FIFO/TPG transport fails exactly like normal memory-backed DSI command DMA. The tested command was Generic Long Write `0x29`, payload `f0 5a 5a`, encoded packet `29 03 00 40 f0 5a 5a ff`; FIFO was selected and the same ~200 ms no-DMA-DONE timeout occurred.

This strongly excludes the external command RAM / IOVA / SMMU / AXI memory-fetch segment as the primary blocker and moves the failure into the path shared after FIFO and memory transports converge.

## Phase283 scope

Keep Phase282 behavior unchanged and add read-only q0/q1/q2 snapshots for:

- DSI controller software state and controller version;
- DSI_CTRL, TRIG_CTRL, TPG control/FIFO status, command length, interrupt state;
- DSI status/FIFO/lane/clock/reset registers;
- actual core/link clock enable states and byte/pixel/byte-interface/escape rates;
- actual 7 nm DSI PHY software power/engine state;
- PHY PLL, PHY status, lane status, clock configuration, regulator/control and lane-control registers.

q0 is immediately before the same Golden FIFO kickoff, q1 immediately after, and q2 is the pristine timeout state before the inherited Phase282/280 retention freeze.

No DSI/PHY register is written. SMMU, mappings/TLBs, recorder implementation, Samsung brightness mapping, panel source, DT, config and timeout recovery remain unchanged.