### PR TITLE
Phase 284: trace v3 PHY and link clock chain

### DIFF
--- a/.github/workflows/284-a52-v3-phy-clock-trace.yml
+++ b/.github/workflows/284-a52-v3-phy-clock-trace.yml
@@ -67,7 +67,7 @@ jobs:
           git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
           git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
           git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
-      - name: Normalize Phase284 disabled-Kconfig assertion
+      - name: Normalize Phase284 config audit and preserve diagnostics
         run: |
           set -Eeuo pipefail
           python3 - <<'PY'
@@ -75,12 +75,50 @@ jobs:
 
           p = Path('scripts/284b_ci_build.sh')
           s = p.read_text()
+
           old = "grep -Fxq 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' \"$OUT/.config\""
           new = "grep -Fxq '# CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE is not set' \"$OUT/.config\""
           if s.count(old) != 1:
               raise SystemExit('Phase284 workflow: expected exactly one stale disabled-Kconfig assertion')
-          p.write_text(s.replace(old, new, 1))
+          s = s.replace(old, new, 1)
+
+          old_fail = "  cp scripts/284b_apply_clock_causality_trace.py phase284-failure/audit/ 2>/dev/null || true\n"
+          new_fail = old_fail + "  cp /tmp/p284-*.config /tmp/p284-*.diff phase284-failure/audit/ 2>/dev/null || true\n"
+          if s.count(old_fail) != 1:
+              raise SystemExit('Phase284 workflow: expected fail_report audit-copy anchor once')
+          s = s.replace(old_fail, new_fail, 1)
+
+          old_make = '''make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \\
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+'''
+          pre_audit = '''cp "$OUT/.config" /tmp/p284-pre-olddefconfig.config
+if ! cmp -s /tmp/p284-base.config /tmp/p284-pre-olddefconfig.config; then
+  diff -u /tmp/p284-base.config /tmp/p284-pre-olddefconfig.config > /tmp/p284-pre-olddefconfig.diff || true
+  echo '::error::Phase284 tracing changed .config before olddefconfig'
+  cat /tmp/p284-pre-olddefconfig.diff
+  exit 1
+fi
+
+'''
+          if s.count(old_make) != 1:
+              raise SystemExit('Phase284 workflow: expected exactly one Phase284 olddefconfig command')
+          s = s.replace(old_make, pre_audit + old_make, 1)
+
+          old_cmp = 'cmp -s /tmp/p284-base.config "$OUT/.config"'
+          new_cmp = '''cp "$OUT/.config" /tmp/p284-post-olddefconfig.config
+if ! cmp -s /tmp/p284-base.config /tmp/p284-post-olddefconfig.config; then
+  diff -u /tmp/p284-base.config /tmp/p284-post-olddefconfig.config > /tmp/p284-config.diff || true
+  echo '::error::Phase284 .config changed after olddefconfig'
+  cat /tmp/p284-config.diff
+  exit 1
+fi'''
+          if s.count(old_cmp) != 1:
+              raise SystemExit('Phase284 workflow: expected exactly one silent config equality audit')
+          s = s.replace(old_cmp, new_cmp, 1)
+
+          p.write_text(s)
           print('Phase284 workflow: disabled-Kconfig assertion normalized')
+          print('Phase284 workflow: strict pre/post-olddefconfig diagnostics installed')
           PY
       - name: Reconstruct Phase283 and build Phase284 candidate
         run: bash scripts/284b_ci_build.sh

--- a/.github/workflows/284-a52-v3-phy-clock-trace.yml
+++ b/.github/workflows/284-a52-v3-phy-clock-trace.yml
@@ -77,12 +77,14 @@ jobs:
           s = p.read_text()
 
           old = "grep -Fxq 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' \"$OUT/.config\""
-          new = '''trusted_line="$(grep -E '^CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=' "$OUT/.config" || true)"
-if [ -n "$trusted_line" ] && [ "$trusted_line" != 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' ]; then
-  echo '::error::CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE must remain disabled'
-  printf '%s\\n' "$trusted_line"
-  exit 1
-fi'''
+          new = "\n".join([
+              'trusted_line="$(grep -E \'^CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=\' "$OUT/.config" || true)"',
+              'if [ -n "$trusted_line" ] && [ "$trusted_line" != \'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n\' ]; then',
+              "  echo '::error::CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE must remain disabled'",
+              '  printf \'%s\\n\' "$trusted_line"',
+              '  exit 1',
+              'fi',
+          ])
           if s.count(old) != 1:
               raise SystemExit('Phase284 workflow: expected exactly one stale disabled-Kconfig assertion')
           s = s.replace(old, new, 1)
