### PR TITLE
Golden control: trace TouchGrass DSI clock construction chain

### DIFF
--- a/.github/workflows/golden-touchgrass-clock-reference.yml
+++ b/.github/workflows/golden-touchgrass-clock-reference.yml
@@ -10,6 +10,13 @@ on:
       - .github/workflows/golden-touchgrass-clock-reference.yml
       - scripts/golden_touchgrass_clock_reference.py
       - scripts/golden_touchgrass_clock_reference_build.sh
+  pull_request:
+    branches:
+      - agent/a52-golden-touchgrass-4.19.200-base
+    paths:
+      - .github/workflows/golden-touchgrass-clock-reference.yml
+      - scripts/golden_touchgrass_clock_reference.py
+      - scripts/golden_touchgrass_clock_reference_build.sh
 
 permissions:
   contents: read

--- a/.github/workflows/golden-touchgrass-clock-reference.yml
+++ b/.github/workflows/golden-touchgrass-clock-reference.yml
@@ -3,14 +3,6 @@ run-name: Golden TouchGrass 4.19.200 DSI clock reference
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - agent/a52-golden-touchgrass-clock-reference-v1
-    paths:
-      - .github/workflows/golden-touchgrass-clock-reference.yml
-      - scripts/golden_touchgrass_clock_reference.py
-      - scripts/golden_touchgrass_clock_origin.py
-      - scripts/golden_touchgrass_clock_reference_build.sh
   pull_request:
     branches:
       - agent/a52-golden-touchgrass-4.19.200-base

--- a/.github/workflows/golden-touchgrass-clock-reference.yml
+++ b/.github/workflows/golden-touchgrass-clock-reference.yml
@@ -1,0 +1,73 @@
+name: Golden TouchGrass - DSI clock reference
+run-name: Golden TouchGrass 4.19.200 DSI clock reference
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-golden-touchgrass-clock-reference-v1
+    paths:
+      - .github/workflows/golden-touchgrass-clock-reference.yml
+      - scripts/golden_touchgrass_clock_reference.py
+      - scripts/golden_touchgrass_clock_reference_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-golden-touchgrass-clock-reference-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JOBS: '4'
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 5G
+
+jobs:
+  build:
+    name: Reconstruct Golden 4.19.200 and add read-only clock trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    steps:
+      - name: Check out Golden reference branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils zip unzip make gcc g++ bc bison flex ccache patch \
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar
+
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: a52xq-golden-clock-ref-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
+            a52xq-linux-4.19.180-ccache-${{ runner.os }}-
+
+      - name: Reconstruct and build Golden clock reference
+        run: bash scripts/golden_touchgrass_clock_reference_build.sh
+
+      - name: Upload Golden clock reference Image and audit
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-GOLDEN-TOUCHGRASS-4.19.200-CLOCK-REFERENCE-${{ github.run_number }}-IMAGE-ONLY
+          path: golden-clock-ref-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-GOLDEN-CLOCK-REFERENCE-FAILURE-${{ github.run_number }}
+          path: golden-clock-ref-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/golden-touchgrass-clock-reference.yml
+++ b/.github/workflows/golden-touchgrass-clock-reference.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - .github/workflows/golden-touchgrass-clock-reference.yml
       - scripts/golden_touchgrass_clock_reference.py
+      - scripts/golden_touchgrass_clock_origin.py
       - scripts/golden_touchgrass_clock_reference_build.sh
   pull_request:
     branches:
@@ -16,6 +17,7 @@ on:
     paths:
       - .github/workflows/golden-touchgrass-clock-reference.yml
       - scripts/golden_touchgrass_clock_reference.py
+      - scripts/golden_touchgrass_clock_origin.py
       - scripts/golden_touchgrass_clock_reference_build.sh
 
 permissions:

--- a/.github/workflows/golden-touchgrass-clock-reference.yml
+++ b/.github/workflows/golden-touchgrass-clock-reference.yml
@@ -24,10 +24,12 @@ env:
   JOBS: '4'
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 5G
+  BOOT_SOURCE_ASSET_ID: '478920392'
+  BOOT_SOURCE_SHA256: '41ae3b24771c70747c26aa17a18d254ffcb1c0d742b96f4f1f1fff20a6638554'
 
 jobs:
   build:
-    name: Reconstruct Golden 4.19.200 and add read-only clock trace
+    name: Reconstruct Golden 4.19.200, trace clocks, and repack boot.img
     runs-on: ubuntu-22.04
     timeout-minutes: 300
     steps:
@@ -39,8 +41,26 @@ jobs:
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            git curl xz-utils zip unzip make gcc g++ bc bison flex ccache patch \
+            git curl xz-utils gzip zip unzip make gcc g++ bc bison flex ccache patch \
             libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar
+
+      - name: Hydrate known-good Golden FDR repack helpers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p scripts projects/a52-p1-boot-image
+          fetch_file() {
+            local ref="$1"
+            local path="$2"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${ref}" \
+              --jq '.content' | tr -d '\n' | base64 --decode > "$path"
+            test -s "$path"
+          }
+          fetch_file main scripts/37_validate_a52_p1_boot_source.py
+          fetch_file main scripts/38_repack_a52_p1_boot.py
+          fetch_file main projects/a52-p1-boot-image/boot-source.lock
+          chmod +x scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
 
       - name: Restore compiler cache
         uses: actions/cache@v4
@@ -54,11 +74,59 @@ jobs:
       - name: Reconstruct and build Golden clock reference
         run: bash scripts/golden_touchgrass_clock_reference_build.sh
 
-      - name: Upload Golden clock reference Image and audit
+      - name: Repack Golden clock reference with known-good FDR boot container
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          OUT=golden-clock-ref-out
+          mkdir -p intake
+
+          test -s "$OUT/Image"
+          gzip -n -9 -c "$OUT/Image" > "$OUT/Image.gz"
+          test -s "$OUT/Image.gz"
+
+          curl --fail --location --retry 3 --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/octet-stream' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${BOOT_SOURCE_ASSET_ID}" \
+            --output intake/boot.img
+
+          test "$(stat -c %s intake/boot.img)" = 100663296
+          printf '%s  %s\n' "$BOOT_SOURCE_SHA256" intake/boot.img | sha256sum -c -
+
+          python3 scripts/37_validate_a52_p1_boot_source.py \
+            intake/boot.img \
+            --lock projects/a52-p1-boot-image/boot-source.lock \
+            --output "$OUT/source-validation.json"
+
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source intake/boot.img \
+            --kernel "$OUT/Image.gz" \
+            --output "$OUT/boot.img" \
+            --report "$OUT/repack-report.json"
+
+          test -s "$OUT/boot.img"
+          test "$(stat -c %s "$OUT/boot.img")" = 100663296
+
+          sed -i 's/^flashable=.*/flashable=yes-known-good-96MiB-boot-container-repacked-with-golden-fdr-repacker/' \
+            "$OUT/BUILD-IDENTITY.txt"
+
+          (
+            cd "$OUT"
+            find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+          )
+
+          echo "Golden clock-reference boot.img repack passed"
+          file "$OUT/boot.img"
+          sha256sum "$OUT/boot.img"
+
+      - name: Upload Golden clock reference repacked boot.img and audit
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-GOLDEN-TOUCHGRASS-4.19.200-CLOCK-REFERENCE-${{ github.run_number }}-IMAGE-ONLY
+          name: A52XQ-GOLDEN-TOUCHGRASS-4.19.200-CLOCK-REFERENCE-${{ github.run_number }}-BOOT-IMG
           path: golden-clock-ref-out/
           if-no-files-found: error
           compression-level: 1

--- a/scripts/golden_touchgrass_clock_origin.py
+++ b/scripts/golden_touchgrass_clock_origin.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+
+DISPLAY = Path('techpack/display/msm/dsi/dsi_display.c')
+MARK = 'A52_GOLDEN_TOUCHGRASS_CLOCK_CHAIN_ORIGIN_V2'
+
+
+def once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected one match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_display(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = once(
+        text,
+        '#define DSI_CLOCK_BITRATE_RADIX 10\n#define MAX_TE_SOURCE_ID  2\n',
+        '#define DSI_CLOCK_BITRATE_RADIX 10\n#define MAX_TE_SOURCE_ID  2\n\n'
+        '/* ' + MARK + ': bounded trace of the rate producer only. */\n'
+        'static unsigned int tgref_derive_logs;\n',
+        'derive marker/counter')
+
+    text = once(
+        text,
+        '\t\tSDE_EVT32(i, bit_rate, byte_clk_rate, pclk_rate);\n\n'
+        '\t\tctrl->clk_freq.byte_clk_rate = byte_clk_rate;\n'
+        '\t\tctrl->clk_freq.byte_intf_clk_rate = byte_intf_clk_rate;\n'
+        '\t\tctrl->clk_freq.pix_clk_rate = pclk_rate;\n'
+        '\t\trc = dsi_clk_set_link_frequencies(display->dsi_clk_handle,\n'
+        '\t\t\tctrl->clk_freq, ctrl->cell_index);\n',
+        '\t\tSDE_EVT32(i, bit_rate, byte_clk_rate, pclk_rate);\n\n'
+        '\t\tif (tgref_derive_logs < 8) {\n'
+        '\t\t\tpr_info("TGREF DERIVE c=%d phy=%u in=%u bit=%llu lane=%llu lanes=%u bpp=%u div=%u b=%llu i=%llu p=%llu\\n",\n'
+        '\t\t\t\tctrl->cell_index, host_cfg->phy_type, bit_clk_rate,\n'
+        '\t\t\t\t(unsigned long long)bit_rate,\n'
+        '\t\t\t\t(unsigned long long)bit_rate_per_lane,\n'
+        '\t\t\t\tnum_of_lanes, bpp, host_cfg->byte_intf_clk_div,\n'
+        '\t\t\t\t(unsigned long long)byte_clk_rate,\n'
+        '\t\t\t\t(unsigned long long)byte_intf_clk_rate,\n'
+        '\t\t\t\t(unsigned long long)pclk_rate);\n'
+        '\t\t\ttgref_derive_logs++;\n'
+        '\t\t}\n\n'
+        '\t\tctrl->clk_freq.byte_clk_rate = byte_clk_rate;\n'
+        '\t\tctrl->clk_freq.byte_intf_clk_rate = byte_intf_clk_rate;\n'
+        '\t\tctrl->clk_freq.pix_clk_rate = pclk_rate;\n'
+        '\t\trc = dsi_clk_set_link_frequencies(display->dsi_clk_handle,\n'
+        '\t\t\tctrl->clk_freq, ctrl->cell_index);\n',
+        'derived-rate trace')
+
+    return text
+
+
+def validate(text: str) -> None:
+    for token in [MARK, 'TGREF DERIVE', 'bit_rate_per_lane',
+                  'host_cfg->byte_intf_clk_div']:
+        if token not in text:
+            raise SystemExit('missing display marker: ' + token)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    path = args.root / DISPLAY
+    text = path.read_text()
+    if not args.check_only:
+        text = patch_display(text)
+        path.write_text(text)
+    validate(text)
+    print('Golden TouchGrass clock-chain origin V2 instrumentation validated')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/golden_touchgrass_clock_reference.py
+++ b/scripts/golden_touchgrass_clock_reference.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+
+CLK = Path('techpack/display/msm/dsi/dsi_clk_manager.c')
+CTRL = Path('techpack/display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_GOLDEN_TOUCHGRASS_CLOCK_REFERENCE_V1'
+
+
+def once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected one match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_clk(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = once(
+        text,
+        'struct dsi_clk_client_info {\n',
+        '/* ' + MARK + '\n'
+        ' * Read-only reference instrumentation for the hardware-working\n'
+        ' * TouchGrass 4.19.200 display clock path. No clock state is changed.\n'
+        ' */\n'
+        'static unsigned long tgref_clk_rate(struct clk *clk)\n'
+        '{\n'
+        '\treturn clk ? clk_get_rate(clk) : 0;\n'
+        '}\n\n'
+        'struct dsi_clk_client_info {\n',
+        'clock reference helper')
+
+    text = once(
+        text,
+        '\tmemcpy(&mngr->link_clks[clk_mngr_index].freq, &freq,\n'
+        '\t\tsizeof(struct link_clk_freq));\n\n'
+        '\treturn rc;\n',
+        '\tmemcpy(&mngr->link_clks[clk_mngr_index].freq, &freq,\n'
+        '\t\tsizeof(struct link_clk_freq));\n\n'
+        '\tpr_info("TGREF CACHE i=%u sp=%u req_b=%llu req_p=%llu req_i=%llu req_e=%llu act_b=%lu act_p=%lu act_i=%lu act_e=%lu\\n",\n'
+        '\t\tindex, mngr->is_cont_splash_enabled ? 1 : 0,\n'
+        '\t\t(unsigned long long)freq.byte_clk_rate,\n'
+        '\t\t(unsigned long long)freq.pix_clk_rate,\n'
+        '\t\t(unsigned long long)freq.byte_intf_clk_rate,\n'
+        '\t\t(unsigned long long)freq.esc_clk_rate,\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].hs_clks.byte_clk),\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].hs_clks.pixel_clk),\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].hs_clks.byte_intf_clk),\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].lp_clks.esc_clk));\n\n'
+        '\treturn rc;\n',
+        'cache-rate trace')
+
+    text = once(
+        text,
+        '\telse\n\t\tmngr->link_clks[index].freq.pix_clk_rate = pixel_clk;\n\n\treturn rc;\n',
+        '\telse\n\t\tmngr->link_clks[index].freq.pix_clk_rate = pixel_clk;\n\n'
+        '\tpr_info("TGREF SETP i=%u req=%llu rc=%d act=%lu\\n", index,\n'
+        '\t\t(unsigned long long)pixel_clk, rc,\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.pixel_clk));\n\n'
+        '\treturn rc;\n',
+        'pixel setter trace')
+
+    old = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {\n\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,\n\t\t\t\t  byte_intf_clk);\n\t\tif (rc)\n\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",\n\t\t\t       rc);\n\t\telse\n\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =\n\t\t\t\t\t\t\t\tbyte_intf_clk;\n\t}\n\n\treturn rc;\n}\n'''
+    new = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {\n\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,\n\t\t\t\t  byte_intf_clk);\n\t\tif (rc)\n\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",\n\t\t\t       rc);\n\t\telse\n\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =\n\t\t\t\t\t\t\t\tbyte_intf_clk;\n\t}\n\n\tpr_info("TGREF SETB i=%u req_b=%llu req_i=%llu rc=%d act_b=%lu act_i=%lu\\n",\n\t\tindex, (unsigned long long)byte_clk,\n\t\t(unsigned long long)byte_intf_clk, rc,\n\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.byte_clk),\n\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.byte_intf_clk));\n\n\treturn rc;\n}\n'''
+    text = once(text, old, new, 'byte setter trace')
+
+    text = once(
+        text,
+        '\tif (mngr->is_cont_splash_enabled)\n\t\treturn 0;\n\n\trc = clk_set_rate(link_hs_clks->byte_clk,\n',
+        '\tpr_info("TGREF APPLY0 i=%d sp=%u req_b=%llu req_p=%llu req_i=%llu act_b=%lu act_p=%lu act_i=%lu\\n",\n'
+        '\t\tindex, mngr->is_cont_splash_enabled ? 1 : 0,\n'
+        '\t\t(unsigned long long)l_clks->freq.byte_clk_rate,\n'
+        '\t\t(unsigned long long)l_clks->freq.pix_clk_rate,\n'
+        '\t\t(unsigned long long)l_clks->freq.byte_intf_clk_rate,\n'
+        '\t\ttgref_clk_rate(link_hs_clks->byte_clk),\n'
+        '\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n'
+        '\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n\n'
+        '\tif (mngr->is_cont_splash_enabled) {\n'
+        '\t\tpr_info("TGREF SKIP i=%d reason=cont_splash act_b=%lu act_p=%lu act_i=%lu\\n",\n'
+        '\t\t\tindex, tgref_clk_rate(link_hs_clks->byte_clk),\n'
+        '\t\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n'
+        '\t\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n'
+        '\t\treturn 0;\n'
+        '\t}\n\n\trc = clk_set_rate(link_hs_clks->byte_clk,\n',
+        'continuous-splash apply trace')
+
+    text = once(
+        text,
+        '\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,\n\t\t\t\tl_clks->freq.byte_intf_clk_rate);\n\t\tif (rc) {\n\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",\n\t\t\t\trc);\n\t\t\tgoto error;\n\t\t}\n\t}\nerror:\n\treturn rc;\n}\n\nstatic int dsi_link_hs_clk_prepare',
+        '\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,\n\t\t\t\tl_clks->freq.byte_intf_clk_rate);\n\t\tif (rc) {\n\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",\n\t\t\t\trc);\n\t\t\tgoto error;\n\t\t}\n\t}\nerror:\n'
+        '\tpr_info("TGREF APPLY1 i=%d rc=%d act_b=%lu act_p=%lu act_i=%lu\\n",\n'
+        '\t\tindex, rc, tgref_clk_rate(link_hs_clks->byte_clk),\n'
+        '\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n'
+        '\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n'
+        '\treturn rc;\n}\n\nstatic int dsi_link_hs_clk_prepare',
+        'post-apply trace')
+
+    text = once(
+        text,
+        '\tmngr = (struct dsi_clk_mngr *)clk_mgr;\n\tmngr->is_cont_splash_enabled = status;\n}\n',
+        '\tmngr = (struct dsi_clk_mngr *)clk_mgr;\n'
+        '\tpr_info("TGREF SPLASH old=%u new=%u b=%lu p=%lu i=%lu e=%lu\\n",\n'
+        '\t\tmngr->is_cont_splash_enabled ? 1 : 0, status ? 1 : 0,\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[0].hs_clks.byte_clk),\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[0].hs_clks.pixel_clk),\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[0].hs_clks.byte_intf_clk),\n'
+        '\t\ttgref_clk_rate(mngr->link_clks[0].lp_clks.esc_clk));\n'
+        '\tmngr->is_cont_splash_enabled = status;\n}\n',
+        'splash state trace')
+
+    return text
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = once(
+        text,
+        '#define DSI_CTRL_TX_TO_MS     200\n',
+        '#define DSI_CTRL_TX_TO_MS     200\n\n'
+        '/* ' + MARK + ': command-boundary control measurement only. */\n',
+        'controller marker')
+
+    old = '''kickoff:\n\tdsi_kickoff_msg_tx(dsi_ctrl, msg, &cmd, &cmd_mem, *flags);\nerror:\n'''
+    new = '''kickoff:\n\tif (msg->type == 0x29 && msg->tx_len == 3 && msg->tx_buf &&\n\t\t((const u8 *)msg->tx_buf)[0] == 0xf0 &&\n\t\t((const u8 *)msg->tx_buf)[1] == 0x5a &&\n\t\t((const u8 *)msg->tx_buf)[2] == 0x5a)\n\t\tpr_info("TGREF CMD PRE f=%x cache_b=%llu cache_p=%llu cache_i=%llu cache_e=%llu act_b=%lu act_p=%lu act_i=%lu act_e=%lu\\n",\n\t\t\t*flags, (unsigned long long)dsi_ctrl->clk_freq.byte_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.pix_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.byte_intf_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.esc_clk_rate,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.pixel_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_intf_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.lp_link_clks.esc_clk ? clk_get_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk) : 0);\n\tdsi_kickoff_msg_tx(dsi_ctrl, msg, &cmd, &cmd_mem, *flags);\n\tif (msg->type == 0x29 && msg->tx_len == 3 && msg->tx_buf &&\n\t\t((const u8 *)msg->tx_buf)[0] == 0xf0 &&\n\t\t((const u8 *)msg->tx_buf)[1] == 0x5a &&\n\t\t((const u8 *)msg->tx_buf)[2] == 0x5a)\n\t\tpr_info("TGREF CMD POST act_b=%lu act_p=%lu act_i=%lu act_e=%lu\\n",\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.pixel_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_intf_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.lp_link_clks.esc_clk ? clk_get_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk) : 0);\nerror:\n'''
+    return once(text, old, new, 'F0 5A 5A command boundary trace')
+
+
+def validate(clk: str, ctrl: str) -> None:
+    for token in [MARK, 'TGREF CACHE', 'TGREF SETP', 'TGREF SETB', 'TGREF APPLY0',
+                  'TGREF SKIP', 'TGREF APPLY1', 'TGREF SPLASH']:
+        if token not in clk:
+            raise SystemExit('missing clk marker: ' + token)
+    for token in [MARK, 'TGREF CMD PRE', 'TGREF CMD POST', 'msg->type == 0x29']:
+        if token not in ctrl:
+            raise SystemExit('missing ctrl marker: ' + token)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    clk_path = args.root / CLK
+    ctrl_path = args.root / CTRL
+    clk = clk_path.read_text()
+    ctrl = ctrl_path.read_text()
+    if not args.check_only:
+        clk = patch_clk(clk)
+        ctrl = patch_ctrl(ctrl)
+        clk_path.write_text(clk)
+        ctrl_path.write_text(ctrl)
+    validate(clk, ctrl)
+    print('Golden TouchGrass clock-reference instrumentation validated')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/golden_touchgrass_clock_reference.py
+++ b/scripts/golden_touchgrass_clock_reference.py
@@ -4,7 +4,7 @@ import argparse
 
 CLK = Path('techpack/display/msm/dsi/dsi_clk_manager.c')
 CTRL = Path('techpack/display/msm/dsi/dsi_ctrl.c')
-MARK = 'A52_GOLDEN_TOUCHGRASS_CLOCK_REFERENCE_V1'
+MARK = 'A52_GOLDEN_TOUCHGRASS_CLOCK_CHAIN_REFERENCE_V2'
 
 
 def once(text: str, old: str, new: str, label: str) -> str:
@@ -22,15 +22,37 @@ def patch_clk(text: str) -> str:
         text,
         'struct dsi_clk_client_info {\n',
         '/* ' + MARK + '\n'
-        ' * Read-only reference instrumentation for the hardware-working\n'
-        ' * TouchGrass 4.19.200 display clock path. No clock state is changed.\n'
+        ' * Read-only, bounded instrumentation for the hardware-working\n'
+        ' * TouchGrass 4.19.200 DSI clock construction path.\n'
+        ' * Log setters/transitions only; do not continuously sample rates.\n'
         ' */\n'
         'static unsigned long tgref_clk_rate(struct clk *clk)\n'
         '{\n'
         '\treturn clk ? clk_get_rate(clk) : 0;\n'
         '}\n\n'
+        'static unsigned long tgref_parent_rate(struct clk *clk)\n'
+        '{\n'
+        '\tstruct clk *parent = clk ? clk_get_parent(clk) : NULL;\n\n'
+        '\treturn parent ? clk_get_rate(parent) : 0;\n'
+        '}\n\n'
+        'static bool tgref_cache_valid[MAX_DSI_CTRL];\n'
+        'static struct link_clk_freq tgref_cache_last[MAX_DSI_CTRL];\n'
+        'static unsigned int tgref_cache_logs;\n'
+        'static unsigned int tgref_setp_logs;\n'
+        'static unsigned int tgref_setb_logs;\n'
+        'static unsigned int tgref_parent_logs;\n'
+        'static unsigned int tgref_src_enable_logs;\n'
+        'static unsigned int tgref_src_disable_logs;\n'
+        'static unsigned int tgref_rate_skip_logs;\n'
+        'static unsigned int tgref_rate_apply_logs;\n'
+        'static unsigned int tgref_prepare_logs;\n'
+        'static unsigned int tgref_enable_logs;\n'
+        'static unsigned int tgref_stop_logs;\n'
+        'static unsigned int tgref_mgr_logs;\n'
+        'static unsigned int tgref_req_logs;\n'
+        'static unsigned int tgref_splash_logs;\n\n'
         'struct dsi_clk_client_info {\n',
-        'clock reference helper')
+        'clock-chain helper and bounded counters')
 
     text = once(
         text,
@@ -39,76 +61,107 @@ def patch_clk(text: str) -> str:
         '\treturn rc;\n',
         '\tmemcpy(&mngr->link_clks[clk_mngr_index].freq, &freq,\n'
         '\t\tsizeof(struct link_clk_freq));\n\n'
-        '\tpr_info("TGREF CACHE i=%u sp=%u req_b=%llu req_p=%llu req_i=%llu req_e=%llu act_b=%lu act_p=%lu act_i=%lu act_e=%lu\\n",\n'
-        '\t\tindex, mngr->is_cont_splash_enabled ? 1 : 0,\n'
-        '\t\t(unsigned long long)freq.byte_clk_rate,\n'
-        '\t\t(unsigned long long)freq.pix_clk_rate,\n'
-        '\t\t(unsigned long long)freq.byte_intf_clk_rate,\n'
-        '\t\t(unsigned long long)freq.esc_clk_rate,\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].hs_clks.byte_clk),\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].hs_clks.pixel_clk),\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].hs_clks.byte_intf_clk),\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[clk_mngr_index].lp_clks.esc_clk));\n\n'
+        '\tif (tgref_cache_logs < 8 &&\n'
+        '\t    (!tgref_cache_valid[clk_mngr_index] ||\n'
+        '\t     memcmp(&tgref_cache_last[clk_mngr_index], &freq,\n'
+        '\t\t    sizeof(struct link_clk_freq)))) {\n'
+        '\t\tpr_info("TGREF CACHE i=%u sp=%u b=%llu p=%llu i=%llu e=%llu\\n",\n'
+        '\t\t\tindex, mngr->is_cont_splash_enabled ? 1 : 0,\n'
+        '\t\t\t(unsigned long long)freq.byte_clk_rate,\n'
+        '\t\t\t(unsigned long long)freq.pix_clk_rate,\n'
+        '\t\t\t(unsigned long long)freq.byte_intf_clk_rate,\n'
+        '\t\t\t(unsigned long long)freq.esc_clk_rate);\n'
+        '\t\tmemcpy(&tgref_cache_last[clk_mngr_index], &freq,\n'
+        '\t\t       sizeof(struct link_clk_freq));\n'
+        '\t\ttgref_cache_valid[clk_mngr_index] = true;\n'
+        '\t\ttgref_cache_logs++;\n'
+        '\t}\n\n'
         '\treturn rc;\n',
-        'cache-rate trace')
+        'changed cached-frequency trace')
 
     text = once(
         text,
         '\telse\n\t\tmngr->link_clks[index].freq.pix_clk_rate = pixel_clk;\n\n\treturn rc;\n',
         '\telse\n\t\tmngr->link_clks[index].freq.pix_clk_rate = pixel_clk;\n\n'
-        '\tpr_info("TGREF SETP i=%u req=%llu rc=%d act=%lu\\n", index,\n'
-        '\t\t(unsigned long long)pixel_clk, rc,\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.pixel_clk));\n\n'
+        '\tif (tgref_setp_logs < 8) {\n'
+        '\t\tpr_info("TGREF SETP i=%u req=%llu rc=%d act=%lu par=%lu\\n",\n'
+        '\t\t\tindex, (unsigned long long)pixel_clk, rc,\n'
+        '\t\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.pixel_clk),\n'
+        '\t\t\ttgref_parent_rate(mngr->link_clks[index].hs_clks.pixel_clk));\n'
+        '\t\ttgref_setp_logs++;\n'
+        '\t}\n\n'
         '\treturn rc;\n',
-        'pixel setter trace')
+        'explicit pixel setter trace')
 
     old = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {\n\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,\n\t\t\t\t  byte_intf_clk);\n\t\tif (rc)\n\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",\n\t\t\t       rc);\n\t\telse\n\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =\n\t\t\t\t\t\t\t\tbyte_intf_clk;\n\t}\n\n\treturn rc;\n}\n'''