@@ -93,30 +95,36 @@ fi'''
               raise SystemExit('Phase284 workflow: expected fail_report audit-copy anchor once')
           s = s.replace(old_fail, new_fail, 1)
 
-          old_make = '''make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \\
-  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
-'''
-          pre_audit = '''cp "$OUT/.config" /tmp/p284-pre-olddefconfig.config
-if ! cmp -s /tmp/p284-base.config /tmp/p284-pre-olddefconfig.config; then
-  diff -u /tmp/p284-base.config /tmp/p284-pre-olddefconfig.config > /tmp/p284-pre-olddefconfig.diff || true
-  echo '::error::Phase284 tracing changed .config before olddefconfig'
-  cat /tmp/p284-pre-olddefconfig.diff
-  exit 1
-fi
-
-'''
+          old_make = "\n".join([
+              'make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \\',
+              '  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig',
+              '',
+          ])
+          pre_audit = "\n".join([
+              'cp "$OUT/.config" /tmp/p284-pre-olddefconfig.config',
+              'if ! cmp -s /tmp/p284-base.config /tmp/p284-pre-olddefconfig.config; then',
+              '  diff -u /tmp/p284-base.config /tmp/p284-pre-olddefconfig.config > /tmp/p284-pre-olddefconfig.diff || true',
+              "  echo '::error::Phase284 tracing changed .config before olddefconfig'",
+              '  cat /tmp/p284-pre-olddefconfig.diff',
+              '  exit 1',
+              'fi',
+              '',
+              '',
+          ])
           if s.count(old_make) != 1:
               raise SystemExit('Phase284 workflow: expected exactly one Phase284 olddefconfig command')
           s = s.replace(old_make, pre_audit + old_make, 1)
 
           old_cmp = 'cmp -s /tmp/p284-base.config "$OUT/.config"'
-          new_cmp = '''cp "$OUT/.config" /tmp/p284-post-olddefconfig.config
-if ! cmp -s /tmp/p284-base.config /tmp/p284-post-olddefconfig.config; then
-  diff -u /tmp/p284-base.config /tmp/p284-post-olddefconfig.config > /tmp/p284-config.diff || true
-  echo '::error::Phase284 .config changed after olddefconfig'
-  cat /tmp/p284-config.diff
-  exit 1
-fi'''
+          new_cmp = "\n".join([
+              'cp "$OUT/.config" /tmp/p284-post-olddefconfig.config',
+              'if ! cmp -s /tmp/p284-base.config /tmp/p284-post-olddefconfig.config; then',
+              '  diff -u /tmp/p284-base.config /tmp/p284-post-olddefconfig.config > /tmp/p284-config.diff || true',
+              "  echo '::error::Phase284 .config changed after olddefconfig'",
+              '  cat /tmp/p284-config.diff',
+              '  exit 1',
+              'fi',
+          ])
           if s.count(old_cmp) != 1:
               raise SystemExit('Phase284 workflow: expected exactly one silent config equality audit')
           s = s.replace(old_cmp, new_cmp, 1)

--- a/.github/workflows/284-a52-v3-phy-clock-trace.yml
+++ b/.github/workflows/284-a52-v3-phy-clock-trace.yml
@@ -1,5 +1,5 @@
-name: 284 - A52 v3 PHY + link clock chain trace
-run-name: Phase 284 - v3 PHY and link clock chain trace
+name: 284 - A52 v3 PHY + full clock causality trace
+run-name: Phase 284 - v3 PHY and full clock causality trace
 on:
   workflow_dispatch:
   push:
@@ -8,14 +8,16 @@ on:
     paths:
       - .github/workflows/284-a52-v3-phy-clock-trace.yml
       - scripts/284_apply_v3_phy_clock_trace.py
-      - scripts/284_ci_build.sh
+      - scripts/284b_apply_clock_causality_trace.py
+      - scripts/284b_ci_build.sh
   pull_request:
     branches:
       - agent/a52-phase283-dsi-shared-engine-clock-trace-v1
     paths:
       - .github/workflows/284-a52-v3-phy-clock-trace.yml
       - scripts/284_apply_v3_phy_clock_trace.py
-      - scripts/284_ci_build.sh
+      - scripts/284b_apply_clock_causality_trace.py
+      - scripts/284b_ci_build.sh
 permissions:
   contents: read
   actions: read
@@ -29,7 +31,7 @@ env:
   PHASE227_SEED_ARTIFACT_ID: '9160764832'
 jobs:
   build:
-    name: Reconstruct Phase283 and build v3 PHY/clock-chain probe
+    name: Reconstruct Phase283 and build full clock-causality probe
     runs-on: ubuntu-22.04
     timeout-minutes: 240
     env:
@@ -66,12 +68,12 @@ jobs:
           git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
           git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
       - name: Reconstruct Phase283 and build Phase284 candidate
-        run: bash scripts/284_ci_build.sh
+        run: bash scripts/284b_ci_build.sh
       - name: Upload Phase284 candidate
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-Phase284-V3-PHY-CLOCK-CHAIN-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          name: A52XQ-Phase284-V3-PHY-FULL-CLOCK-CAUSALITY-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
           path: phase284-out/
           if-no-files-found: error
           compression-level: 1
@@ -80,7 +82,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-Phase284-V3-PHY-CLOCK-FAILURE-${{ github.run_number }}
+          name: A52XQ-Phase284-CLOCK-CAUSALITY-FAILURE-${{ github.run_number }}
           path: phase284-failure/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/284-a52-v3-phy-clock-trace.yml
+++ b/.github/workflows/284-a52-v3-phy-clock-trace.yml
@@ -1,0 +1,86 @@
+name: 284 - A52 v3 PHY + link clock chain trace
+run-name: Phase 284 - v3 PHY and link clock chain trace
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase284-v3-phy-clock-chain-v1
+    paths:
+      - .github/workflows/284-a52-v3-phy-clock-trace.yml
+      - scripts/284_apply_v3_phy_clock_trace.py
+      - scripts/284_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase283-dsi-shared-engine-clock-trace-v1
+    paths:
+      - .github/workflows/284-a52-v3-phy-clock-trace.yml
+      - scripts/284_apply_v3_phy_clock_trace.py
+      - scripts/284_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase284-v3-phy-clock-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase283 and build v3 PHY/clock-chain probe
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase284 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Reconstruct Phase283 and build Phase284 candidate
+        run: bash scripts/284_ci_build.sh
+      - name: Upload Phase284 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase284-V3-PHY-CLOCK-CHAIN-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase284-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase284-V3-PHY-CLOCK-FAILURE-${{ github.run_number }}
+          path: phase284-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/284-a52-v3-phy-clock-trace.yml
+++ b/.github/workflows/284-a52-v3-phy-clock-trace.yml
@@ -77,7 +77,12 @@ jobs:
           s = p.read_text()
 
           old = "grep -Fxq 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' \"$OUT/.config\""
-          new = "grep -Fxq '# CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE is not set' \"$OUT/.config\""
+          new = '''trusted_line="$(grep -E '^CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=' "$OUT/.config" || true)"
+if [ -n "$trusted_line" ] && [ "$trusted_line" != 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' ]; then
+  echo '::error::CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE must remain disabled'
+  printf '%s\\n' "$trusted_line"
+  exit 1
+fi'''
           if s.count(old) != 1:
               raise SystemExit('Phase284 workflow: expected exactly one stale disabled-Kconfig assertion')
           s = s.replace(old, new, 1)
@@ -117,7 +122,7 @@ fi'''
           s = s.replace(old_cmp, new_cmp, 1)
 
           p.write_text(s)
-          print('Phase284 workflow: disabled-Kconfig assertion normalized')
+          print('Phase284 workflow: trusted-source disabled invariant normalized semantically')
           print('Phase284 workflow: strict pre/post-olddefconfig diagnostics installed')
           PY
       - name: Reconstruct Phase283 and build Phase284 candidate

--- a/.github/workflows/284-a52-v3-phy-clock-trace.yml
+++ b/.github/workflows/284-a52-v3-phy-clock-trace.yml
@@ -67,6 +67,21 @@ jobs:
           git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
           git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
           git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Normalize Phase284 disabled-Kconfig assertion
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          p = Path('scripts/284b_ci_build.sh')
+          s = p.read_text()
+          old = "grep -Fxq 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' \"$OUT/.config\""
+          new = "grep -Fxq '# CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE is not set' \"$OUT/.config\""
+          if s.count(old) != 1:
+              raise SystemExit('Phase284 workflow: expected exactly one stale disabled-Kconfig assertion')
+          p.write_text(s.replace(old, new, 1))
+          print('Phase284 workflow: disabled-Kconfig assertion normalized')
+          PY
       - name: Reconstruct Phase283 and build Phase284 candidate
         run: bash scripts/284b_ci_build.sh
       - name: Upload Phase284 candidate

--- a/scripts/284_apply_v3_phy_clock_trace.py
+++ b/scripts/284_apply_v3_phy_clock_trace.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+
+MARK = 'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1'
+CTRL_REL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+PHY_REL = Path('drivers/a52_display/msm/dsi/dsi_phy.c')
+
+
+def replace_one(text, old, new, why):
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase284: expected exactly one {why} anchor, found {n}')
+    return text.replace(old, new, 1)
+
+
+def apply_ctrl(path: Path):
+    text = path.read_text()
+    if MARK in text:
+        return
+
+    anchor = '''static unsigned long a52_p283_clk_rate(struct clk *clk)\n{\n\treturn clk ? clk_get_rate(clk) : 0;\n}\n\n'''
+    inject = anchor + '''/* A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1\n * Read-only continuation of Phase283. Capture the configured link rates and\n * the actual RCG/selected-source/parent clock chain. No clock state is changed.\n */\nstatic u32 a52_p284_rate32(unsigned long rate)\n{\n\treturn rate > 0xffffffffUL ? 0xffffffffU : (u32)rate;\n}\n\nstatic u32 a52_p284_u64_rate32(u64 rate)\n{\n\treturn rate > 0xffffffffULL ? 0xffffffffU : (u32)rate;\n}\n\nstatic u32 a52_p284_clk_rate32(struct clk *clk)\n{\n\treturn a52_p284_rate32(a52_p283_clk_rate(clk));\n}\n\n'''
+    text = replace_one(text, anchor, inject, 'clock helper')
+
+    anchor2 = '''\ta52_ackfr_record("P276 283C2 q=%u i=%lx e=%lx", point,\n\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk),\n\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk));\n\ta52_p283_phy_snapshot(dsi_ctrl->cell_index, point);\n'''
+    inject2 = '''\ta52_ackfr_record("P276 283C2 q=%u i=%lx e=%lx", point,\n\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk),\n\t\ta52_p283_clk_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk));\n\t{\n\t\tstruct clk *bc = dsi_ctrl->clk_info.hs_link_clks.byte_clk;\n\t\tstruct clk *pc = dsi_ctrl->clk_info.hs_link_clks.pixel_clk;\n\t\tstruct clk *bp = bc ? clk_get_parent(bc) : NULL;\n\t\tstruct clk *pp = pc ? clk_get_parent(pc) : NULL;\n\t\tstruct clk *bg = bp ? clk_get_parent(bp) : NULL;\n\t\tstruct clk *pg = pp ? clk_get_parent(pp) : NULL;\n\t\tu32 en = 0;\n\n\t\ta52_ackfr_record("P276 284C0 q=%u %x %x %x %x", point,\n\t\t\ta52_p284_u64_rate32(dsi_ctrl->clk_freq.byte_clk_rate),\n\t\t\ta52_p284_u64_rate32(dsi_ctrl->clk_freq.pix_clk_rate),\n\t\t\ta52_p284_u64_rate32(dsi_ctrl->clk_freq.byte_intf_clk_rate),\n\t\t\ta52_p284_u64_rate32(dsi_ctrl->clk_freq.esc_clk_rate));\n\t\ta52_ackfr_record("P276 284C1 q=%u %x %x %x %x", point,\n\t\t\ta52_p284_clk_rate32(dsi_ctrl->clk_info.rcg_clks.byte_clk),\n\t\t\ta52_p284_clk_rate32(dsi_ctrl->clk_info.rcg_clks.pixel_clk),\n\t\t\ta52_p284_clk_rate32(dsi_ctrl->clk_info.pll_op_clks.byte_clk),\n\t\t\ta52_p284_clk_rate32(dsi_ctrl->clk_info.pll_op_clks.pixel_clk));\n\t\ta52_ackfr_record("P276 284C2 q=%u %x %x %x %x %x %x", point,\n\t\t\ta52_p284_clk_rate32(bc), a52_p284_clk_rate32(bp),\n\t\t\ta52_p284_clk_rate32(bg), a52_p284_clk_rate32(pc),\n\t\t\ta52_p284_clk_rate32(pp), a52_p284_clk_rate32(pg));\n\t\ten |= a52_p283_clk_enabled(dsi_ctrl->clk_info.rcg_clks.byte_clk) << 0;\n\t\ten |= a52_p283_clk_enabled(dsi_ctrl->clk_info.rcg_clks.pixel_clk) << 2;\n\t\ten |= a52_p283_clk_enabled(dsi_ctrl->clk_info.pll_op_clks.byte_clk) << 4;\n\t\ten |= a52_p283_clk_enabled(dsi_ctrl->clk_info.pll_op_clks.pixel_clk) << 6;\n\t\ten |= a52_p283_clk_enabled(bp) << 8;\n\t\ten |= a52_p283_clk_enabled(bg) << 10;\n\t\ten |= a52_p283_clk_enabled(pp) << 12;\n\t\ten |= a52_p283_clk_enabled(pg) << 14;\n\t\ta52_ackfr_record("P276 284C3 q=%u e=%x", point, en);\n\t}\n\ta52_p283_phy_snapshot(dsi_ctrl->cell_index, point);\n'''
+    text = replace_one(text, anchor2, inject2, 'Phase283 C2 tail')
+    path.write_text(text)
+
+
+def apply_phy(path: Path):
+    text = path.read_text()
+    if MARK in text:
+        return
+
+    anchor = '''#define A52_P283_PHY_LANE_STATUS1   0x14c\n\n'''
+    inject = anchor + '''/* A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1\n * Snapdragon 720G/Lagoon reports DSI_PHY_VERSION_3_0. These offsets are the\n * exact 10-nm v3.0 common/lane/status offsets used by TouchGrass. Read-only.\n */\n#define A52_P284_V3_CLK_CFG0        0x010\n#define A52_P284_V3_CLK_CFG1        0x014\n#define A52_P284_V3_GLBL_CTRL       0x018\n#define A52_P284_V3_RBUF_CTRL       0x01c\n#define A52_P284_V3_VREG_CTRL       0x020\n#define A52_P284_V3_CTRL0           0x024\n#define A52_P284_V3_CTRL1           0x028\n#define A52_P284_V3_CTRL2           0x02c\n#define A52_P284_V3_LANE_CFG0       0x030\n#define A52_P284_V3_LANE_CFG1       0x034\n#define A52_P284_V3_PLL_CTRL        0x038\n#define A52_P284_V3_LANE_CTRL0      0x098\n#define A52_P284_V3_LANE_CTRL1      0x09c\n#define A52_P284_V3_LANE_CTRL2      0x0a0\n#define A52_P284_V3_LANE_CTRL3      0x0a4\n#define A52_P284_V3_LANE_CTRL4      0x0a8\n#define A52_P284_V3_STATUS          0x0ec\n#define A52_P284_V3_LANE_STATUS0    0x0f4\n#define A52_P284_V3_LANE_STATUS1    0x0f8\n\n'''
+    text = replace_one(text, anchor, inject, 'PHY define tail')
+
+    anchor2 = '''\tver = phy->ver_info->version;\n\tif (ver != DSI_PHY_VERSION_4_0 && ver != DSI_PHY_VERSION_4_1) {\n'''
+    inject2 = '''\tver = phy->ver_info->version;\n\tif (ver == DSI_PHY_VERSION_3_0) {\n\t\tbase = phy->hw.base;\n\t\ta52_ackfr_record("P276 284P0 q=%u %u %x %x %x %x", point, ver,\n\t\t\treadl_relaxed(base + A52_P284_V3_PLL_CTRL),\n\t\t\treadl_relaxed(base + A52_P284_V3_STATUS),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_STATUS0),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_STATUS1));\n\t\ta52_ackfr_record("P276 284P1 q=%u %x %x %x %x %x %x", point,\n\t\t\treadl_relaxed(base + A52_P284_V3_CLK_CFG0),\n\t\t\treadl_relaxed(base + A52_P284_V3_CLK_CFG1),\n\t\t\treadl_relaxed(base + A52_P284_V3_GLBL_CTRL),\n\t\t\treadl_relaxed(base + A52_P284_V3_RBUF_CTRL),\n\t\t\treadl_relaxed(base + A52_P284_V3_VREG_CTRL),\n\t\t\treadl_relaxed(base + A52_P284_V3_CTRL0));\n\t\ta52_ackfr_record("P276 284P2 q=%u %x %x %x %x %x %x", point,\n\t\t\treadl_relaxed(base + A52_P284_V3_CTRL1),\n\t\t\treadl_relaxed(base + A52_P284_V3_CTRL2),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CFG0),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CFG1),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CTRL0),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CTRL1));\n\t\ta52_ackfr_record("P276 284P3 q=%u %x %x %x", point,\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CTRL2),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CTRL3),\n\t\t\treadl_relaxed(base + A52_P284_V3_LANE_CTRL4));\n\t\treturn;\n\t}\n\tif (ver != DSI_PHY_VERSION_4_0 && ver != DSI_PHY_VERSION_4_1) {\n'''
+    text = replace_one(text, anchor2, inject2, 'PHY version dispatch')
+    path.write_text(text)
+
+
+def check(root: Path):
+    ctrl = (root / CTRL_REL).read_text()
+    phy = (root / PHY_REL).read_text()
+    need_ctrl = [MARK, 'P276 284C0 q=%u %x %x %x %x', 'P276 284C1 q=%u %x %x %x %x',
+                 'P276 284C2 q=%u %x %x %x %x %x %x', 'P276 284C3 q=%u e=%x',
+                 'clk_freq.byte_intf_clk_rate', 'clk_info.pll_op_clks.byte_clk']
+    need_phy = [MARK, 'DSI_PHY_VERSION_3_0', 'A52_P284_V3_PLL_CTRL        0x038',
+                'A52_P284_V3_STATUS          0x0ec', 'P276 284P0 q=%u %u %x %x %x %x',
+                'P276 284P1 q=%u %x %x %x %x %x %x', 'P276 284P2 q=%u %x %x %x %x %x %x',
+                'P276 284P3 q=%u %x %x %x']
+    for x in need_ctrl:
+        if x not in ctrl:
+            raise SystemExit('Phase284 controller check missing: ' + x)
+    for x in need_phy:
+        if x not in phy:
+            raise SystemExit('Phase284 PHY check missing: ' + x)
+    print('Phase284 v3 PHY + link clock chain trace: PASS')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', required=True)
+    ap.add_argument('--check-only', action='store_true')
+    ns = ap.parse_args()
+    root = Path(ns.root)
+    if not ns.check_only:
+        apply_ctrl(root / CTRL_REL)
+        apply_phy(root / PHY_REL)
+    check(root)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/284_ci_build.sh
+++ b/scripts/284_ci_build.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+DISPLAY="$ROOT/drivers/a52_display/msm/dsi/dsi_display.c"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+COMMON="$ROOT/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"
+PANEL="$ROOT/drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c"
+
+fail_report(){
+  set +e
+  rm -rf phase284-failure
+  mkdir -p phase284-failure/{source,logs,audit}
+  cp phase284-compile.log phase284-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$PHY" "$DISPLAY" "$SMMU" "$REC" "$COMMON" "$PANEL"; do
+    [ -f "$f" ] && cp "$f" phase284-failure/source/ || true
+  done
+  cp scripts/284_apply_v3_phy_clock_trace.py phase284-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact successful Phase283C lineage first. Phase284 is only a
+# read-only v3.0 PHY + link-clock-source extension over that hardware capture.
+bash scripts/283c_ci_build.sh
+test -s phase283b-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DSI" "$PHY" "$DISPLAY" "$SMMU" "$REC" "$COMMON" "$PANEL"; do test -s "$f"; done
+
+cp "$OUT/.config" /tmp/p284-base.config
+cp "$DSI" /tmp/p284-dsi-before.c
+cp "$PHY" /tmp/p284-phy-before.c
+cp "$DISPLAY" /tmp/p284-display-before.c
+cp "$SMMU" /tmp/p284-smmu-before.c
+cp "$REC" /tmp/p284-rec-before.c
+cp "$COMMON" /tmp/p284-common-before.c
+cp "$PANEL" /tmp/p284-panel-before.c
+
+python3 -m py_compile scripts/284_apply_v3_phy_clock_trace.py
+python3 scripts/284_apply_v3_phy_clock_trace.py --root "$ROOT"
+python3 scripts/284_apply_v3_phy_clock_trace.py --root "$ROOT" --check-only
+
+# Phase284 must touch only the two diagnostic sources.
+cmp -s /tmp/p284-display-before.c "$DISPLAY"
+cmp -s /tmp/p284-smmu-before.c "$SMMU"
+cmp -s /tmp/p284-rec-before.c "$REC"
+cmp -s /tmp/p284-common-before.c "$COMMON"
+cmp -s /tmp/p284-panel-before.c "$PANEL"
+! cmp -s /tmp/p284-dsi-before.c "$DSI"
+! cmp -s /tmp/p284-phy-before.c "$PHY"
+
+grep -Fq 'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1' "$DSI"
+grep -Fq 'P276 284C0 q=%u %x %x %x %x' "$DSI"
+grep -Fq 'P276 284C3 q=%u e=%x' "$DSI"
+grep -Fq 'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1' "$PHY"
+grep -Fq 'A52_P284_V3_PLL_CTRL        0x038' "$PHY"
+grep -Fq 'A52_P284_V3_STATUS          0x0ec' "$PHY"
+grep -Fq 'P276 284P0 q=%u %u %x %x %x %x' "$PHY"
+grep -Fq 'P276 282F a=0 t=1' "$DSI"
+grep -Fq 'P276 280Z q=2' "$DSI"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p284-base.config "$OUT/.config"
+grep -Fxq 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase284-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase284-out
+mkdir -p phase284-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase284-out/compile/Image
+cp "$OUT/.config" phase284-out/config/final.config
+cp /tmp/p284-base.config phase284-out/audit/phase283-final.config
+cp /tmp/p284-dsi-before.c phase284-out/audit/dsi-ctrl-before.c
+cp /tmp/p284-phy-before.c phase284-out/audit/dsi-phy-before.c
+cp /tmp/p284-display-before.c phase284-out/audit/dsi-display-before.c
+cp phase284-compile.log phase284-out/audit/
+cp scripts/284_apply_v3_phy_clock_trace.py phase284-out/audit/
+cp "$DSI" phase284-out/source/dsi_ctrl.c
+cp "$PHY" phase284-out/source/dsi_phy.c
+cp "$DISPLAY" phase284-out/source/dsi_display.c
+
+gzip -n -c "$IMAGE" > phase284-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase283b-out/package/boot.img \
+  --kernel phase284-out/package/Image.gz \
+  --output phase284-out/package/boot.img \
+  --report phase284-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase284-out')
+idn={
+ 'phase':'284',
+ 'name':'V3-PHY-LINK-CLOCK-CHAIN-TRACE',
+ 'git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,
+ 'base':'hardware-tested Phase283 shared DSI/PHY + Golden handoff trace',
+ 'phase283_result':'FIFO still times out; controller/runtime-PM and controller+PHY regulators remain asserted; PHY is version 3.0, which Phase283 raw tracer did not decode',
+ 'behavior_change_from_phase283':False,
+ 'brightness_mapping_changed':False,
+ 'smmu_changed':False,
+ 'timeout_recovery_changed':False,
+ 'splash_handoff_changed':False,
+ 'records':{
+   '284C0':'configured target byte/pixel/byte-interface/escape rates',
+   '284C1':'controller RCG byte/pixel + selected PLL-source byte/pixel rates',
+   '284C2':'byte leaf/parent/grandparent + pixel leaf/parent/grandparent rates',
+   '284C3':'packed enabled states for RCG, selected PLL source, and parent chains',
+   '284P0':'v3 PHY version, PLL control, PHY status, lane status 0/1',
+   '284P1':'v3 common clock/global/rbuf/vreg/control0 registers',
+   '284P2':'v3 control1/2, lane config0/1, lane control0/1',
+   '284P3':'v3 lane control2/3/4'
+ }
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=['compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json','audit/phase283-final.config','audit/dsi-ctrl-before.c','audit/dsi-phy-before.c','audit/dsi-display-before.c','audit/phase284-compile.log','audit/284_apply_v3_phy_clock_trace.py','source/dsi_ctrl.c','source/dsi_phy.c','source/dsi_display.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files: f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase284-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r=Path('phase284-out')
+d=(r/'source/dsi_ctrl.c').read_text(); p=(r/'source/dsi_phy.c').read_text(); img=(r/'compile/Image').read_bytes()
+for m in ['A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1','P276 284C0 q=%u %x %x %x %x','P276 284C1 q=%u %x %x %x %x','P276 284C2 q=%u %x %x %x %x %x %x','P276 284C3 q=%u e=%x','P276 282F a=0 t=1','P276 280Z q=2']:
+ if m not in d: raise SystemExit('Phase284 DSI source marker missing: '+m)
+for m in ['A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1','P276 284P0 q=%u %u %x %x %x %x','P276 284P1 q=%u %x %x %x %x %x %x','P276 284P2 q=%u %x %x %x %x %x %x','P276 284P3 q=%u %x %x %x']:
+ if m not in p: raise SystemExit('Phase284 PHY source marker missing: '+m)
+for m in ['P276 284C0 q=%u %x %x %x %x','P276 284C3 q=%u e=%x','P276 284P0 q=%u %u %x %x %x %x','P276 284P3 q=%u %x %x %x','P276 282F a=0 t=1','P276 280Z q=2']:
+ if m.encode() not in img: raise SystemExit('Phase284 runtime marker missing from Image: '+m)
+print('Phase284 v3 PHY + link clock chain marker audit: PASS')
+PY
+
+python3 scripts/284_apply_v3_phy_clock_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase284 v3 PHY + link clock chain trace build/repack: PASS'

--- a/scripts/284b_apply_clock_causality_trace.py
+++ b/scripts/284b_apply_clock_causality_trace.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CLK = Path('drivers/a52_display/msm/dsi/dsi_clk_manager.c')
+DISPLAY = Path('drivers/a52_display/msm/dsi/dsi_display.c')
+MARK = 'A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase284 causality: expected one {label} anchor, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_display(text: str) -> str:
+    if MARK in text:
+        return text
+
+    if 'A52_PHASE283_GOLDEN_HANDOFF_TRACE_V1' not in text:
+        raise SystemExit('Phase284 causality: Phase283 display handoff prerequisite missing')
+    if '#include <linux/a52_ack_secure_flight_recorder.h>' not in text:
+        raise SystemExit('Phase284 causality: recorder include missing from reconstructed display source')
+
+    text = replace_one(
+        text,
+        '#define DSI_CLOCK_BITRATE_RADIX 10\n#define MAX_TE_SOURCE_ID  2\n',
+        '#define DSI_CLOCK_BITRATE_RADIX 10\n#define MAX_TE_SOURCE_ID  2\n\n'
+        '/* ' + MARK + '\n'
+        ' * Bounded, read-only trace of the rate producer. This is the GKI-side\n'
+        ' * counterpart to Golden TGREF DERIVE and does not alter clock values.\n'
+        ' */\n'
+        'static unsigned int a52_p284_origin_logs;\n',
+        'display clock-origin counter')
+
+    old = (
+        '\t\tSDE_EVT32(i, bit_rate, byte_clk_rate, pclk_rate);\n\n'
+        '\t\tctrl->clk_freq.byte_clk_rate = byte_clk_rate;\n'
+        '\t\tctrl->clk_freq.byte_intf_clk_rate = byte_intf_clk_rate;\n'
+        '\t\tctrl->clk_freq.pix_clk_rate = pclk_rate;\n'
+        '\t\trc = dsi_clk_set_link_frequencies(display->dsi_clk_handle,\n'
+        '\t\t\tctrl->clk_freq, ctrl->cell_index);\n'
+    )
+    new = (
+        '\t\tSDE_EVT32(i, bit_rate, byte_clk_rate, pclk_rate);\n\n'
+        '\t\tif (a52_p284_origin_logs < 8) {\n'
+        '\t\t\ta52_ackfr_record("P276 284O0 c=%d y=%u in=%u l=%u b=%u d=%u",\n'
+        '\t\t\t\tctrl->cell_index, host_cfg->phy_type, bit_clk_rate,\n'
+        '\t\t\t\tnum_of_lanes, bpp, host_cfg->byte_intf_clk_div);\n'
+        '\t\t\ta52_ackfr_record("P276 284O1 bit=%llx lane=%llx b=%llx i=%llx p=%llx",\n'
+        '\t\t\t\t(unsigned long long)bit_rate,\n'
+        '\t\t\t\t(unsigned long long)bit_rate_per_lane,\n'
+        '\t\t\t\t(unsigned long long)byte_clk_rate,\n'
+        '\t\t\t\t(unsigned long long)byte_intf_clk_rate,\n'
+        '\t\t\t\t(unsigned long long)pclk_rate);\n'
+        '\t\t\ta52_p284_origin_logs++;\n'
+        '\t\t}\n\n'
+        '\t\tctrl->clk_freq.byte_clk_rate = byte_clk_rate;\n'
+        '\t\tctrl->clk_freq.byte_intf_clk_rate = byte_intf_clk_rate;\n'
+        '\t\tctrl->clk_freq.pix_clk_rate = pclk_rate;\n'
+        '\t\trc = dsi_clk_set_link_frequencies(display->dsi_clk_handle,\n'
+        '\t\t\tctrl->clk_freq, ctrl->cell_index);\n'
+    )
+    return replace_one(text, old, new, 'display derived-rate')
+
+
+def patch_clk(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = replace_one(
+        text,
+        '#include "dsi_clk.h"\n',
+        '#include "dsi_clk.h"\n'
+        '#include <linux/clk.h>\n'
+        '#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'clock-manager recorder include')
+
+    helper_anchor = '''struct dsi_core_clks {\n'''
+    helper = '''/* A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1
+ * Bounded, read-only trace of how DSI link rates move from the cached request
+ * into clock-framework parents and leaf clocks. No parent/rate/enable operation
+ * is added, removed, retried or reordered.
+ */
+static unsigned int a52_p284_cache_logs;
+static unsigned int a52_p284_setp_logs;
+static unsigned int a52_p284_setb_logs;
+static unsigned int a52_p284_parent_logs;
+static unsigned int a52_p284_apply_logs;
+
+static unsigned long a52_p284_clk_rate(struct clk *clk)
+{
+\treturn clk ? clk_get_rate(clk) : 0;
+}
+
+static unsigned long a52_p284_parent_rate(struct clk *clk)
+{
+\tstruct clk *parent = clk ? clk_get_parent(clk) : NULL;
+
+\treturn parent ? clk_get_rate(parent) : 0;
+}
+
+struct dsi_core_clks {
+'''
+    text = replace_one(text, helper_anchor, helper, 'clock-manager helper')
+
+    old = '''\tmemcpy(&mngr->link_clks[clk_mngr_index].freq, &freq,
+\t\tsizeof(struct link_clk_freq));
+
+\treturn rc;
+}
+'''
+    new = '''\tmemcpy(&mngr->link_clks[clk_mngr_index].freq, &freq,
+\t\tsizeof(struct link_clk_freq));
+
+\tif (a52_p284_cache_logs < 8) {
+\t\ta52_ackfr_record("P276 284M0 c=%u m=%d b=%llx p=%llx i=%llx e=%llx",
+\t\t\tindex, clk_mngr_index,
+\t\t\t(unsigned long long)freq.byte_clk_rate,
+\t\t\t(unsigned long long)freq.pix_clk_rate,
+\t\t\t(unsigned long long)freq.byte_intf_clk_rate,
+\t\t\t(unsigned long long)freq.esc_clk_rate);
+\t\ta52_p284_cache_logs++;
+\t}
+
+\treturn rc;
+}
+'''
+    text = replace_one(text, old, new, 'cached-frequency propagation')
+
+    old = '''\trc = clk_set_rate(mngr->link_clks[index].hs_clks.pixel_clk, pixel_clk);
+\tif (rc)
+\t\tDSI_ERR("failed to set clk rate for pixel clk, rc=%d\\n", rc);
+\telse
+\t\tmngr->link_clks[index].freq.pix_clk_rate = pixel_clk;
+
+\treturn rc;
+}
+'''
+    new = '''\trc = clk_set_rate(mngr->link_clks[index].hs_clks.pixel_clk, pixel_clk);
+\tif (rc)
+\t\tDSI_ERR("failed to set clk rate for pixel clk, rc=%d\\n", rc);
+\telse
+\t\tmngr->link_clks[index].freq.pix_clk_rate = pixel_clk;
+
+\tif (a52_p284_setp_logs < 8) {
+\t\ta52_ackfr_record("P276 284M1 c=%u req=%llx rc=%d a=%lx p=%lx",
+\t\t\tindex, (unsigned long long)pixel_clk, rc,
+\t\t\ta52_p284_clk_rate(mngr->link_clks[index].hs_clks.pixel_clk),
+\t\t\ta52_p284_parent_rate(mngr->link_clks[index].hs_clks.pixel_clk));
+\t\ta52_p284_setp_logs++;
+\t}
+
+\treturn rc;
+}
+'''
+    text = replace_one(text, old, new, 'explicit pixel setter')
+
+    old = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {
+\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,
+\t\t\t\t  byte_intf_clk);
+\t\tif (rc)
+\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",
+\t\t\t       rc);
+\t\telse
+\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =
+\t\t\t\t\t\t\t\tbyte_intf_clk;
+\t}
+
+\treturn rc;
+}
+'''
+    new = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {
+\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,
+\t\t\t\t  byte_intf_clk);
+\t\tif (rc)
+\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",
+\t\t\t       rc);
+\t\telse
+\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =
+\t\t\t\t\t\t\t\tbyte_intf_clk;
+\t}
+
+\tif (a52_p284_setb_logs < 8) {
+\t\ta52_ackfr_record("P276 284M2 c=%u rb=%llx ri=%llx rc=%d ab=%lx pb=%lx ai=%lx",
+\t\t\tindex, (unsigned long long)byte_clk,
+\t\t\t(unsigned long long)byte_intf_clk, rc,
+\t\t\ta52_p284_clk_rate(mngr->link_clks[index].hs_clks.byte_clk),
+\t\t\ta52_p284_parent_rate(mngr->link_clks[index].hs_clks.byte_clk),
+\t\t\ta52_p284_clk_rate(mngr->link_clks[index].hs_clks.byte_intf_clk));
+\t\ta52_p284_setb_logs++;
+\t}
+
+\treturn rc;
+}
+'''
+    text = replace_one(text, old, new, 'explicit byte setter')
+
+    old = '''int dsi_clk_update_parent(struct dsi_clk_link_set *parent,
+\t\t\t  struct dsi_clk_link_set *child)
+{
+\tint rc = 0;
+
+\trc = clk_set_parent(child->byte_clk, parent->byte_clk);
+'''
+    new = '''int dsi_clk_update_parent(struct dsi_clk_link_set *parent,
+\t\t\t  struct dsi_clk_link_set *child)
+{
+\tint rc = 0;
+\tbool a52_trace = a52_p284_parent_logs < 8;
+
+\tif (a52_trace)
+\t\ta52_ackfr_record("P276 284M3 cb=%lx cp=%lx tb=%lx pp=%lx tp=%lx",
+\t\t\ta52_p284_clk_rate(child->byte_clk),
+\t\t\ta52_p284_clk_rate(child->pixel_clk),
+\t\t\ta52_p284_clk_rate(parent->byte_clk),
+\t\t\ta52_p284_parent_rate(child->pixel_clk),
+\t\t\ta52_p284_clk_rate(parent->pixel_clk));
+
+\trc = clk_set_parent(child->byte_clk, parent->byte_clk);
+'''
+    text = replace_one(text, old, new, 'clock-parent pre-state')
+
+    old = '''error:
+\treturn rc;
+}
+
+/**
+ * dsi_clk_prepare_enable()'''
+    new = '''error:
+\tif (a52_trace) {
+\t\ta52_ackfr_record("P276 284M4 rc=%d cb=%lx bp=%lx cp=%lx pp=%lx",
+\t\t\trc, a52_p284_clk_rate(child->byte_clk),
+\t\t\ta52_p284_parent_rate(child->byte_clk),
+\t\t\ta52_p284_clk_rate(child->pixel_clk),
+\t\t\ta52_p284_parent_rate(child->pixel_clk));
+\t\ta52_p284_parent_logs++;
+\t}
+\treturn rc;
+}
+
+/**
+ * dsi_clk_prepare_enable()'''
+    text = replace_one(text, old, new, 'clock-parent post-state')
+
+    old = '''\tif (mngr->is_cont_splash_enabled)
+\t\treturn 0;
+
+\trc = clk_set_rate(link_hs_clks->byte_clk,
+\t\tl_clks->freq.byte_clk_rate);
+\tif (rc) {
+\t\tDSI_ERR("clk_set_rate failed for byte_clk rc = %d\\n", rc);
+\t\tgoto error;
+\t}
+
+\trc = clk_set_rate(link_hs_clks->pixel_clk,
+\t\tl_clks->freq.pix_clk_rate);
+\tif (rc) {
+\t\tDSI_ERR("clk_set_rate failed for pixel_clk rc = %d\\n", rc);
+\t\tgoto error;
+\t}
+
+\t/*
+\t * If byte_intf_clk is present, set rate for that too.
+\t */
+\tif (link_hs_clks->byte_intf_clk) {
+\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,
+\t\t\t\tl_clks->freq.byte_intf_clk_rate);
+\t\tif (rc) {
+\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",
+\t\t\t\trc);
+\t\t\tgoto error;
+\t\t}
+\t}
+error:
+\treturn rc;
+}
+'''
+    new = '''\tif (mngr->is_cont_splash_enabled) {
+\t\tif (a52_p284_apply_logs < 12) {
+\t\t\ta52_ackfr_record("P276 284M5 c=%d sp=1 b=%llx p=%llx i=%llx",
+\t\t\t\tindex,
+\t\t\t\t(unsigned long long)l_clks->freq.byte_clk_rate,
+\t\t\t\t(unsigned long long)l_clks->freq.pix_clk_rate,
+\t\t\t\t(unsigned long long)l_clks->freq.byte_intf_clk_rate);
+\t\t\ta52_p284_apply_logs++;
+\t\t}
+\t\treturn 0;
+\t}
+
+\trc = clk_set_rate(link_hs_clks->byte_clk,
+\t\tl_clks->freq.byte_clk_rate);
+\tif (a52_p284_apply_logs < 12) {
+\t\ta52_ackfr_record("P276 284M6 c=%d req=%llx rc=%d a=%lx p=%lx",
+\t\t\tindex, (unsigned long long)l_clks->freq.byte_clk_rate, rc,
+\t\t\ta52_p284_clk_rate(link_hs_clks->byte_clk),
+\t\t\ta52_p284_parent_rate(link_hs_clks->byte_clk));
+\t\ta52_p284_apply_logs++;
+\t}
+\tif (rc) {
+\t\tDSI_ERR("clk_set_rate failed for byte_clk rc = %d\\n", rc);
+\t\tgoto error;
+\t}
+
+\trc = clk_set_rate(link_hs_clks->pixel_clk,
+\t\tl_clks->freq.pix_clk_rate);
+\tif (a52_p284_apply_logs < 12) {
+\t\ta52_ackfr_record("P276 284M7 c=%d req=%llx rc=%d a=%lx p=%lx",
+\t\t\tindex, (unsigned long long)l_clks->freq.pix_clk_rate, rc,
+\t\t\ta52_p284_clk_rate(link_hs_clks->pixel_clk),
+\t\t\ta52_p284_parent_rate(link_hs_clks->pixel_clk));
+\t\ta52_p284_apply_logs++;
+\t}
+\tif (rc) {
+\t\tDSI_ERR("clk_set_rate failed for pixel_clk rc = %d\\n", rc);
+\t\tgoto error;
+\t}
+
+\t/*
+\t * If byte_intf_clk is present, set rate for that too.
+\t */
+\tif (link_hs_clks->byte_intf_clk) {
+\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,
+\t\t\t\tl_clks->freq.byte_intf_clk_rate);
+\t\tif (a52_p284_apply_logs < 12) {
+\t\t\ta52_ackfr_record("P276 284M8 c=%d req=%llx rc=%d a=%lx p=%lx",
+\t\t\t\tindex,
+\t\t\t\t(unsigned long long)l_clks->freq.byte_intf_clk_rate, rc,
+\t\t\t\ta52_p284_clk_rate(link_hs_clks->byte_intf_clk),
+\t\t\t\ta52_p284_parent_rate(link_hs_clks->byte_intf_clk));
+\t\t\ta52_p284_apply_logs++;
+\t\t}
+\t\tif (rc) {
+\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",
+\t\t\t\trc);
+\t\t\tgoto error;
+\t\t}
+\t}
+error:
+\treturn rc;
+}
+'''
+    text = replace_one(text, old, new, 'link HS rate application')
+    return text
+
+
+def validate(root: Path) -> None:
+    clk = (root / CLK).read_text()
+    display = (root / DISPLAY).read_text()
+    for token in [
+        MARK,
+        'P276 284M0 c=%u m=%d b=%llx p=%llx i=%llx e=%llx',
+        'P276 284M1 c=%u req=%llx rc=%d a=%lx p=%lx',
+        'P276 284M2 c=%u rb=%llx ri=%llx rc=%d ab=%lx pb=%lx ai=%lx',
+        'P276 284M3 cb=%lx cp=%lx tb=%lx pp=%lx tp=%lx',
+        'P276 284M4 rc=%d cb=%lx bp=%lx cp=%lx pp=%lx',
+        'P276 284M5 c=%d sp=1 b=%llx p=%llx i=%llx',
+        'P276 284M6 c=%d req=%llx rc=%d a=%lx p=%lx',
+        'P276 284M7 c=%d req=%llx rc=%d a=%lx p=%lx',
+        'P276 284M8 c=%d req=%llx rc=%d a=%lx p=%lx',
+    ]:
+        if token not in clk:
+            raise SystemExit('Phase284 causality clock check missing: ' + token)
+    for token in [
+        MARK,
+        'P276 284O0 c=%d y=%u in=%u l=%u b=%u d=%u',
+        'P276 284O1 bit=%llx lane=%llx b=%llx i=%llx p=%llx',
+        'bit_rate_per_lane',
+        'host_cfg->byte_intf_clk_div',
+    ]:
+        if token not in display:
+            raise SystemExit('Phase284 causality display check missing: ' + token)
+    print('Phase284 clock causality trace: PASS')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', required=True, type=Path)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    if not args.check_only:
+        clk_path = args.root / CLK
+        display_path = args.root / DISPLAY
+        clk_path.write_text(patch_clk(clk_path.read_text()))
+        display_path.write_text(patch_display(display_path.read_text()))
+
+    validate(args.root)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/284b_apply_clock_causality_trace.py
+++ b/scripts/284b_apply_clock_causality_trace.py
@@ -213,10 +213,11 @@ struct dsi_core_clks {
 \tbool a52_trace = a52_p284_parent_logs < 8;
 
 \tif (a52_trace)
-\t\ta52_ackfr_record("P276 284M3 cb=%lx cp=%lx tb=%lx pp=%lx tp=%lx",
+\t\ta52_ackfr_record("P276 284M3 cb=%lx bp=%lx tb=%lx cp=%lx pp=%lx tp=%lx",
 \t\t\ta52_p284_clk_rate(child->byte_clk),
-\t\t\ta52_p284_clk_rate(child->pixel_clk),
+\t\t\ta52_p284_parent_rate(child->byte_clk),
 \t\t\ta52_p284_clk_rate(parent->byte_clk),
+\t\t\ta52_p284_clk_rate(child->pixel_clk),
 \t\t\ta52_p284_parent_rate(child->pixel_clk),
 \t\t\ta52_p284_clk_rate(parent->pixel_clk));
 
@@ -355,7 +356,7 @@ def validate(root: Path) -> None:
         'P276 284M0 c=%u m=%d b=%llx p=%llx i=%llx e=%llx',
         'P276 284M1 c=%u req=%llx rc=%d a=%lx p=%lx',
         'P276 284M2 c=%u rb=%llx ri=%llx rc=%d ab=%lx pb=%lx ai=%lx',
-        'P276 284M3 cb=%lx cp=%lx tb=%lx pp=%lx tp=%lx',
+        'P276 284M3 cb=%lx bp=%lx tb=%lx cp=%lx pp=%lx tp=%lx',
         'P276 284M4 rc=%d cb=%lx bp=%lx cp=%lx pp=%lx',
         'P276 284M5 c=%d sp=1 b=%llx p=%llx i=%llx',
         'P276 284M6 c=%d req=%llx rc=%d a=%lx p=%lx',

--- a/scripts/284b_ci_build.sh
+++ b/scripts/284b_ci_build.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+DISPLAY="$ROOT/drivers/a52_display/msm/dsi/dsi_display.c"
+CLK="$ROOT/drivers/a52_display/msm/dsi/dsi_clk_manager.c"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+COMMON="$ROOT/drivers/a52_display/msm/samsung/ss_dsi_panel_common.c"
+PANEL="$ROOT/drivers/a52_display/msm/samsung/S6E3FC3_AMS646YD01/ss_dsi_panel_S6E3FC3_AMS646YD01.c"
+
+fail_report(){
+  set +e
+  rm -rf phase284-failure
+  mkdir -p phase284-failure/{source,logs,audit}
+  cp phase284-compile.log phase284-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$PHY" "$DISPLAY" "$CLK" "$SMMU" "$REC" "$COMMON" "$PANEL"; do
+    [ -f "$f" ] && cp "$f" phase284-failure/source/ || true
+  done
+  cp scripts/284_apply_v3_phy_clock_trace.py phase284-failure/audit/ 2>/dev/null || true
+  cp scripts/284b_apply_clock_causality_trace.py phase284-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact successful Phase283C lineage. Phase284 then layers two
+# strictly read-only probes: the v3 PHY/result snapshot and the upstream rate
+# producer/cache/parent/set-rate causality chain.
+bash scripts/283c_ci_build.sh
+test -s phase283b-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DSI" "$PHY" "$DISPLAY" "$CLK" "$SMMU" "$REC" "$COMMON" "$PANEL"; do
+  test -s "$f"
+done
+
+cp "$OUT/.config" /tmp/p284-base.config
+cp "$DSI" /tmp/p284-dsi-before.c
+cp "$PHY" /tmp/p284-phy-before.c
+cp "$DISPLAY" /tmp/p284-display-before.c
+cp "$CLK" /tmp/p284-clk-before.c
+cp "$SMMU" /tmp/p284-smmu-before.c
+cp "$REC" /tmp/p284-rec-before.c
+cp "$COMMON" /tmp/p284-common-before.c
+cp "$PANEL" /tmp/p284-panel-before.c
+
+python3 -m py_compile \
+  scripts/284_apply_v3_phy_clock_trace.py \
+  scripts/284b_apply_clock_causality_trace.py
+python3 scripts/284_apply_v3_phy_clock_trace.py --root "$ROOT"
+python3 scripts/284b_apply_clock_causality_trace.py --root "$ROOT"
+python3 scripts/284_apply_v3_phy_clock_trace.py --root "$ROOT" --check-only
+python3 scripts/284b_apply_clock_causality_trace.py --root "$ROOT" --check-only
+
+# Phase284 remains observational. Only the four DSI diagnostic sources may
+# differ from the reconstructed Phase283C tree.
+cmp -s /tmp/p284-smmu-before.c "$SMMU"
+cmp -s /tmp/p284-rec-before.c "$REC"
+cmp -s /tmp/p284-common-before.c "$COMMON"
+cmp -s /tmp/p284-panel-before.c "$PANEL"
+! cmp -s /tmp/p284-dsi-before.c "$DSI"
+! cmp -s /tmp/p284-phy-before.c "$PHY"
+! cmp -s /tmp/p284-display-before.c "$DISPLAY"
+! cmp -s /tmp/p284-clk-before.c "$CLK"
+
+grep -Fq 'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1' "$DSI"
+grep -Fq 'P276 284C0 q=%u %x %x %x %x' "$DSI"
+grep -Fq 'P276 284C3 q=%u e=%x' "$DSI"
+grep -Fq 'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1' "$PHY"
+grep -Fq 'A52_P284_V3_PLL_CTRL        0x038' "$PHY"
+grep -Fq 'A52_P284_V3_STATUS          0x0ec' "$PHY"
+grep -Fq 'P276 284P0 q=%u %u %x %x %x %x' "$PHY"
+grep -Fq 'A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1' "$DISPLAY"
+grep -Fq 'P276 284O0 c=%d y=%u in=%u l=%u b=%u d=%u' "$DISPLAY"
+grep -Fq 'P276 284O1 bit=%llx lane=%llx b=%llx i=%llx p=%llx' "$DISPLAY"
+grep -Fq 'A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1' "$CLK"
+for m in 284M0 284M1 284M2 284M3 284M4 284M5 284M6 284M7 284M8; do
+  grep -Fq "P276 $m" "$CLK"
+done
+grep -Fq 'P276 282F a=0 t=1' "$DSI"
+grep -Fq 'P276 280Z q=2' "$DSI"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p284-base.config "$OUT/.config"
+grep -Fxq 'CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE=n' "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase284-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase284-out
+mkdir -p phase284-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase284-out/compile/Image
+cp "$OUT/.config" phase284-out/config/final.config
+cp /tmp/p284-base.config phase284-out/audit/phase283-final.config
+cp /tmp/p284-dsi-before.c phase284-out/audit/dsi-ctrl-before.c
+cp /tmp/p284-phy-before.c phase284-out/audit/dsi-phy-before.c
+cp /tmp/p284-display-before.c phase284-out/audit/dsi-display-before.c
+cp /tmp/p284-clk-before.c phase284-out/audit/dsi-clk-manager-before.c
+cp phase284-compile.log phase284-out/audit/
+cp scripts/284_apply_v3_phy_clock_trace.py phase284-out/audit/
+cp scripts/284b_apply_clock_causality_trace.py phase284-out/audit/
+cp "$DSI" phase284-out/source/dsi_ctrl.c
+cp "$PHY" phase284-out/source/dsi_phy.c
+cp "$DISPLAY" phase284-out/source/dsi_display.c
+cp "$CLK" phase284-out/source/dsi_clk_manager.c
+
+gzip -n -c "$IMAGE" > phase284-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase283b-out/package/boot.img \
+  --kernel phase284-out/package/Image.gz \
+  --output phase284-out/package/boot.img \
+  --report phase284-out/package/repack-report.json
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+
+r = Path('phase284-out')
+idn = {
+    'phase': '284',
+    'name': 'V3-PHY-LINK-CLOCK-CAUSALITY-TRACE',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'hardware_validated': False,
+    'base': 'hardware-tested Phase283 shared DSI/PHY + Golden handoff trace',
+    'phase283_result': (
+        'FIFO still times out while controller/runtime-PM and controller+PHY '
+        'regulator votes remain asserted; PHY reports v3.0'
+    ),
+    'behavior_change_from_phase283': False,
+    'brightness_mapping_changed': False,
+    'smmu_changed': False,
+    'timeout_recovery_changed': False,
+    'splash_handoff_changed': False,
+    'causal_question': (
+        'Does the zero-Hz result originate in rate derivation/cache, in '
+        'continuous-splash rate skipping, or during parent/set-rate propagation?'
+    ),
+    'records': {
+        '284O0': 'rate-producer inputs: controller, PHY type, input bit clock, lanes, bpp, byte-interface divisor',
+        '284O1': 'rate-producer outputs: aggregate/lane bit rate and byte/interface/pixel rates',
+        '284M0': 'clock-manager cached link frequencies',
+        '284M1': 'explicit pixel-rate setter request/result/actual/parent',
+        '284M2': 'explicit byte/interface setter request/result/actual/parent',
+        '284M3': 'clock-parent state immediately before parent switching',
+        '284M4': 'clock-parent state immediately after parent switching',
+        '284M5': 'continuous-splash rate-application skip and cached rates',
+        '284M6': 'byte clock set-rate request/result/actual/parent',
+        '284M7': 'pixel clock set-rate request/result/actual/parent',
+        '284M8': 'byte-interface clock set-rate request/result/actual/parent',
+        '284C0': 'configured target byte/pixel/byte-interface/escape rates at command snapshot',
+        '284C1': 'controller RCG byte/pixel + selected PLL-source byte/pixel rates',
+        '284C2': 'byte leaf/parent/grandparent + pixel leaf/parent/grandparent rates',
+        '284C3': 'packed enabled states for RCG, selected PLL source, and parent chains',
+        '284P0': 'v3 PHY version, PLL control, PHY status, lane status 0/1',
+        '284P1': 'v3 common clock/global/rbuf/vreg/control0 registers',
+        '284P2': 'v3 control1/2, lane config0/1, lane control0/1',
+        '284P3': 'v3 lane control2/3/4',
+    },
+}
+(r / 'BUILD-IDENTITY.json').write_text(json.dumps(idn, indent=2, sort_keys=True) + '\n')
+files = [
+    'compile/Image',
+    'config/final.config',
+    'package/Image.gz',
+    'package/boot.img',
+    'package/repack-report.json',
+    'audit/phase283-final.config',
+    'audit/dsi-ctrl-before.c',
+    'audit/dsi-phy-before.c',
+    'audit/dsi-display-before.c',
+    'audit/dsi-clk-manager-before.c',
+    'audit/phase284-compile.log',
+    'audit/284_apply_v3_phy_clock_trace.py',
+    'audit/284b_apply_clock_causality_trace.py',
+    'source/dsi_ctrl.c',
+    'source/dsi_phy.c',
+    'source/dsi_display.c',
+    'source/dsi_clk_manager.c',
+    'BUILD-IDENTITY.json',
+]
+with (r / 'SHA256SUMS').open('w') as f:
+    for n in files:
+        f.write(hashlib.sha256((r / n).read_bytes()).hexdigest() + '  ./' + n + '\n')
+PY
+(cd phase284-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+
+r = Path('phase284-out')
+d = (r / 'source/dsi_ctrl.c').read_text()
+p = (r / 'source/dsi_phy.c').read_text()
+o = (r / 'source/dsi_display.c').read_text()
+m = (r / 'source/dsi_clk_manager.c').read_text()
+img = (r / 'compile/Image').read_bytes()
+
+for token in [
+    'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1',
+    'P276 284C0 q=%u %x %x %x %x',
+    'P276 284C1 q=%u %x %x %x %x',
+    'P276 284C2 q=%u %x %x %x %x %x %x',
+    'P276 284C3 q=%u e=%x',
+    'P276 282F a=0 t=1',
+    'P276 280Z q=2',
+]:
+    if token not in d:
+        raise SystemExit('Phase284 DSI source marker missing: ' + token)
+
+for token in [
+    'A52_PHASE284_V3_PHY_CLOCK_CHAIN_TRACE_V1',
+    'P276 284P0 q=%u %u %x %x %x %x',
+    'P276 284P1 q=%u %x %x %x %x %x %x',
+    'P276 284P2 q=%u %x %x %x %x %x %x',
+    'P276 284P3 q=%u %x %x %x',
+]:
+    if token not in p:
+        raise SystemExit('Phase284 PHY source marker missing: ' + token)
+
+for token in [
+    'A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1',
+    'P276 284O0 c=%d y=%u in=%u l=%u b=%u d=%u',
+    'P276 284O1 bit=%llx lane=%llx b=%llx i=%llx p=%llx',
+]:
+    if token not in o:
+        raise SystemExit('Phase284 origin source marker missing: ' + token)
+
+for token in [
+    'A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1',
+    'P276 284M0 c=%u m=%d b=%llx p=%llx i=%llx e=%llx',
+    'P276 284M3 cb=%lx cp=%lx tb=%lx pp=%lx tp=%lx',
+    'P276 284M4 rc=%d cb=%lx bp=%lx cp=%lx pp=%lx',
+    'P276 284M5 c=%d sp=1 b=%llx p=%llx i=%llx',
+    'P276 284M6 c=%d req=%llx rc=%d a=%lx p=%lx',
+    'P276 284M7 c=%d req=%llx rc=%d a=%lx p=%lx',
+    'P276 284M8 c=%d req=%llx rc=%d a=%lx p=%lx',
+]:
+    if token not in m:
+        raise SystemExit('Phase284 manager source marker missing: ' + token)
+
+for token in [
+    'P276 284C0 q=%u %x %x %x %x',
+    'P276 284C3 q=%u e=%x',
+    'P276 284P0 q=%u %u %x %x %x %x',
+    'P276 284P3 q=%u %x %x %x',
+    'P276 284O0 c=%d y=%u in=%u l=%u b=%u d=%u',
+    'P276 284O1 bit=%llx lane=%llx b=%llx i=%llx p=%llx',
+    'P276 284M0 c=%u m=%d b=%llx p=%llx i=%llx e=%llx',
+    'P276 284M5 c=%d sp=1 b=%llx p=%llx i=%llx',
+    'P276 284M6 c=%d req=%llx rc=%d a=%lx p=%lx',
+    'P276 284M7 c=%d req=%llx rc=%d a=%lx p=%lx',
+    'P276 282F a=0 t=1',
+    'P276 280Z q=2',
+]:
+    if token.encode() not in img:
+        raise SystemExit('Phase284 runtime marker missing from Image: ' + token)
+
+print('Phase284 v3 PHY + full clock-causality marker audit: PASS')
+PY
+
+python3 scripts/284_apply_v3_phy_clock_trace.py --root "$ROOT" --check-only
+python3 scripts/284b_apply_clock_causality_trace.py --root "$ROOT" --check-only
+
+trap - EXIT
+echo 'Phase284 v3 PHY + full clock-causality build/repack: PASS'

--- a/scripts/284b_ci_build.sh
+++ b/scripts/284b_ci_build.sh
@@ -232,7 +232,7 @@ for token in [
 for token in [
     'A52_PHASE284_CLOCK_CAUSALITY_TRACE_V1',
     'P276 284M0 c=%u m=%d b=%llx p=%llx i=%llx e=%llx',
-    'P276 284M3 cb=%lx cp=%lx tb=%lx pp=%lx tp=%lx',
+    'P276 284M3 cb=%lx bp=%lx tb=%lx cp=%lx pp=%lx tp=%lx',
     'P276 284M4 rc=%d cb=%lx bp=%lx cp=%lx pp=%lx',
     'P276 284M5 c=%d sp=1 b=%llx p=%llx i=%llx',
     'P276 284M6 c=%d req=%llx rc=%d a=%lx p=%lx',


### PR DESCRIPTION
Phase 283 hardware evidence keeps controller/runtime-PM and controller+PHY regulator votes asserted while the one-shot Golden FIFO command still times out. Its PHY tracer returned version 5, which is DSI_PHY_VERSION_3_0 in the exact TouchGrass lineage; the Phase 283 raw PHY offsets only covered v4.x.

Phase 284 remains read-only, but now covers the complete clock-causality chain rather than only the final command-time clock snapshot:
- `284O0/O1`: the upstream bitrate producer inputs and derived aggregate/lane/byte/byte-interface/pixel rates, matching the role of Golden `TGREF DERIVE`;
- `284M0`: the exact frequencies cached by `dsi_clk_set_link_frequencies`;
- `284M1/M2`: explicit pixel and byte/interface setter requests, return codes, actual leaf rates and parent rates;
- `284M3/M4`: child/target clock state immediately before and after `dsi_clk_update_parent`;
- `284M5`: continuous-splash rate-application skip, if that path suppresses programming;
- `284M6/M7/M8`: byte/pixel/byte-interface `clk_set_rate` request, return code, actual rate and parent rate;
- `284C0-C3`: command-time configured target rates, RCG/PLL-source rates, leaf/parent/grandparent rates and packed enable state;
- `284P0-P3`: exact v3.0/10-nm PHY PLL, readiness, lane-status and common/lane-control registers.

This should distinguish three materially different causes of the observed 0 Hz result: zero was produced/cached upstream, a valid rate was intentionally skipped during continuous-splash handling, or a valid request was lost during parent/rate propagation.

No SMMU, recorder implementation, Samsung panel/common, display-handoff behavior, timeout/recovery, brightness, DT/config or transport behavior is changed. CI reconstructs the exact corrected Phase 283 lineage first, requires the vendor-blob trusted-source boolean to remain disabled (`# CONFIG_A52_VENDOR_BLOB_TRUSTED_SOURCE is not set`), byte-compares protected sources/config, audits both causality and v3 PHY markers into the final Image, and repacks a 96 MiB boot image from the Phase 283 container.