-    new = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {\n\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,\n\t\t\t\t  byte_intf_clk);\n\t\tif (rc)\n\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",\n\t\t\t       rc);\n\t\telse\n\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =\n\t\t\t\t\t\t\t\tbyte_intf_clk;\n\t}\n\n\tpr_info("TGREF SETB i=%u req_b=%llu req_i=%llu rc=%d act_b=%lu act_i=%lu\\n",\n\t\tindex, (unsigned long long)byte_clk,\n\t\t(unsigned long long)byte_intf_clk, rc,\n\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.byte_clk),\n\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.byte_intf_clk));\n\n\treturn rc;\n}\n'''
-    text = once(text, old, new, 'byte setter trace')
+    new = '''\tif (mngr->link_clks[index].hs_clks.byte_intf_clk) {\n\t\trc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,\n\t\t\t\t  byte_intf_clk);\n\t\tif (rc)\n\t\t\tDSI_ERR("failed to set clk rate for byte intf clk=%d\\n",\n\t\t\t       rc);\n\t\telse\n\t\t\tmngr->link_clks[index].freq.byte_intf_clk_rate =\n\t\t\t\t\t\t\t\tbyte_intf_clk;\n\t}\n\n\tif (tgref_setb_logs < 8) {\n\t\tpr_info("TGREF SETB i=%u req_b=%llu req_i=%llu rc=%d act_b=%lu par_b=%lu act_i=%lu par_i=%lu\\n",\n\t\t\tindex, (unsigned long long)byte_clk,\n\t\t\t(unsigned long long)byte_intf_clk, rc,\n\t\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.byte_clk),\n\t\t\ttgref_parent_rate(mngr->link_clks[index].hs_clks.byte_clk),\n\t\t\ttgref_clk_rate(mngr->link_clks[index].hs_clks.byte_intf_clk),\n\t\t\ttgref_parent_rate(mngr->link_clks[index].hs_clks.byte_intf_clk));\n\t\ttgref_setb_logs++;\n\t}\n\n\treturn rc;\n}\n'''
+    text = once(text, old, new, 'explicit byte setter trace')
 
     text = once(
         text,
-        '\tif (mngr->is_cont_splash_enabled)\n\t\treturn 0;\n\n\trc = clk_set_rate(link_hs_clks->byte_clk,\n',
-        '\tpr_info("TGREF APPLY0 i=%d sp=%u req_b=%llu req_p=%llu req_i=%llu act_b=%lu act_p=%lu act_i=%lu\\n",\n'
-        '\t\tindex, mngr->is_cont_splash_enabled ? 1 : 0,\n'
-        '\t\t(unsigned long long)l_clks->freq.byte_clk_rate,\n'
-        '\t\t(unsigned long long)l_clks->freq.pix_clk_rate,\n'
-        '\t\t(unsigned long long)l_clks->freq.byte_intf_clk_rate,\n'
-        '\t\ttgref_clk_rate(link_hs_clks->byte_clk),\n'
-        '\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n'
-        '\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n\n'
-        '\tif (mngr->is_cont_splash_enabled) {\n'
-        '\t\tpr_info("TGREF SKIP i=%d reason=cont_splash act_b=%lu act_p=%lu act_i=%lu\\n",\n'
-        '\t\t\tindex, tgref_clk_rate(link_hs_clks->byte_clk),\n'
-        '\t\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n'
-        '\t\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n'
-        '\t\treturn 0;\n'
-        '\t}\n\n\trc = clk_set_rate(link_hs_clks->byte_clk,\n',
-        'continuous-splash apply trace')
+        '''int dsi_clk_update_parent(struct dsi_clk_link_set *parent,\n\t\t\t  struct dsi_clk_link_set *child)\n{\n\tint rc = 0;\n\n\trc = clk_set_parent(child->byte_clk, parent->byte_clk);\n''',
+        '''int dsi_clk_update_parent(struct dsi_clk_link_set *parent,\n\t\t\t  struct dsi_clk_link_set *child)\n{\n\tint rc = 0;\n\tbool tgref_trace = tgref_parent_logs < 8;\n\n\tif (tgref_trace)\n\t\tpr_info("TGREF PARENT PRE cb=%lu cbp=%lu tb=%lu cp=%lu cpp=%lu tp=%lu\\n",\n\t\t\ttgref_clk_rate(child->byte_clk),\n\t\t\ttgref_parent_rate(child->byte_clk),\n\t\t\ttgref_clk_rate(parent->byte_clk),\n\t\t\ttgref_clk_rate(child->pixel_clk),\n\t\t\ttgref_parent_rate(child->pixel_clk),\n\t\t\ttgref_clk_rate(parent->pixel_clk));\n\n\trc = clk_set_parent(child->byte_clk, parent->byte_clk);\n''',
+        'parent pre-trace')
 
     text = once(
         text,
-        '\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,\n\t\t\t\tl_clks->freq.byte_intf_clk_rate);\n\t\tif (rc) {\n\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",\n\t\t\t\trc);\n\t\t\tgoto error;\n\t\t}\n\t}\nerror:\n\treturn rc;\n}\n\nstatic int dsi_link_hs_clk_prepare',
-        '\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,\n\t\t\t\tl_clks->freq.byte_intf_clk_rate);\n\t\tif (rc) {\n\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",\n\t\t\t\trc);\n\t\t\tgoto error;\n\t\t}\n\t}\nerror:\n'
-        '\tpr_info("TGREF APPLY1 i=%d rc=%d act_b=%lu act_p=%lu act_i=%lu\\n",\n'
-        '\t\tindex, rc, tgref_clk_rate(link_hs_clks->byte_clk),\n'
-        '\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n'
-        '\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n'
-        '\treturn rc;\n}\n\nstatic int dsi_link_hs_clk_prepare',
-        'post-apply trace')
+        '''error:\n\treturn rc;\n}\n\n/**\n * dsi_clk_prepare_enable()''',
+        '''error:\n\tif (tgref_trace) {\n\t\tpr_info("TGREF PARENT POST rc=%d cb=%lu cbp=%lu cp=%lu cpp=%lu\\n",\n\t\t\trc, tgref_clk_rate(child->byte_clk),\n\t\t\ttgref_parent_rate(child->byte_clk),\n\t\t\ttgref_clk_rate(child->pixel_clk),\n\t\t\ttgref_parent_rate(child->pixel_clk));\n\t\ttgref_parent_logs++;\n\t}\n\treturn rc;\n}\n\n/**\n * dsi_clk_prepare_enable()''',
+        'parent post-trace')
 
     text = once(
         text,
-        '\tmngr = (struct dsi_clk_mngr *)clk_mgr;\n\tmngr->is_cont_splash_enabled = status;\n}\n',
-        '\tmngr = (struct dsi_clk_mngr *)clk_mgr;\n'
-        '\tpr_info("TGREF SPLASH old=%u new=%u b=%lu p=%lu i=%lu e=%lu\\n",\n'
-        '\t\tmngr->is_cont_splash_enabled ? 1 : 0, status ? 1 : 0,\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[0].hs_clks.byte_clk),\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[0].hs_clks.pixel_clk),\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[0].hs_clks.byte_intf_clk),\n'
-        '\t\ttgref_clk_rate(mngr->link_clks[0].lp_clks.esc_clk));\n'
-        '\tmngr->is_cont_splash_enabled = status;\n}\n',
-        'splash state trace')
+        '''\trc = clk_prepare_enable(clk->pixel_clk);\n\tif (rc) {\n\t\tDSI_ERR("failed to enable pixel src clk %d\\n", rc);\n\t\treturn rc;\n\t}\n\n\treturn 0;\n}\n\n/**\n * dsi_clk_disable_unprepare()''',
+        '''\trc = clk_prepare_enable(clk->pixel_clk);\n\tif (rc) {\n\t\tDSI_ERR("failed to enable pixel src clk %d\\n", rc);\n\t\treturn rc;\n\t}\n\n\tif (tgref_src_enable_logs < 8) {\n\t\tpr_info("TGREF SRC_ON b=%lu bp=%lu p=%lu pp=%lu\\n",\n\t\t\ttgref_clk_rate(clk->byte_clk), tgref_parent_rate(clk->byte_clk),\n\t\t\ttgref_clk_rate(clk->pixel_clk), tgref_parent_rate(clk->pixel_clk));\n\t\ttgref_src_enable_logs++;\n\t}\n\n\treturn 0;\n}\n\n/**\n * dsi_clk_disable_unprepare()''',
+        'source-clock enable trace')
+
+    text = once(
+        text,
+        '''void dsi_clk_disable_unprepare(struct dsi_clk_link_set *clk)\n{\n\tclk_disable_unprepare(clk->pixel_clk);\n\tclk_disable_unprepare(clk->byte_clk);\n}\n''',
+        '''void dsi_clk_disable_unprepare(struct dsi_clk_link_set *clk)\n{\n\tif (tgref_src_disable_logs < 8) {\n\t\tpr_info("TGREF SRC_OFF b=%lu bp=%lu p=%lu pp=%lu\\n",\n\t\t\ttgref_clk_rate(clk->byte_clk), tgref_parent_rate(clk->byte_clk),\n\t\t\ttgref_clk_rate(clk->pixel_clk), tgref_parent_rate(clk->pixel_clk));\n\t\ttgref_src_disable_logs++;\n\t}\n\tclk_disable_unprepare(clk->pixel_clk);\n\tclk_disable_unprepare(clk->byte_clk);\n}\n''',
+        'source-clock disable trace')
+
+    text = once(
+        text,
+        '''\tif (mngr->is_cont_splash_enabled)\n\t\treturn 0;\n\n\trc = clk_set_rate(link_hs_clks->byte_clk,\n\t\tl_clks->freq.byte_clk_rate);\n\tif (rc) {\n\t\tDSI_ERR("clk_set_rate failed for byte_clk rc = %d\\n", rc);\n\t\tgoto error;\n\t}\n\n\trc = clk_set_rate(link_hs_clks->pixel_clk,\n\t\tl_clks->freq.pix_clk_rate);\n\tif (rc) {\n\t\tDSI_ERR("clk_set_rate failed for pixel_clk rc = %d\\n", rc);\n\t\tgoto error;\n\t}\n\n\t/*\n\t * If byte_intf_clk is present, set rate for that too.\n\t */\n\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,\n\t\t\t\tl_clks->freq.byte_intf_clk_rate);\n\t\tif (rc) {\n\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",\n\t\t\t\trc);\n\t\t\tgoto error;\n\t\t}\n\t}\nerror:\n\treturn rc;\n}\n''',
+        '''\tif (mngr->is_cont_splash_enabled) {\n\t\tif (tgref_rate_skip_logs < 4) {\n\t\t\tpr_info("TGREF RATE_SKIP i=%d b=%llu p=%llu i=%llu act_b=%lu act_p=%lu act_i=%lu\\n",\n\t\t\t\tindex, (unsigned long long)l_clks->freq.byte_clk_rate,\n\t\t\t\t(unsigned long long)l_clks->freq.pix_clk_rate,\n\t\t\t\t(unsigned long long)l_clks->freq.byte_intf_clk_rate,\n\t\t\t\ttgref_clk_rate(link_hs_clks->byte_clk),\n\t\t\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n\t\t\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n\t\t\ttgref_rate_skip_logs++;\n\t\t}\n\t\treturn 0;\n\t}\n\n\t{\n\t\tbool tgref_trace = tgref_rate_apply_logs < 4;\n\n\t\tif (tgref_trace)\n\t\t\ttgref_rate_apply_logs++;\n\n\t\trc = clk_set_rate(link_hs_clks->byte_clk,\n\t\t\tl_clks->freq.byte_clk_rate);\n\t\tif (tgref_trace)\n\t\t\tpr_info("TGREF RATE_B i=%d req=%llu rc=%d act=%lu par=%lu\\n",\n\t\t\t\tindex, (unsigned long long)l_clks->freq.byte_clk_rate,\n\t\t\t\trc, tgref_clk_rate(link_hs_clks->byte_clk),\n\t\t\t\ttgref_parent_rate(link_hs_clks->byte_clk));\n\t\tif (rc) {\n\t\t\tDSI_ERR("clk_set_rate failed for byte_clk rc = %d\\n", rc);\n\t\t\tgoto error;\n\t\t}\n\n\t\trc = clk_set_rate(link_hs_clks->pixel_clk,\n\t\t\tl_clks->freq.pix_clk_rate);\n\t\tif (tgref_trace)\n\t\t\tpr_info("TGREF RATE_P i=%d req=%llu rc=%d act=%lu par=%lu\\n",\n\t\t\t\tindex, (unsigned long long)l_clks->freq.pix_clk_rate,\n\t\t\t\trc, tgref_clk_rate(link_hs_clks->pixel_clk),\n\t\t\t\ttgref_parent_rate(link_hs_clks->pixel_clk));\n\t\tif (rc) {\n\t\t\tDSI_ERR("clk_set_rate failed for pixel_clk rc = %d\\n", rc);\n\t\t\tgoto error;\n\t\t}\n\n\t\t/* If byte_intf_clk is present, set rate for that too. */\n\t\tif (link_hs_clks->byte_intf_clk) {\n\t\t\trc = clk_set_rate(link_hs_clks->byte_intf_clk,\n\t\t\t\tl_clks->freq.byte_intf_clk_rate);\n\t\t\tif (tgref_trace)\n\t\t\t\tpr_info("TGREF RATE_I i=%d req=%llu rc=%d act=%lu par=%lu\\n",\n\t\t\t\t\tindex,\n\t\t\t\t\t(unsigned long long)l_clks->freq.byte_intf_clk_rate,\n\t\t\t\t\trc, tgref_clk_rate(link_hs_clks->byte_intf_clk),\n\t\t\t\t\ttgref_parent_rate(link_hs_clks->byte_intf_clk));\n\t\t\tif (rc) {\n\t\t\t\tDSI_ERR("set_rate failed for byte_intf_clk rc = %d\\n",\n\t\t\t\t\trc);\n\t\t\t\tgoto error;\n\t\t\t}\n\t\t}\n\t}\nerror:\n\treturn rc;\n}\n''',
+        'bounded splash/set-rate chain trace')
+
+    text = once(
+        text,
+        '''\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_prepare(link_hs_clks->byte_intf_clk);\n\t\tif (rc) {\n\t\t\tDSI_ERR("Failed to prepare dsi byte intf clk, rc=%d\\n",\n\t\t\t\trc);\n\t\t\tgoto byte_intf_clk_err;\n\t\t}\n\t}\n\n\treturn rc;\n''',
+        '''\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_prepare(link_hs_clks->byte_intf_clk);\n\t\tif (rc) {\n\t\t\tDSI_ERR("Failed to prepare dsi byte intf clk, rc=%d\\n",\n\t\t\t\trc);\n\t\t\tgoto byte_intf_clk_err;\n\t\t}\n\t}\n\n\tif (tgref_prepare_logs < 4) {\n\t\tpr_info("TGREF PREP b=%lu p=%lu i=%lu\\n",\n\t\t\ttgref_clk_rate(link_hs_clks->byte_clk),\n\t\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n\t\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n\t\ttgref_prepare_logs++;\n\t}\n\n\treturn rc;\n''',
+        'HS prepare trace')
+
+    text = once(
+        text,
+        '''\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_enable(link_hs_clks->byte_intf_clk);\n\t\tif (rc) {\n\t\t\tDSI_ERR("Failed to enable dsi byte intf clk, rc=%d\\n",\n\t\t\t\trc);\n\t\t\tgoto byte_intf_clk_err;\n\t\t}\n\t}\n\n\treturn rc;\n''',
+        '''\tif (link_hs_clks->byte_intf_clk) {\n\t\trc = clk_enable(link_hs_clks->byte_intf_clk);\n\t\tif (rc) {\n\t\t\tDSI_ERR("Failed to enable dsi byte intf clk, rc=%d\\n",\n\t\t\t\trc);\n\t\t\tgoto byte_intf_clk_err;\n\t\t}\n\t}\n\n\tif (tgref_enable_logs < 4) {\n\t\tpr_info("TGREF ENABLE b=%lu p=%lu i=%lu\\n",\n\t\t\ttgref_clk_rate(link_hs_clks->byte_clk),\n\t\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n\t\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n\t\ttgref_enable_logs++;\n\t}\n\n\treturn rc;\n''',
+        'HS enable trace')
+
+    text = once(
+        text,
+        '''\tl_clks = container_of(link_hs_clks, struct dsi_link_clks, hs_clks);\n\n\tdsi_link_hs_clk_disable(link_hs_clks);\n''',
+        '''\tl_clks = container_of(link_hs_clks, struct dsi_link_clks, hs_clks);\n\n\tif (tgref_stop_logs < 8) {\n\t\tpr_info("TGREF HS_STOP b=%lu p=%lu i=%lu\\n",\n\t\t\ttgref_clk_rate(link_hs_clks->byte_clk),\n\t\t\ttgref_clk_rate(link_hs_clks->pixel_clk),\n\t\t\ttgref_clk_rate(link_hs_clks->byte_intf_clk));\n\t\ttgref_stop_logs++;\n\t}\n\n\tdsi_link_hs_clk_disable(link_hs_clks);\n''',
+        'HS stop trace')
+
+    text = once(
+        text,
+        '''\tif (c_clks || l_clks) {\n\t\trc = dsi_update_clk_state(mngr, c_clks, new_core_clk_state,\n''',
+        '''\tif ((c_clks || l_clks) && tgref_mgr_logs < 16) {\n\t\tpr_info("TGREF MGR core=%u->%u link=%u->%u sp=%u\\n",\n\t\t\told_c_clk_state, new_core_clk_state,\n\t\t\told_l_clk_state, new_link_clk_state,\n\t\t\tmngr->is_cont_splash_enabled ? 1 : 0);\n\t\ttgref_mgr_logs++;\n\t}\n\n\tif (c_clks || l_clks) {\n\t\trc = dsi_update_clk_state(mngr, c_clks, new_core_clk_state,\n''',
+        'manager state transition trace')
+
+    text = once(
+        text,
+        '''\tif (changed) {\n\t\trc = dsi_recheck_clk_state(mngr);\n''',
+        '''\tif (changed && tgref_req_logs < 16) {\n\t\tpr_info("TGREF REQ client=%s clk=%x req=%u cr=%u cs=%u lr=%u ls=%u\\n",\n\t\t\tc->name, clk, state, c->core_refcount, c->core_clk_state,\n\t\t\tc->link_refcount, c->link_clk_state);\n\t\ttgref_req_logs++;\n\t}\n\n\tif (changed) {\n\t\trc = dsi_recheck_clk_state(mngr);\n''',
+        'client request transition trace')
+
+    text = once(
+        text,
+        '''\tmngr = (struct dsi_clk_mngr *)clk_mgr;\n\tmngr->is_cont_splash_enabled = status;\n}\n''',
+        '''\tmngr = (struct dsi_clk_mngr *)clk_mgr;\n\tif (mngr->is_cont_splash_enabled != status && tgref_splash_logs < 4) {\n\t\tpr_info("TGREF SPLASH %u->%u\\n",\n\t\t\tmngr->is_cont_splash_enabled ? 1 : 0, status ? 1 : 0);\n\t\ttgref_splash_logs++;\n\t}\n\tmngr->is_cont_splash_enabled = status;\n}\n''',
+        'splash transition-only trace')
 
     return text
 
@@ -121,22 +174,32 @@ def patch_ctrl(text: str) -> str:
         text,
         '#define DSI_CTRL_TX_TO_MS     200\n',
         '#define DSI_CTRL_TX_TO_MS     200\n\n'
-        '/* ' + MARK + ': command-boundary control measurement only. */\n',
-        'controller marker')
+        '/* ' + MARK + ': one-shot first F0 5A 5A command boundary. */\n'
+        'static bool tgref_f0_armed;\n'
+        'static bool tgref_f0_done;\n',
+        'controller marker and one-shot state')
 
     old = '''kickoff:\n\tdsi_kickoff_msg_tx(dsi_ctrl, msg, &cmd, &cmd_mem, *flags);\nerror:\n'''
-    new = '''kickoff:\n\tif (msg->type == 0x29 && msg->tx_len == 3 && msg->tx_buf &&\n\t\t((const u8 *)msg->tx_buf)[0] == 0xf0 &&\n\t\t((const u8 *)msg->tx_buf)[1] == 0x5a &&\n\t\t((const u8 *)msg->tx_buf)[2] == 0x5a)\n\t\tpr_info("TGREF CMD PRE f=%x cache_b=%llu cache_p=%llu cache_i=%llu cache_e=%llu act_b=%lu act_p=%lu act_i=%lu act_e=%lu\\n",\n\t\t\t*flags, (unsigned long long)dsi_ctrl->clk_freq.byte_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.pix_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.byte_intf_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.esc_clk_rate,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.pixel_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_intf_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.lp_link_clks.esc_clk ? clk_get_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk) : 0);\n\tdsi_kickoff_msg_tx(dsi_ctrl, msg, &cmd, &cmd_mem, *flags);\n\tif (msg->type == 0x29 && msg->tx_len == 3 && msg->tx_buf &&\n\t\t((const u8 *)msg->tx_buf)[0] == 0xf0 &&\n\t\t((const u8 *)msg->tx_buf)[1] == 0x5a &&\n\t\t((const u8 *)msg->tx_buf)[2] == 0x5a)\n\t\tpr_info("TGREF CMD POST act_b=%lu act_p=%lu act_i=%lu act_e=%lu\\n",\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.pixel_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_intf_clk ? clk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.lp_link_clks.esc_clk ? clk_get_rate(dsi_ctrl->clk_info.lp_link_clks.esc_clk) : 0);\nerror:\n'''
-    return once(text, old, new, 'F0 5A 5A command boundary trace')
+    new = '''kickoff:\n\tif (!tgref_f0_done && !tgref_f0_armed && msg->type == 0x29 &&\n\t    msg->tx_len == 3 && msg->tx_buf &&\n\t    ((const u8 *)msg->tx_buf)[0] == 0xf0 &&\n\t    ((const u8 *)msg->tx_buf)[1] == 0x5a &&\n\t    ((const u8 *)msg->tx_buf)[2] == 0x5a) {\n\t\ttgref_f0_armed = true;\n\t\tpr_info("TGREF CMD PRE f=%x cache_b=%llu cache_p=%llu cache_i=%llu act_b=%lu act_p=%lu act_i=%lu\\n",\n\t\t\t*flags, (unsigned long long)dsi_ctrl->clk_freq.byte_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.pix_clk_rate,\n\t\t\t(unsigned long long)dsi_ctrl->clk_freq.byte_intf_clk_rate,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_clk ?\n\t\t\t\tclk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.pixel_clk ?\n\t\t\t\tclk_get_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_intf_clk ?\n\t\t\t\tclk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) : 0);\n\t}\n\n\tdsi_kickoff_msg_tx(dsi_ctrl, msg, &cmd, &cmd_mem, *flags);\n\n\tif (tgref_f0_armed && !tgref_f0_done && msg->type == 0x29 &&\n\t    msg->tx_len == 3 && msg->tx_buf &&\n\t    ((const u8 *)msg->tx_buf)[0] == 0xf0 &&\n\t    ((const u8 *)msg->tx_buf)[1] == 0x5a &&\n\t    ((const u8 *)msg->tx_buf)[2] == 0x5a) {\n\t\tpr_info("TGREF CMD POST act_b=%lu act_p=%lu act_i=%lu\\n",\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_clk ?\n\t\t\t\tclk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.pixel_clk ?\n\t\t\t\tclk_get_rate(dsi_ctrl->clk_info.hs_link_clks.pixel_clk) : 0,\n\t\t\tdsi_ctrl->clk_info.hs_link_clks.byte_intf_clk ?\n\t\t\t\tclk_get_rate(dsi_ctrl->clk_info.hs_link_clks.byte_intf_clk) : 0);\n\t\ttgref_f0_done = true;\n\t\ttgref_f0_armed = false;\n\t}\nerror:\n'''
+    return once(text, old, new, 'one-shot F0 5A 5A command boundary trace')
 
 
 def validate(clk: str, ctrl: str) -> None:
-    for token in [MARK, 'TGREF CACHE', 'TGREF SETP', 'TGREF SETB', 'TGREF APPLY0',
-                  'TGREF SKIP', 'TGREF APPLY1', 'TGREF SPLASH']:
+    for token in [
+        MARK, 'TGREF CACHE', 'TGREF SETP', 'TGREF SETB',
+        'TGREF PARENT PRE', 'TGREF PARENT POST', 'TGREF SRC_ON',
+        'TGREF SRC_OFF', 'TGREF RATE_SKIP', 'TGREF RATE_B',
+        'TGREF RATE_P', 'TGREF RATE_I', 'TGREF PREP', 'TGREF ENABLE',
+        'TGREF HS_STOP', 'TGREF MGR', 'TGREF REQ', 'TGREF SPLASH'
+    ]:
         if token not in clk:
             raise SystemExit('missing clk marker: ' + token)
-    for token in [MARK, 'TGREF CMD PRE', 'TGREF CMD POST', 'msg->type == 0x29']:
+    for token in [MARK, 'TGREF CMD PRE', 'TGREF CMD POST', 'tgref_f0_done']:
         if token not in ctrl:
             raise SystemExit('missing ctrl marker: ' + token)
+    for obsolete in ['TGREF APPLY0', 'TGREF APPLY1']:
+        if obsolete in clk:
+            raise SystemExit('obsolete noisy marker still present: ' + obsolete)
 
 
 def main() -> None:
@@ -155,7 +218,7 @@ def main() -> None:
         clk_path.write_text(clk)
         ctrl_path.write_text(ctrl)
     validate(clk, ctrl)
-    print('Golden TouchGrass clock-reference instrumentation validated')
+    print('Golden TouchGrass clock-chain reference V2 instrumentation validated')
 
 
 if __name__ == '__main__':

--- a/scripts/golden_touchgrass_clock_reference_build.sh
+++ b/scripts/golden_touchgrass_clock_reference_build.sh
@@ -43,13 +43,18 @@ chmod +x scripts/*.sh scripts/*.py
 # Freeze the pre-instrumentation display files for audit.
 cp "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c" "$OUT/audit/dsi_clk_manager-before.c"
 cp "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c" "$OUT/audit/dsi_ctrl-before.c"
+cp "$KERNEL/techpack/display/msm/dsi/dsi_display.c" "$OUT/audit/dsi_display-before.c"
 
 python3 scripts/golden_touchgrass_clock_reference.py --root "$KERNEL"
 python3 scripts/golden_touchgrass_clock_reference.py --root "$KERNEL" --check-only
+python3 scripts/golden_touchgrass_clock_origin.py --root "$KERNEL"
+python3 scripts/golden_touchgrass_clock_origin.py --root "$KERNEL" --check-only
 
 git -C "$KERNEL" diff --check
 
 grep -Fq 'A52_GOLDEN_TOUCHGRASS_CLOCK_CHAIN_REFERENCE_V2' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'A52_GOLDEN_TOUCHGRASS_CLOCK_CHAIN_ORIGIN_V2' "$KERNEL/techpack/display/msm/dsi/dsi_display.c"
+grep -Fq 'TGREF DERIVE' "$KERNEL/techpack/display/msm/dsi/dsi_display.c"
 grep -Fq 'TGREF RATE_SKIP' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
 grep -Fq 'TGREF PARENT PRE' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
 grep -Fq 'TGREF REQ' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
@@ -73,11 +78,13 @@ cp "$IMAGE" "$OUT/Image"
 cp "$CONFIG" "$OUT/config"
 cp "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c" "$OUT/audit/dsi_clk_manager-after.c"
 cp "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c" "$OUT/audit/dsi_ctrl-after.c"
+cp "$KERNEL/techpack/display/msm/dsi/dsi_display.c" "$OUT/audit/dsi_display-after.c"
 cp scripts/golden_touchgrass_clock_reference.py "$OUT/audit/"
+cp scripts/golden_touchgrass_clock_origin.py "$OUT/audit/"
 
 strings "$OUT/Image" > "$OUT/Image.strings.txt"
 for marker in \
-  'TGREF CACHE' 'TGREF SETP' 'TGREF SETB' \
+  'TGREF DERIVE' 'TGREF CACHE' 'TGREF SETP' 'TGREF SETB' \
   'TGREF PARENT PRE' 'TGREF PARENT POST' \
   'TGREF SRC_ON' 'TGREF SRC_OFF' \
   'TGREF RATE_SKIP' 'TGREF RATE_B' 'TGREF RATE_P' 'TGREF RATE_I' \
@@ -100,7 +107,7 @@ touchgrass_base=6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
 kernel_version=4.19.200-touchGrassKernel+
 reference_workflow_run=29199421254
 reference_runtime_build_time=2026-07-12T16:13:54Z
-markers=TGREF_CACHE,TGREF_SETP,TGREF_SETB,TGREF_PARENT_PRE,TGREF_PARENT_POST,TGREF_SRC_ON,TGREF_SRC_OFF,TGREF_RATE_SKIP,TGREF_RATE_B,TGREF_RATE_P,TGREF_RATE_I,TGREF_PREP,TGREF_ENABLE,TGREF_HS_STOP,TGREF_MGR,TGREF_REQ,TGREF_SPLASH,TGREF_CMD_PRE,TGREF_CMD_POST
+markers=TGREF_DERIVE,TGREF_CACHE,TGREF_SETP,TGREF_SETB,TGREF_PARENT_PRE,TGREF_PARENT_POST,TGREF_SRC_ON,TGREF_SRC_OFF,TGREF_RATE_SKIP,TGREF_RATE_B,TGREF_RATE_P,TGREF_RATE_I,TGREF_PREP,TGREF_ENABLE,TGREF_HS_STOP,TGREF_MGR,TGREF_REQ,TGREF_SPLASH,TGREF_CMD_PRE,TGREF_CMD_POST
 flashable=no-image-only-until-golden-boot-container-repack
 EOF
 

--- a/scripts/golden_touchgrass_clock_reference_build.sh
+++ b/scripts/golden_touchgrass_clock_reference_build.sh
@@ -49,10 +49,14 @@ python3 scripts/golden_touchgrass_clock_reference.py --root "$KERNEL" --check-on
 
 git -C "$KERNEL" diff --check
 
-grep -Fq 'A52_GOLDEN_TOUCHGRASS_CLOCK_REFERENCE_V1' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
-grep -Fq 'TGREF SKIP' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'A52_GOLDEN_TOUCHGRASS_CLOCK_CHAIN_REFERENCE_V2' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'TGREF RATE_SKIP' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'TGREF PARENT PRE' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'TGREF REQ' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
 grep -Fq 'TGREF CMD PRE' "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c"
 grep -Fq 'TGREF CMD POST' "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c"
+! grep -Fq 'TGREF APPLY0' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+! grep -Fq 'TGREF APPLY1' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
 
 ./scripts/07_patch_resukisu_exec_hook.sh
 
@@ -73,25 +77,31 @@ cp scripts/golden_touchgrass_clock_reference.py "$OUT/audit/"
 
 strings "$OUT/Image" > "$OUT/Image.strings.txt"
 for marker in \
-  'TGREF CACHE' 'TGREF SETP' 'TGREF SETB' 'TGREF APPLY0' \
-  'TGREF SKIP' 'TGREF APPLY1' 'TGREF SPLASH' \
+  'TGREF CACHE' 'TGREF SETP' 'TGREF SETB' \
+  'TGREF PARENT PRE' 'TGREF PARENT POST' \
+  'TGREF SRC_ON' 'TGREF SRC_OFF' \
+  'TGREF RATE_SKIP' 'TGREF RATE_B' 'TGREF RATE_P' 'TGREF RATE_I' \
+  'TGREF PREP' 'TGREF ENABLE' 'TGREF HS_STOP' \
+  'TGREF MGR' 'TGREF REQ' 'TGREF SPLASH' \
   'TGREF CMD PRE' 'TGREF CMD POST'; do
   grep -Fq "$marker" "$OUT/Image.strings.txt"
 done
 
+! grep -Fq 'TGREF APPLY0' "$OUT/Image.strings.txt"
+! grep -Fq 'TGREF APPLY1' "$OUT/Image.strings.txt"
 grep -Fq 'Linux version 4.19.200-touchGrassKernel+' "$OUT/Image.strings.txt"
 
 sha256sum "$OUT/Image" "$OUT/config" > "$OUT/SHA256SUMS"
 cat > "$OUT/BUILD-IDENTITY.txt" <<EOF
-experiment=GOLDEN-TOUCHGRASS-CLOCK-REFERENCE
-behavior_change=none-read-only-pr_info-only
+experiment=GOLDEN-TOUCHGRASS-CLOCK-CHAIN-REFERENCE-V2
+behavior_change=none-read-only-bounded-pr_info-only
 base_project_commit=d6f75d100f0307866938c386347732b8a776c97e
 touchgrass_base=6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
 kernel_version=4.19.200-touchGrassKernel+
 reference_workflow_run=29199421254
 reference_runtime_build_time=2026-07-12T16:13:54Z
-markers=TGREF_CACHE,TGREF_SETP,TGREF_SETB,TGREF_APPLY0,TGREF_SKIP,TGREF_APPLY1,TGREF_SPLASH,TGREF_CMD_PRE,TGREF_CMD_POST
-flashable=no-image-only-until-template-repack
+markers=TGREF_CACHE,TGREF_SETP,TGREF_SETB,TGREF_PARENT_PRE,TGREF_PARENT_POST,TGREF_SRC_ON,TGREF_SRC_OFF,TGREF_RATE_SKIP,TGREF_RATE_B,TGREF_RATE_P,TGREF_RATE_I,TGREF_PREP,TGREF_ENABLE,TGREF_HS_STOP,TGREF_MGR,TGREF_REQ,TGREF_SPLASH,TGREF_CMD_PRE,TGREF_CMD_POST
+flashable=no-image-only-until-golden-boot-container-repack
 EOF
 
-echo "Golden TouchGrass clock reference build passed"
+echo "Golden TouchGrass clock-chain reference V2 build passed"

--- a/scripts/golden_touchgrass_clock_reference_build.sh
+++ b/scripts/golden_touchgrass_clock_reference_build.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+OUT="$ROOT/golden-clock-ref-out"
+FAIL="$ROOT/golden-clock-ref-failure"
+KERNEL="$ROOT/workspace/touchgrass-a52xq"
+rm -rf "$OUT" "$FAIL"
+mkdir -p "$OUT/audit" "$FAIL"
+
+on_err() {
+  rc=$?
+  {
+    echo "rc=$rc"
+    date -u
+    git status --short || true
+    if [ -d "$KERNEL" ]; then
+      git -C "$KERNEL" status --short || true
+      git -C "$KERNEL" diff --stat || true
+      git -C "$KERNEL" diff --check || true
+    fi
+  } > "$FAIL/diagnostics.txt" 2>&1
+  exit "$rc"
+}
+trap on_err ERR
+
+chmod +x scripts/*.sh scripts/*.py
+
+# Reproduce the exact reviewed 4.19.200 sequence used by workflow run 29199421254.
+./scripts/01_prepare_source.sh
+./scripts/03_apply_linux_4.19.153.sh
+./scripts/04_apply_linux_4.19.154.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+./scripts/checkpoint_resolve_linux_4.19.159.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+./scripts/checkpoint_resolve_linux_4.19.164.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+./scripts/checkpoint_resolve_linux_4.19.180.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+./scripts/checkpoint_resolve_linux_4.19.200.sh
+
+# Freeze the pre-instrumentation display files for audit.
+cp "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c" "$OUT/audit/dsi_clk_manager-before.c"
+cp "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c" "$OUT/audit/dsi_ctrl-before.c"
+
+python3 scripts/golden_touchgrass_clock_reference.py --root "$KERNEL"
+python3 scripts/golden_touchgrass_clock_reference.py --root "$KERNEL" --check-only
+
+git -C "$KERNEL" diff --check
+
+grep -Fq 'A52_GOLDEN_TOUCHGRASS_CLOCK_REFERENCE_V1' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'TGREF SKIP' "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c"
+grep -Fq 'TGREF CMD PRE' "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c"
+grep -Fq 'TGREF CMD POST' "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c"
+
+./scripts/07_patch_resukisu_exec_hook.sh
+
+set -o pipefail
+./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.200 \
+  2>&1 | tee "$OUT/golden-clock-reference-build.log"
+
+IMAGE="$(find artifacts -maxdepth 1 -type f -name 'Image-touchgrass-4.19.200-resukisu-v4.1.0-safe' -print -quit)"
+CONFIG="$(find artifacts -maxdepth 1 -type f -name 'config-touchgrass-4.19.200-resukisu-v4.1.0-safe' -print -quit)"
+test -n "$IMAGE" -a -f "$IMAGE"
+test -n "$CONFIG" -a -f "$CONFIG"
+
+cp "$IMAGE" "$OUT/Image"
+cp "$CONFIG" "$OUT/config"
+cp "$KERNEL/techpack/display/msm/dsi/dsi_clk_manager.c" "$OUT/audit/dsi_clk_manager-after.c"
+cp "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c" "$OUT/audit/dsi_ctrl-after.c"
+cp scripts/golden_touchgrass_clock_reference.py "$OUT/audit/"
+
+strings "$OUT/Image" > "$OUT/Image.strings.txt"
+for marker in \
+  'TGREF CACHE' 'TGREF SETP' 'TGREF SETB' 'TGREF APPLY0' \
+  'TGREF SKIP' 'TGREF APPLY1' 'TGREF SPLASH' \
+  'TGREF CMD PRE' 'TGREF CMD POST'; do
+  grep -Fq "$marker" "$OUT/Image.strings.txt"
+done
+
+grep -Fq 'Linux version 4.19.200-touchGrassKernel+' "$OUT/Image.strings.txt"
+
+sha256sum "$OUT/Image" "$OUT/config" > "$OUT/SHA256SUMS"
+cat > "$OUT/BUILD-IDENTITY.txt" <<EOF
+experiment=GOLDEN-TOUCHGRASS-CLOCK-REFERENCE
+behavior_change=none-read-only-pr_info-only
+base_project_commit=d6f75d100f0307866938c386347732b8a776c97e
+touchgrass_base=6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+kernel_version=4.19.200-touchGrassKernel+
+reference_workflow_run=29199421254
+reference_runtime_build_time=2026-07-12T16:13:54Z
+markers=TGREF_CACHE,TGREF_SETP,TGREF_SETB,TGREF_APPLY0,TGREF_SKIP,TGREF_APPLY1,TGREF_SPLASH,TGREF_CMD_PRE,TGREF_CMD_POST
+flashable=no-image-only-until-template-repack
+EOF
+
+echo "Golden TouchGrass clock reference build passed"


### PR DESCRIPTION
Known-good control experiment for the A52 display investigation. Base is frozen at the exact project commit used by the reviewed 4.19.200 TouchGrass build.

V2 removes the noisy continuous APPLY0/APPLY1 sampling and replaces it with bounded, read-only transition/setter tracing of the causal DSI clock path:

- panel bitrate/lane/BPP/divider -> derived byte/pixel/byte-interface targets (`TGREF DERIVE`)
- cache updates (`TGREF CACHE`)
- explicit byte/pixel setters (`TGREF SETB`, `TGREF SETP`)
- parent selection (`TGREF PARENT PRE/POST`)
- source-clock ON/OFF (`TGREF SRC_ON/OFF`)
- continuous-splash skip versus actual HS rate programming (`TGREF RATE_SKIP`, `TGREF RATE_B/P/I`)
- HS prepare/enable/stop (`TGREF PREP`, `TGREF ENABLE`, `TGREF HS_STOP`)
- client and manager clock-state transitions (`TGREF REQ`, `TGREF MGR`)
- continuous-splash state transitions (`TGREF SPLASH`)
- one-shot first successful `F0 5A 5A` command boundary (`TGREF CMD PRE/POST`)

All logging is bounded or transition-only so later Android refresh-rate/clock activity cannot flood the ring buffer and overwrite the boot-time chain. No clock programming, panel behavior, DT, config, or GKI recorder behavior is changed.

CI reconstructs the exact reviewed TouchGrass 4.19.200 lineage, builds the traced kernel, then uses the same known-good Golden definitive-FDR repack chain: release asset `478920392` is SHA-256 locked, validated as the 96 MiB source boot image, the new kernel is gzip-packed, and `scripts/38_repack_a52_p1_boot.py` emits a validated 96 MiB `boot.img`. The uploaded artifact therefore contains the real repacked `boot.img` plus the kernel/config/audit and repack reports.