### PR TITLE
Phase287: DSI DMA fetch provenance recorder

### DIFF
--- a/.github/workflows/287-a52-dsi-dma-fetch-provenance.yml
+++ b/.github/workflows/287-a52-dsi-dma-fetch-provenance.yml
@@ -1,0 +1,94 @@
+name: 287 - A52 DSI DMA fetch provenance
+run-name: Phase 287 - DSI DMA fetch provenance
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase287-dsi-dma-fetch-provenance-v1
+    paths:
+      - .github/workflows/287-a52-dsi-dma-fetch-provenance.yml
+      - scripts/287_apply_dsi_dma_fetch_provenance.py
+      - scripts/287_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase286-golden-fdr-dma-chain-v1
+    paths:
+      - .github/workflows/287-a52-dsi-dma-fetch-provenance.yml
+      - scripts/287_apply_dsi_dma_fetch_provenance.py
+      - scripts/287_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase287-dsi-dma-fetch-provenance-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build Phase287 DMA fetch provenance recorder
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase287 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build Phase287 candidate
+        run: bash scripts/287_ci_build.sh
+      - name: Verify real boot image
+        run: |
+          set -Eeuo pipefail
+          test -s phase287-out/package/boot.img
+          test "$(stat -c '%s' phase287-out/package/boot.img)" -gt 1000000
+          file phase287-out/package/boot.img
+          sha256sum phase287-out/package/boot.img
+      - name: Upload Phase287 candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase287-DMA-FETCH-PROVENANCE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase287-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase287-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/287-a52-dsi-dma-fetch-provenance.yml
+++ b/.github/workflows/287-a52-dsi-dma-fetch-provenance.yml
@@ -1,5 +1,5 @@
-name: 287 - A52 DSI DMA fetch provenance
-run-name: Phase 287 - DSI DMA fetch provenance
+name: 287B - A52 retained DSI DMA fetch provenance
+run-name: Phase 287B - Retained DSI DMA fetch provenance
 on:
   workflow_dispatch:
   push:
@@ -7,18 +7,27 @@ on:
       - agent/a52-phase287-dsi-dma-fetch-provenance-v1
     paths:
       - .github/workflows/287-a52-dsi-dma-fetch-provenance.yml
+      - scripts/286_ci_build.sh
+      - scripts/286b_apply_dma_chain_retention.py
+      - scripts/286c_fix_dma_replay_width.py
       - scripts/287_apply_dsi_dma_fetch_provenance.py
+      - scripts/287b_apply_retained_fetch_provenance.py
       - scripts/287_ci_build.sh
   pull_request:
     branches:
       - agent/a52-phase286-golden-fdr-dma-chain-v1
     paths:
       - .github/workflows/287-a52-dsi-dma-fetch-provenance.yml
+      - scripts/286_ci_build.sh
+      - scripts/286b_apply_dma_chain_retention.py
+      - scripts/286c_fix_dma_replay_width.py
       - scripts/287_apply_dsi_dma_fetch_provenance.py
+      - scripts/287b_apply_retained_fetch_provenance.py
       - scripts/287_ci_build.sh
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 concurrency:
   group: a52-phase287-dsi-dma-fetch-provenance-${{ github.ref }}
   cancel-in-progress: true
@@ -29,14 +38,18 @@ env:
   PHASE227_SEED_ARTIFACT_ID: '9160764832'
 jobs:
   build:
-    name: Build Phase287 DMA fetch provenance recorder
+    name: Build Phase287B retained DMA fetch provenance recorder
     runs-on: ubuntu-22.04
     timeout-minutes: 240
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Check out Phase287 branch
+      - name: Check out Phase287B branch
         uses: actions/checkout@v4
+      - name: Publish Phase287B run ID
+        run: |
+          set -Eeuo pipefail
+          gh pr comment 152 --repo "$GITHUB_REPOSITORY" --body "Phase287B CI started | run ${{ github.run_id }} | https://github.com/${GITHUB_REPOSITORY}/actions/runs/${{ github.run_id }} | commit ${{ github.sha }}"
       - name: Prepare runner
         run: |
           set -Eeuo pipefail
@@ -65,7 +78,7 @@ jobs:
           git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
           git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
           git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
-      - name: Build Phase287 candidate
+      - name: Build Phase287B candidate
         run: bash scripts/287_ci_build.sh
       - name: Verify real boot image
         run: |
@@ -74,11 +87,11 @@ jobs:
           test "$(stat -c '%s' phase287-out/package/boot.img)" -gt 1000000
           file phase287-out/package/boot.img
           sha256sum phase287-out/package/boot.img
-      - name: Upload Phase287 candidate
+      - name: Upload Phase287B candidate
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-Phase287-DMA-FETCH-PROVENANCE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          name: A52XQ-Phase287B-DMA-FETCH-PROVENANCE-RETAINED-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
           path: phase287-out/
           if-no-files-found: error
           compression-level: 1
@@ -87,8 +100,13 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: A52XQ-Phase287-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          name: A52XQ-Phase287B-FAILURE-DIAGNOSTICS-${{ github.run_number }}
           path: |
             phase*-failure/
           if-no-files-found: warn
           retention-days: 30
+      - name: Report this run to Phase287 PR
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          gh pr comment 152 --repo "$GITHUB_REPOSITORY" --body "Phase287B CI finished: **${{ job.status }}** | run ${{ github.run_id }} | https://github.com/${GITHUB_REPOSITORY}/actions/runs/${{ github.run_id }} | commit ${{ github.sha }}"

--- a/scripts/286_ci_build.sh
+++ b/scripts/286_ci_build.sh
@@ -13,13 +13,15 @@ fail_report(){
   mkdir -p phase286-failure/{source,logs,audit,config}
   cp phase286-compile.log phase286-failure/logs/ 2>/dev/null || true
   for f in "$DSI" "$HW" "$REC"; do [ -f "$f" ] && cp "$f" phase286-failure/source/ || true; done
-  cp scripts/286_apply_golden_fdr_dma_chain.py phase286-failure/audit/ 2>/dev/null || true
+  cp scripts/286*.py phase286-failure/audit/ 2>/dev/null || true
   cp /tmp/p286-*.config /tmp/p286-*.diff phase286-failure/config/ 2>/dev/null || true
 }
 trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
 
-# Reconstruct the exact Phase285 lineage first, including the already-proven
-# Golden FDR retention transport. Phase286 then changes only DSI tracing code.
+# Reconstruct the exact Phase285 lineage first. Phase286 adds passive DSI
+# producers. Phase286B captures their exact typed varargs in a private circular
+# tail and replays them just before Phase280 freezes the timeout snapshot.
+# Phase286C enforces that every replay record fits the recorder's packed field.
 bash scripts/285_ci_build.sh
 test -s phase285-out/package/boot.img
 test -s "$OUT/arch/arm64/boot/Image"
@@ -30,15 +32,20 @@ cp "$DSI" /tmp/p286-dsi-before.c
 cp "$HW" /tmp/p286-hw-before.c
 cp "$REC" /tmp/p286-rec-before.c
 
-python3 -m py_compile scripts/286_apply_golden_fdr_dma_chain.py
+python3 -m py_compile \
+  scripts/286_apply_golden_fdr_dma_chain.py \
+  scripts/286b_apply_dma_chain_retention.py \
+  scripts/286c_fix_dma_replay_width.py
 python3 scripts/286_apply_golden_fdr_dma_chain.py --root "$ROOT"
+python3 scripts/286b_apply_dma_chain_retention.py --root "$ROOT"
 python3 scripts/286_apply_golden_fdr_dma_chain.py --root "$ROOT" --check-only
+python3 scripts/286b_apply_dma_chain_retention.py --root "$ROOT" --check-only
+python3 scripts/286c_fix_dma_replay_width.py --root "$ROOT"
+python3 scripts/286c_fix_dma_replay_width.py --root "$ROOT" --check-only
 
-# Recorder implementation and config are immutable in this phase. We reuse its
-# proven retention path and only add passive producers in DSI controller code.
-cmp -s /tmp/p286-rec-before.c "$REC"
 ! cmp -s /tmp/p286-dsi-before.c "$DSI"
 ! cmp -s /tmp/p286-hw-before.c "$HW"
+! cmp -s /tmp/p286-rec-before.c "$REC"
 cmp -s /tmp/p286-base.config "$OUT/.config"
 
 for token in \
@@ -56,6 +63,39 @@ for token in \
   'P286 HK c=%d o=%x l=%x f=%x sw=1' \
   'P286 HK c=%d o=%x l=%x f=%x sw=0' \
   'P286 HT c=%d sw=1'; do grep -Fq "$token" "$HW"; done
+for token in \
+  'A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1' \
+  'A52_PHASE286C_PACKED_REPLAY_WIDTH_V1' \
+  '#define A52_P286_TAIL 32U' \
+  'a52_p286_capture_fmt(fmt, args);' \
+  'return !strncmp(message, "P286 ", 5)' \
+  'strncmp(fmt, "P286", 4)' \
+  'P286 RH %llx %llx' \
+  'P286 R0 %llx %x %x %llx %llx' \
+  'P286 R1 %llx %llx %llx' \
+  'EXPORT_SYMBOL_GPL(a52_p286_flush_timeout_chain);'; do grep -Fq "$token" "$REC"; done
+
+grep -Fq 'a52_p286_flush_timeout_chain();' "$DSI"
+python3 - <<'PY'
+from pathlib import Path
+d=Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl.c').read_text()
+assert d.index('P286 T c=%d st=%x done=%d irq=%d') < d.index('a52_p286_flush_timeout_chain();')
+assert d.index('a52_p286_flush_timeout_chain();') < d.index('P276 280Z q=2')
+assert d.index('P276 280Z q=2') < d.index('a52_ackfr_retain_timeout_snapshot();')
+print('Phase286 replay-before-freeze ordering: PASS')
+PY
+
+python3 - <<'PY'
+lines = [
+    'P286 RH ' + 'f'*16 + ' ' + 'f'*16,
+    'P286 R0 ' + 'f'*16 + ' ff ff ' + 'f'*16 + ' ' + 'f'*16,
+    'P286 R1 ' + 'f'*16 + ' ' + 'f'*16 + ' ' + 'f'*16,
+]
+for line in lines:
+    if len(line) > 72:
+        raise SystemExit(f'Phase286 replay format can truncate: {len(line)} bytes: {line}')
+print('Phase286 replay packed-width audit:', max(map(len, lines)), '<= 72')
+PY
 
 make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
   CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
@@ -83,13 +123,13 @@ cp /tmp/p286-hw-before.c phase286-out/audit/dsi-ctrl-hw-cmn-before.c
 cp /tmp/p286-rec-before.c phase286-out/audit/recorder-before.c
 cp phase286-compile.log phase286-out/audit/
 cp scripts/286_apply_golden_fdr_dma_chain.py phase286-out/audit/
+cp scripts/286b_apply_dma_chain_retention.py phase286-out/audit/
+cp scripts/286c_fix_dma_replay_width.py phase286-out/audit/
 cp "$DSI" phase286-out/source/dsi_ctrl.c
 cp "$HW" phase286-out/source/dsi_ctrl_hw_cmn.c
 cp "$REC" phase286-out/source/a52_ack_secure_flight_recorder.c
 
 gzip -n -c "$IMAGE" > phase286-out/package/Image.gz
-# Golden FDR repack: keep the exact validated Phase285 boot container and only
-# replace its kernel payload using the established Phase38 repacker.
 python3 scripts/38_repack_a52_p1_boot.py \
   --source phase285-out/package/boot.img \
   --kernel phase286-out/package/Image.gz \
@@ -102,6 +142,7 @@ file phase286-out/package/boot.img | tee phase286-out/package/boot-file.txt
 cat > phase286-out/PHASE286-RECORD-SCHEMA.txt <<'EOF'
 Phase286 Golden-FDR DSI DMA causal chain
 ========================================
+Live producer records:
 A  message entry: controller, mipi msg flags, controller flags, type, tx_len
 B  kickoff policy: controller, controller flags, low-level hw_flags, panel mode, video-engine state
 HK low-level memory kickoff after DMA offset/length+wmb: offset, length, hw_flags, immediate SW-trigger yes/no
@@ -112,6 +153,32 @@ E  high-level trigger call returned: slave / scheduled master / direct master
 G  ISR observed DMA_DONE before setting dma_irq_trig/completing waiter
 W  completion wait result and dma_irq_trig
 T  timeout raw interrupt status and DMA_DONE bit
+
+Phase286B/C guaranteed timeout-tail retention:
+The exact varargs for the final 32 P286 producer events are captured in a
+private circular typed buffer before normal FDR text packing. On DMA timeout,
+that tail is replayed immediately before P276 280Z and the Phase280 recorder
+freeze. Therefore ordinary ring overwrite cannot remove the causal tail.
+Every replay line is CI-audited to fit the recorder's 72-byte packed field.
+
+Replay:
+  P286 RH <total> <first-retained-seq>
+  P286 R0 <seq> <type> <argc> <v0> <v1>
+  P286 R1 <v2> <v3> <v4> when argc > 2; associates with preceding R0
+Type map:
+  1=A
+  2=B
+  3=D
+  4=DX(no-LAST)
+  5=E(slave)
+  6=E(scheduled master)
+  7=E(direct master)
+  8=W
+  9=T
+ 10=G(DMA_DONE ISR)
+ 11=HK(immediate SW trigger)
+ 12=HK(deferred, trigger omitted here)
+ 13=HT(actual deferred SW-trigger write)
 
 Inherited Phase281 q0/q1/q2 records provide DSI_STATUS, FIFO_STATUS,
 COMMAND_MODE_DMA_CTRL, DMA_FIFO_CTRL, DMA_SW_TRIGGER, INT_CTRL, ACK_ERR,
@@ -124,8 +191,8 @@ import hashlib, json, os
 from pathlib import Path
 r=Path('phase286-out')
 idn={
- 'phase':'286',
- 'name':'GOLDEN-FDR-DSI-DMA-CAUSAL-CHAIN',
+ 'phase':'286C',
+ 'name':'GOLDEN-FDR-DSI-DMA-CAUSAL-CHAIN-TYPED-RETENTION',
  'git_sha':os.getenv('GITHUB_SHA'),
  'hardware_validated':False,
  'base':'exact Phase285 lineage and Golden FDR retention transport',
@@ -134,7 +201,9 @@ idn={
  'trigger_behavior_changed':False,
  'timeout_recovery_changed':False,
  'brightness_behavior_changed':False,
- 'recorder_implementation_changed':False,
+ 'recorder_implementation_changed':True,
+ 'recorder_change':'admit P286; capture exact varargs for last 32 causal events; replay immediately before Phase280 timeout freeze; enforce <=72 byte replay records',
+ 'previous_failure_addressed':'ordinary early trace records can be filtered, overwritten, or packed/truncated before ramoops harvest; Phase286C explicitly guards all three failure modes',
  'question':'Where exactly does the real TouchGrass command-DMA path stop before DMA_DONE: deferred gate, SW trigger, hardware completion, IRQ delivery, or waiter completion?',
  'golden_repack_source':'phase285-out/package/boot.img',
  'repacker':'scripts/38_repack_a52_p1_boot.py'
@@ -156,11 +225,13 @@ for m in [
  'P286 A c=%d mf=%x f=%x t=%u l=%u','P286 B c=%d f=%x h=%x pm=%d ve=%d',
  'P286 D c=%d f=%x last=%d bm=%d b=%d','P286 DX c=%d reason=nolast',
  'P286 HT c=%d sw=1','P286 E c=%d k=master','P286 W c=%d r=%d irq=%d',
- 'P286 T c=%d st=%x done=%d irq=%d','P286 G c=%d st=%x irq0=%d']:
+ 'P286 T c=%d st=%x done=%d irq=%d','P286 G c=%d st=%x irq0=%d',
+ 'P286 RH %llx %llx','P286 R0 %llx %x %x %llx %llx','P286 R1 %llx %llx %llx']:
  if m.encode() not in img: raise SystemExit('Phase286 runtime marker missing: '+m)
-print('Phase286 compiled marker audit: PASS')
+print('Phase286 compiled producer + typed-retention marker audit: PASS')
 PY
 
 python3 scripts/286_apply_golden_fdr_dma_chain.py --root "$ROOT" --check-only
+python3 scripts/286c_fix_dma_replay_width.py --root "$ROOT" --check-only
 trap - EXIT
-echo 'Phase286 Golden-FDR DSI DMA causal-chain build/repack: PASS'
+echo 'Phase286C Golden-FDR DSI DMA causal-chain build/repack: PASS'

--- a/scripts/286b_apply_dma_chain_retention.py
+++ b/scripts/286b_apply_dma_chain_retention.py
@@ -192,13 +192,27 @@ def patch_dsi(text: str) -> str:
                   'P276 280Z q=2']:
         if token not in text:
             raise SystemExit('Phase286B DSI prerequisite missing: ' + token)
+    # Phase286A's original generic status anchor matched the 50us slave-status
+    # polling loop instead of the real 200ms completion-timeout path. Move T
+    # to the timeout status read before retaining the causal tail.
+    misplaced = '''\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P286 T c=%d st=%x done=%d irq=%d",\n\t\t\t\tdsi_ctrl->cell_index, status, !!(status & mask),\n\t\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\tif (status & mask) {\n'''
+    clean_poll = '''\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n\t\tif (status & mask) {\n'''
+    if misplaced in text:
+        text = one(text, misplaced, clean_poll, 'remove misplaced timeout marker')
+    wait_fn = text.index('static void dsi_ctrl_dma_cmd_wait_for_done(')
+    freeze_fn = text.index('P276 280Z q=2', wait_fn)
+    timeout_fmt = 'P286 T c=%d st=%x done=%d irq=%d'
+    if timeout_fmt not in text[wait_fn:freeze_fn]:
+        real_old = '''\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P276 P S st=%x dn=%u a=%d im=%x ir=%u",\n'''
+        real_new = '''\t\tstatus = dsi_hw_ops.get_interrupt_status(&dsi_ctrl->hw);\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P286 T c=%d st=%x done=%d irq=%d",\n\t\t\t\tdsi_ctrl->cell_index, status, !!(status & mask),\n\t\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P276 P S st=%x dn=%u a=%d im=%x ir=%u",\n'''
+        text = one(text, real_old, real_new, 'real 200ms timeout marker')
     text = one(text,
                'extern void a52_ackfr_retain_timeout_snapshot(void);\n',
                'extern void a52_ackfr_retain_timeout_snapshot(void);\nextern void a52_p286_flush_timeout_chain(void); /* ' + MARK + ' */\n',
                'flush declaration')
     text = one(text,
-               '\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n',
-               '\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_p286_flush_timeout_chain();\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n',
+               '\t\t\ta52_ackfr_record("P276 282Z q=2");\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n',
+               '\t\t\ta52_ackfr_record("P276 282Z q=2");\n\t\t\ta52_p286_flush_timeout_chain();\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n',
                'flush immediately before retention freeze')
     return text
 

--- a/scripts/286b_apply_dma_chain_retention.py
+++ b/scripts/286b_apply_dma_chain_retention.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+DSI = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+BLOCK = r'''
+/* A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1
+ * Phase284 taught us that emitting a trace line is not sufficient evidence:
+ * useful early records can be overwritten before ramoops is harvested.
+ *
+ * Capture the exact P286 varargs into a private circular tail buffer before
+ * text packing, independent of the normal FDR ring. At the DMA timeout, replay
+ * the final 32 causal events into the normal persistent recorder immediately
+ * before Phase280 freezes it. This preserves the chain that directly led to
+ * the timeout even if earlier live P286 lines were overwritten.
+ *
+ * Replay grammar, all values raw hexadecimal:
+ *   P286 R0 q=<seq> t=<type> n=<argc> a=<v0> b=<v1>
+ *   P286 R1 q=<seq> c=<v2> d=<v3> e=<v4>     (only when argc > 2)
+ * Type map is emitted in the build artifact schema.
+ */
+#define A52_P286_TAIL 32U
+#define A52_P286_VALUES 5U
+
+struct a52_p286_sample {
+	u64 seq;
+	u64 v[A52_P286_VALUES];
+	u8 type;
+	u8 n;
+};
+
+static struct a52_p286_sample a52_p286_tail[A52_P286_TAIL];
+static DEFINE_SPINLOCK(a52_p286_lock);
+static atomic64_t a52_p286_seq = ATOMIC64_INIT(0);
+
+static void a52_p286_store(u8 type, u8 n, const u64 *v)
+{
+	struct a52_p286_sample s;
+	unsigned long flags;
+	u64 seq;
+
+	if (!type || !n || n > A52_P286_VALUES || !v)
+		return;
+	memset(&s, 0, sizeof(s));
+	seq = (u64)atomic64_inc_return(&a52_p286_seq);
+	s.seq = seq;
+	s.type = type;
+	s.n = n;
+	memcpy(s.v, v, n * sizeof(v[0]));
+	spin_lock_irqsave(&a52_p286_lock, flags);
+	a52_p286_tail[(seq - 1) % A52_P286_TAIL] = s;
+	spin_unlock_irqrestore(&a52_p286_lock, flags);
+}
+
+static void a52_p286_capture_fmt(const char *fmt, va_list src)
+{
+	va_list ap;
+	u64 v[A52_P286_VALUES] = { 0 };
+	u8 type = 0, n = 0;
+
+	if (!fmt || strncmp(fmt, "P286 ", 5))
+		return;
+	va_copy(ap, src);
+	if (!strcmp(fmt, "P286 A c=%d mf=%x f=%x t=%u l=%u")) {
+		type = 1; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int); v[4] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P286 B c=%d f=%x h=%x pm=%d ve=%d")) {
+		type = 2; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = (u64)(s64)va_arg(ap, int); v[4] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 D c=%d f=%x last=%d bm=%d b=%d")) {
+		type = 3; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = va_arg(ap, unsigned int);
+		v[2] = (u64)(s64)va_arg(ap, int); v[3] = (u64)(s64)va_arg(ap, int);
+		v[4] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 DX c=%d reason=nolast")) {
+		type = 4; n = 1; v[0] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 E c=%d k=slave")) {
+		type = 5; n = 1; v[0] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 E c=%d k=sched cl=%u sl=%u lb=%u")) {
+		type = 6; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = va_arg(ap, unsigned int);
+		v[2] = va_arg(ap, unsigned int); v[3] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P286 E c=%d k=master")) {
+		type = 7; n = 1; v[0] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 W c=%d r=%d irq=%d")) {
+		type = 8; n = 3;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = (u64)(s64)va_arg(ap, int);
+		v[2] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 T c=%d st=%x done=%d irq=%d")) {
+		type = 9; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = va_arg(ap, unsigned int);
+		v[2] = (u64)(s64)va_arg(ap, int); v[3] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 G c=%d st=%x irq0=%d")) {
+		type = 10; n = 3;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = va_arg(ap, unsigned int);
+		v[2] = (u64)(s64)va_arg(ap, int);
+	} else if (!strcmp(fmt, "P286 HK c=%d o=%x l=%x f=%x sw=1")) {
+		type = 11; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = va_arg(ap, unsigned int);
+		v[2] = va_arg(ap, unsigned int); v[3] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P286 HK c=%d o=%x l=%x f=%x sw=0")) {
+		type = 12; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int); v[1] = va_arg(ap, unsigned int);
+		v[2] = va_arg(ap, unsigned int); v[3] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P286 HT c=%d sw=1")) {
+		type = 13; n = 1; v[0] = (u64)(s64)va_arg(ap, int);
+	}
+	va_end(ap);
+	if (type)
+		a52_p286_store(type, n, v);
+}
+
+void a52_p286_flush_timeout_chain(void)
+{
+	u64 total = (u64)atomic64_read(&a52_p286_seq);
+	u64 first = total > A52_P286_TAIL ? total - A52_P286_TAIL + 1 : 1;
+	u64 q;
+
+	a52_ackfr_record("P286 RH n=%llx first=%llx", (unsigned long long)total,
+		(unsigned long long)first);
+	for (q = first; q <= total; q++) {
+		struct a52_p286_sample s;
+		unsigned long flags;
+
+		memset(&s, 0, sizeof(s));
+		spin_lock_irqsave(&a52_p286_lock, flags);
+		s = a52_p286_tail[(q - 1) % A52_P286_TAIL];
+		spin_unlock_irqrestore(&a52_p286_lock, flags);
+		if (s.seq != q || !s.type || !s.n)
+			continue;
+		a52_ackfr_record("P286 R0 q=%llx t=%x n=%x a=%llx b=%llx",
+			(unsigned long long)s.seq, s.type, s.n,
+			(unsigned long long)s.v[0], (unsigned long long)s.v[1]);
+		if (s.n > 2)
+			a52_ackfr_record("P286 R1 q=%llx c=%llx d=%llx e=%llx",
+				(unsigned long long)s.seq, (unsigned long long)s.v[2],
+				(unsigned long long)s.v[3], (unsigned long long)s.v[4]);
+	}
+}
+EXPORT_SYMBOL_GPL(a52_p286_flush_timeout_chain);
+'''
+
+
+def patch_rec(text: str) -> str:
+    if MARK in text:
+        return text
+    for token in ['A52_PHASE285_LATCHED_CLOCK_CHAIN_VALUES_V1',
+                  'a52_p285_capture_fmt(fmt, args);',
+                  'strncmp(fmt, "P285", 4)',
+                  'strncmp(message, "P285 ", 5)']:
+        if token not in text:
+            raise SystemExit('Phase286B recorder prerequisite missing: ' + token)
+    text = one(text, 'static struct rs_control *a52_r179_rs;\n',
+               'static struct rs_control *a52_r179_rs;\n' + BLOCK + '\n',
+               'typed-tail insertion')
+    text = one(text,
+               'return !strncmp(message, "P285 ", 5) ||\n       !strncmp(message, "P276 ", 5) ||',
+               'return !strncmp(message, "P286 ", 5) ||\n       !strncmp(message, "P285 ", 5) ||\n       !strncmp(message, "P276 ", 5) ||',
+               'critical P286 admission')
+    text = one(text,
+               'if (strncmp(fmt, "P285", 4) &&\n    strncmp(fmt, "P276", 4) &&',
+               'if (strncmp(fmt, "P286", 4) &&\n    strncmp(fmt, "P285", 4) &&\n    strncmp(fmt, "P276", 4) &&',
+               'focused P286 admission')
+    text = one(text,
+               '\tva_start(args, fmt);\n\ta52_p285_capture_fmt(fmt, args);\n\tvscnprintf(event.message, sizeof(event.message), fmt, args);',
+               '\tva_start(args, fmt);\n\ta52_p286_capture_fmt(fmt, args);\n\ta52_p285_capture_fmt(fmt, args);\n\tvscnprintf(event.message, sizeof(event.message), fmt, args);',
+               'typed capture before packing')
+    return text
+
+
+def patch_dsi(text: str) -> str:
+    if 'a52_p286_flush_timeout_chain();' in text:
+        return text
+    for token in ['A52_PHASE286_GOLDEN_FDR_DMA_CHAIN_V1',
+                  'extern void a52_ackfr_retain_timeout_snapshot(void);',
+                  'P276 280Z q=2']:
+        if token not in text:
+            raise SystemExit('Phase286B DSI prerequisite missing: ' + token)
+    text = one(text,
+               'extern void a52_ackfr_retain_timeout_snapshot(void);\n',
+               'extern void a52_ackfr_retain_timeout_snapshot(void);\nextern void a52_p286_flush_timeout_chain(void); /* ' + MARK + ' */\n',
+               'flush declaration')
+    text = one(text,
+               '\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n',
+               '\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_p286_flush_timeout_chain();\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n',
+               'flush immediately before retention freeze')
+    return text
+
+
+def validate(rec: str, dsi: str) -> None:
+    required_rec = [
+        MARK, '#define A52_P286_TAIL 32U', 'a52_p286_capture_fmt(fmt, args);',
+        'return !strncmp(message, "P286 ", 5)', 'strncmp(fmt, "P286", 4)',
+        'P286 RH n=%llx first=%llx', 'P286 R0 q=%llx t=%x n=%x a=%llx b=%llx',
+        'P286 R1 q=%llx c=%llx d=%llx e=%llx',
+        'EXPORT_SYMBOL_GPL(a52_p286_flush_timeout_chain);'
+    ]
+    for token in required_rec:
+        if token not in rec:
+            raise SystemExit('Phase286B recorder marker missing: ' + token)
+    for fmt in [
+        'P286 A c=%d mf=%x f=%x t=%u l=%u', 'P286 B c=%d f=%x h=%x pm=%d ve=%d',
+        'P286 D c=%d f=%x last=%d bm=%d b=%d', 'P286 DX c=%d reason=nolast',
+        'P286 E c=%d k=slave', 'P286 E c=%d k=sched cl=%u sl=%u lb=%u',
+        'P286 E c=%d k=master', 'P286 W c=%d r=%d irq=%d',
+        'P286 T c=%d st=%x done=%d irq=%d', 'P286 G c=%d st=%x irq0=%d',
+        'P286 HK c=%d o=%x l=%x f=%x sw=1', 'P286 HK c=%d o=%x l=%x f=%x sw=0',
+        'P286 HT c=%d sw=1']:
+        if fmt not in rec:
+            raise SystemExit('Phase286B exact format not captured: ' + fmt)
+    if 'a52_p286_flush_timeout_chain();' not in dsi:
+        raise SystemExit('Phase286B timeout flush missing')
+    if not (dsi.index('P286 T c=%d st=%x done=%d irq=%d') <
+            dsi.index('a52_p286_flush_timeout_chain();') <
+            dsi.index('P276 280Z q=2') <
+            dsi.index('a52_ackfr_retain_timeout_snapshot();')):
+        raise SystemExit('Phase286B replay/freeze ordering invalid')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    rp, dp = args.root / REC, args.root / DSI
+    if not rp.is_file() or not dp.is_file():
+        raise SystemExit('Phase286B source files missing')
+    r, d = rp.read_text(), dp.read_text()
+    if not args.check_only:
+        r, d = patch_rec(r), patch_dsi(d)
+        rp.write_text(r); dp.write_text(d)
+    validate(r, d)
+    print('Phase286B typed DMA-chain retention + pre-freeze replay: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/286c_fix_dma_replay_width.py
+++ b/scripts/286c_fix_dma_replay_width.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE286C_PACKED_REPLAY_WIDTH_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1' not in text:
+        raise SystemExit('Phase286C requires Phase286B typed retention')
+    text = one(text,
+               '/* A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1',
+               '/* A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1\n * ' + MARK,
+               'Phase286C marker')
+    text = one(text,
+               'a52_ackfr_record("P286 RH n=%llx first=%llx", (unsigned long long)total,\n\t\t(unsigned long long)first);',
+               'a52_ackfr_record("P286 RH %llx %llx", (unsigned long long)total,\n\t\t(unsigned long long)first);',
+               'retention header width')
+    text = one(text,
+               'a52_ackfr_record("P286 R0 q=%llx t=%x n=%x a=%llx b=%llx",\n\t\t\t(unsigned long long)s.seq, s.type, s.n,\n\t\t\t(unsigned long long)s.v[0], (unsigned long long)s.v[1]);',
+               'a52_ackfr_record("P286 R0 %llx %x %x %llx %llx",\n\t\t\t(unsigned long long)s.seq, s.type, s.n,\n\t\t\t(unsigned long long)s.v[0], (unsigned long long)s.v[1]);',
+               'R0 width')
+    text = one(text,
+               'a52_ackfr_record("P286 R1 q=%llx c=%llx d=%llx e=%llx",\n\t\t\t\t(unsigned long long)s.seq, (unsigned long long)s.v[2],\n\t\t\t\t(unsigned long long)s.v[3], (unsigned long long)s.v[4]);',
+               'a52_ackfr_record("P286 R1 %llx %llx %llx",\n\t\t\t\t(unsigned long long)s.v[2], (unsigned long long)s.v[3],\n\t\t\t\t(unsigned long long)s.v[4]);',
+               'R1 width')
+    return text
+
+
+def validate(text: str) -> None:
+    for token in [MARK, 'P286 RH %llx %llx',
+                  'P286 R0 %llx %x %x %llx %llx',
+                  'P286 R1 %llx %llx %llx']:
+        if token not in text:
+            raise SystemExit('Phase286C marker missing: ' + token)
+    for old in ['P286 RH n=%llx first=%llx',
+                'P286 R0 q=%llx t=%x n=%x a=%llx b=%llx',
+                'P286 R1 q=%llx c=%llx d=%llx e=%llx']:
+        if old in text:
+            raise SystemExit('Phase286C long replay format still present: ' + old)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    path = args.root / REC
+    if not path.is_file():
+        raise SystemExit('missing recorder source')
+    text = path.read_text()
+    if not args.check_only:
+        text = patch(text)
+        path.write_text(text)
+    validate(text)
+    print('Phase286C packed replay width: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/287_apply_dsi_dma_fetch_provenance.py
+++ b/scripts/287_apply_dsi_dma_fetch_provenance.py
@@ -25,7 +25,7 @@ def patch_ctrl(text: str) -> str:
     # Exact memory-backed command-buffer provenance immediately after the
     # normal GEM sync and before CPU copies the encoded packet bytes.
     old = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n'''
-    new = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\t/* %s */\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P287 M0 c=%d i=%llx va=%llx pre=%u add=%u",\n\t\t\t\tdsi_ctrl->cell_index,\n\t\t\t\t(unsigned long long)dsi_ctrl->cmd_buffer_iova,\n\t\t\t\t(unsigned long long)(uintptr_t)dsi_ctrl->vaddr,\n\t\t\t\tdsi_ctrl->cmd_len, length);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n''' % MARK
+    new = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\t/* %s */\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P287 M0 c=%d i=%llx va=%llx pre=%u add=%u",\n\t\t\t\tdsi_ctrl->cell_index,\n\t\t\t\t(unsigned long long)dsi_ctrl->cmd_buffer_iova,\n\t\t\t\t(unsigned long long)(unsigned long)dsi_ctrl->vaddr,\n\t\t\t\tdsi_ctrl->cmd_len, length);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n''' % MARK
     text = replace_one(text, old, new, 'Phase287 post-sync provenance')
 
     # The final DMA descriptor length is only committed on LASTCOMMAND.

--- a/scripts/287_apply_dsi_dma_fetch_provenance.py
+++ b/scripts/287_apply_dsi_dma_fetch_provenance.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+MARK = 'A52_PHASE287_DSI_DMA_FETCH_PROVENANCE_V1'
+
+
+def replace_one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected exactly 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+    for token in ['A52_PHASE286_GOLDEN_FDR_DMA_CHAIN_V1', 'P286 A c=%d mf=%x f=%x t=%u l=%u']:
+        if token not in text:
+            raise SystemExit('Phase287 requires Phase286: ' + token)
+
+    # Exact memory-backed command-buffer provenance immediately after the
+    # normal GEM sync and before CPU copies the encoded packet bytes.
+    old = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n'''
+    new = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\t/* %s */\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P287 M0 c=%d i=%llx va=%llx pre=%u add=%u",\n\t\t\t\tdsi_ctrl->cell_index,\n\t\t\t\t(unsigned long long)dsi_ctrl->cmd_buffer_iova,\n\t\t\t\t(unsigned long long)(uintptr_t)dsi_ctrl->vaddr,\n\t\t\t\tdsi_ctrl->cmd_len, length);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n''' % MARK
+    text = replace_one(text, old, new, 'Phase287 post-sync provenance')
+
+    # The final DMA descriptor length is only committed on LASTCOMMAND.
+    old = '''\t\t\tcmd_mem.length = dsi_ctrl->cmd_len;\n\t\t\tdsi_ctrl->cmd_len = 0;\n'''
+    new = '''\t\t\tcmd_mem.length = dsi_ctrl->cmd_len;\n\t\t\tif (a52_p276r_deep_active())\n\t\t\t\ta52_ackfr_record("P287 M1 c=%d i=%llx len=%u last=1",\n\t\t\t\t\tdsi_ctrl->cell_index,\n\t\t\t\t\t(unsigned long long)cmd_mem.offset, cmd_mem.length);\n\t\t\tdsi_ctrl->cmd_len = 0;\n'''
+    text = replace_one(text, old, new, 'Phase287 final DMA descriptor')
+
+    # Capture the first 8 bytes from the actual mapped command buffer after the
+    # copy, not merely from the temporary packet buffer. This proves CPU-side
+    # contents at the address paired with the DMA IOVA.
+    old = '''\t\tdsi_ctrl->cmd_len += length;\n\n\t\tif (!(msg->flags & MIPI_DSI_MSG_LASTCOMMAND)) {\n'''
+    new = '''\t\tdsi_ctrl->cmd_len += length;\n\t\tif (a52_p276r_deep_active() && dsi_ctrl->cmd_len >= 8)\n\t\t\ta52_ackfr_record("P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x",\n\t\t\t\tdsi_ctrl->cell_index, cmdbuf[0], cmdbuf[1], cmdbuf[2], cmdbuf[3],\n\t\t\t\tcmdbuf[4], cmdbuf[5], cmdbuf[6], cmdbuf[7]);\n\n\t\tif (!(msg->flags & MIPI_DSI_MSG_LASTCOMMAND)) {\n'''
+    text = replace_one(text, old, new, 'Phase287 mapped bytes')
+    return text
+
+
+def patch_hw(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE286_LOWLEVEL_SW_TRIGGER_V1' not in text:
+        raise SystemExit('Phase287 requires Phase286 low-level trigger trace')
+
+    # For immediate kickoff, all register reads happen only after the normal SW
+    # trigger and after Phase286's post-trigger marker, so trigger timing is not
+    # delayed by this deeper discriminator.
+    old = '''\t\tif (a52_p286_dma_trace_active())\n\t\t\ta52_ackfr_record("P286 HK c=%d o=%x l=%x f=%x sw=1",\n\t\t\t\tctrl->index, cmd->offset, cmd->length, flags);\n'''
+    new = old + '''\t\tif (a52_p286_dma_trace_active())\n\t\t\ta52_ackfr_record("P287 R c=%d ro=%x rl=%x ax=%x vb=%x",\n\t\t\t\tctrl->index, DSI_R32(ctrl, DSI_DMA_CMD_OFFSET),\n\t\t\t\tDSI_R32(ctrl, DSI_DMA_CMD_LENGTH),\n\t\t\t\tDSI_R32(ctrl, DSI_AXI2AHB_CTRL), DSI_R32(ctrl, DSI_VBIF_CTRL));\n'''
+    text = replace_one(text, old, new, 'Phase287 immediate post-trigger readback')
+
+    # Deferred path readback, likewise strictly after the SW trigger write.
+    old = '''\tif (a52_p286_dma_trace_active())\n\t\ta52_ackfr_record("P286 HT c=%d sw=1", ctrl->index);\n}\n'''
+    new = '''\tif (a52_p286_dma_trace_active())\n\t\ta52_ackfr_record("P286 HT c=%d sw=1", ctrl->index);\n\tif (a52_p286_dma_trace_active())\n\t\ta52_ackfr_record("P287 R c=%d ro=%x rl=%x ax=%x vb=%x",\n\t\t\tctrl->index, DSI_R32(ctrl, DSI_DMA_CMD_OFFSET),\n\t\t\tDSI_R32(ctrl, DSI_DMA_CMD_LENGTH),\n\t\t\tDSI_R32(ctrl, DSI_AXI2AHB_CTRL), DSI_R32(ctrl, DSI_VBIF_CTRL));\n}\n'''
+    text = replace_one(text, old, new, 'Phase287 deferred post-trigger readback')
+    # Place the phase marker in a comment without changing includes/behavior.
+    text = text.replace('/* A52_PHASE286_LOWLEVEL_SW_TRIGGER_V1 */',
+                        '/* A52_PHASE286_LOWLEVEL_SW_TRIGGER_V1\n * %s */' % MARK, 1)
+    return text
+
+
+def validate(ctrl: str, hw: str) -> None:
+    for token in [MARK, 'P287 M0 c=%d i=%llx va=%llx pre=%u add=%u',
+                  'P287 M1 c=%d i=%llx len=%u last=1',
+                  'P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x']:
+        if token not in ctrl and token not in hw:
+            raise SystemExit('Phase287 marker missing: ' + token)
+    if hw.count('P287 R c=%d ro=%x rl=%x ax=%x vb=%x') != 2:
+        raise SystemExit('Phase287 requires immediate and deferred register readback sites')
+    fn = hw.index('void dsi_ctrl_hw_cmn_trigger_command_dma(')
+    write = hw.index('DSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);', fn)
+    rec = hw.index('P287 R c=%d ro=%x rl=%x ax=%x vb=%x', fn)
+    if rec < write:
+        raise SystemExit('Phase287 deferred readback occurs before SW trigger write')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    cp, hp = args.root / CTRL, args.root / HW
+    if not cp.is_file() or not hp.is_file():
+        raise SystemExit('missing Phase287 source files')
+    ct, ht = cp.read_text(), hp.read_text()
+    if not args.check_only:
+        ct, ht = patch_ctrl(ct), patch_hw(ht)
+        cp.write_text(ct); hp.write_text(ht)
+    validate(ct, ht)
+    print('Phase287 DSI DMA fetch provenance recorder: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/287_apply_dsi_dma_fetch_provenance.py
+++ b/scripts/287_apply_dsi_dma_fetch_provenance.py
@@ -25,7 +25,7 @@ def patch_ctrl(text: str) -> str:
     # Exact memory-backed command-buffer provenance immediately after the
     # normal GEM sync and before CPU copies the encoded packet bytes.
     old = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n'''
-    new = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\t/* %s */\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P287 M0 c=%d i=%llx va=%llx pre=%u add=%u",\n\t\t\t\tdsi_ctrl->cell_index,\n\t\t\t\t(unsigned long long)dsi_ctrl->cmd_buffer_iova,\n\t\t\t\t(unsigned long long)(unsigned long)dsi_ctrl->vaddr,\n\t\t\t\tdsi_ctrl->cmd_len, length);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n''' % MARK
+    new = '''\t\tcmdbuf = (u8 *)(dsi_ctrl->vaddr);\n\n\t\tmsm_gem_sync(dsi_ctrl->tx_cmd_buf);\n\t\t/* %s */\n\t\tif (a52_p276r_deep_active())\n\t\t\ta52_ackfr_record("P287 M0 c=%d i=%llx va=%llx pre=%u add=%u",\n\t\t\t\tdsi_ctrl->cell_index,\n\t\t\t\t(unsigned long long)dsi_ctrl->cmd_buffer_iova,\n\t\t\t\t(unsigned long long)(unsigned long)dsi_ctrl->vaddr,\n\t\t\t\tdsi_ctrl->cmd_len, length);\n\t\tfor (cnt = 0; cnt < length; cnt++)\n'''.replace('%s', MARK, 1)
     text = replace_one(text, old, new, 'Phase287 post-sync provenance')
 
     # The final DMA descriptor length is only committed on LASTCOMMAND.

--- a/scripts/287_ci_build.sh
+++ b/scripts/287_ci_build.sh
@@ -12,32 +12,65 @@ fail_report(){
   mkdir -p phase287-failure/{source,logs,audit,config}
   cp phase287-compile.log phase287-failure/logs/ 2>/dev/null || true
   for f in "$DSI" "$HW" "$REC"; do [ -f "$f" ] && cp "$f" phase287-failure/source/ || true; done
-  cp scripts/287_apply_dsi_dma_fetch_provenance.py phase287-failure/audit/ 2>/dev/null || true
+  cp scripts/287*.py phase287-failure/audit/ 2>/dev/null || true
   cp /tmp/p287-*.config /tmp/p287-*.diff phase287-failure/config/ 2>/dev/null || true
 }
 trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
 
-# Build the complete Phase286 causal recorder first, then add only read-only
-# command-buffer provenance and post-trigger register readbacks.
+# Build the complete Phase286C causal recorder first. Phase287 then adds only
+# read-only command-buffer provenance and post-trigger register readbacks, and
+# Phase287B folds those exact values into Phase286C's typed timeout tail.
 bash scripts/286_ci_build.sh
 test -s phase286-out/package/boot.img
 for f in "$DSI" "$HW" "$REC"; do test -s "$f"; done
+grep -Fq 'A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1' "$REC"
+grep -Fq 'A52_PHASE286C_PACKED_REPLAY_WIDTH_V1' "$REC"
+grep -Fq 'P286 R0 %llx %x %x %llx %llx' "$REC"
+grep -Fq 'P286 R1 %llx %llx %llx' "$REC"
+
 cp "$OUT/.config" /tmp/p287-base.config
 cp "$DSI" /tmp/p287-dsi-before.c
 cp "$HW" /tmp/p287-hw-before.c
 cp "$REC" /tmp/p287-rec-before.c
 
-python3 -m py_compile scripts/287_apply_dsi_dma_fetch_provenance.py
+python3 -m py_compile \
+  scripts/287_apply_dsi_dma_fetch_provenance.py \
+  scripts/287b_apply_retained_fetch_provenance.py
 python3 scripts/287_apply_dsi_dma_fetch_provenance.py --root "$ROOT"
+python3 scripts/287b_apply_retained_fetch_provenance.py --root "$ROOT"
 python3 scripts/287_apply_dsi_dma_fetch_provenance.py --root "$ROOT" --check-only
-cmp -s /tmp/p287-rec-before.c "$REC"
+python3 scripts/287b_apply_retained_fetch_provenance.py --root "$ROOT" --check-only
+
+! cmp -s /tmp/p287-rec-before.c "$REC"
 ! cmp -s /tmp/p287-dsi-before.c "$DSI"
 ! cmp -s /tmp/p287-hw-before.c "$HW"
 cmp -s /tmp/p287-base.config "$OUT/.config"
 
+for token in \
+  'P287 M0 c=%d i=%llx va=%llx pre=%u add=%u' \
+  'P287 M1 c=%d i=%llx len=%u last=1' \
+  'P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x'; do grep -Fq "$token" "$DSI"; done
+test "$(grep -Fc 'P287 R c=%d ro=%x rl=%x ax=%x vb=%x' "$HW")" -eq 2
+for token in \
+  'A52_PHASE287B_RETAINED_FETCH_PROVENANCE_V1' \
+  'a52_p287_capture_fmt(fmt, args);' \
+  'return !strncmp(message, "P287 ", 5)' \
+  'strncmp(fmt, "P287", 4)' \
+  'type = 14; n = 5;' \
+  'type = 15; n = 3;' \
+  'type = 16; n = 2;' \
+  'type = 17; n = 5;' \
+  'P286 R0 %llx %x %x %llx %llx' \
+  'P286 R1 %llx %llx %llx'; do grep -Fq "$token" "$REC"; done
+
 make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
   CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
-cmp -s /tmp/p287-base.config "$OUT/.config"
+if ! cmp -s /tmp/p287-base.config "$OUT/.config"; then
+  diff -u /tmp/p287-base.config "$OUT/.config" > /tmp/p287-config.diff || true
+  echo '::error::Phase287 changed kernel config'
+  cat /tmp/p287-config.diff
+  exit 1
+fi
 make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
   CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
   2>&1 | tee phase287-compile.log
@@ -48,12 +81,13 @@ rm -rf phase287-out
 mkdir -p phase287-out/{compile,config,package,audit,source}
 cp "$IMAGE" phase287-out/compile/Image
 cp "$OUT/.config" phase287-out/config/final.config
-cp /tmp/p287-base.config phase287-out/audit/phase286-final.config
+cp /tmp/p287-base.config phase287-out/audit/phase286c-final.config
 cp /tmp/p287-dsi-before.c phase287-out/audit/dsi-ctrl-before.c
 cp /tmp/p287-hw-before.c phase287-out/audit/dsi-ctrl-hw-cmn-before.c
 cp /tmp/p287-rec-before.c phase287-out/audit/recorder-before.c
 cp phase287-compile.log phase287-out/audit/
 cp scripts/287_apply_dsi_dma_fetch_provenance.py phase287-out/audit/
+cp scripts/287b_apply_retained_fetch_provenance.py phase287-out/audit/
 cp "$DSI" phase287-out/source/dsi_ctrl.c
 cp "$HW" phase287-out/source/dsi_ctrl_hw_cmn.c
 cp "$REC" phase287-out/source/a52_ack_secure_flight_recorder.c
@@ -78,7 +112,19 @@ M2 first 8 bytes read back from the actual mapped command buffer after CPU copy
 R  hardware DMA offset/length plus AXI2AHB and VBIF register readback strictly
    after the normal SW trigger write, for both immediate and deferred trigger paths
 
-All Phase286 A/B/HK/D/DX/HT/E/G/W/T records remain present.
+Phase287B retention:
+P287 is explicitly admitted by the focused and post-capacity Golden FDR filters.
+Its exact varargs are captured before text packing into the same final-32-event
+circular causal tail used by Phase286C, then replayed immediately before the
+Phase280 timeout freeze. Replay uses the existing compact P286 R0/R1 grammar.
+Additional replay type map:
+ 14=M0: [controller, IOVA, CPU vaddr, pre_len, add_len]
+ 15=M1: [controller, IOVA, final_len]
+ 16=M2: [controller, packed8]
+       packed8 byte order: b0 in bits 7:0, b1 in 15:8 ... b7 in 63:56
+ 17=R:  [controller, DMA_OFFSET, DMA_LENGTH, AXI2AHB, VBIF]
+
+All Phase286 A/B/HK/D/DX/HT/E/G/W/T records and types 1..13 remain present.
 EOF
 
 python3 - <<'PY'
@@ -86,9 +132,11 @@ import hashlib,json,os
 from pathlib import Path
 r=Path('phase287-out')
 idn={
- 'phase':'287','name':'DSI-DMA-FETCH-PROVENANCE','git_sha':os.getenv('GITHUB_SHA'),
- 'hardware_validated':False,'base':'Phase286 Golden-FDR causal-chain recorder',
+ 'phase':'287B','name':'DSI-DMA-FETCH-PROVENANCE-RETAINED','git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,'base':'Phase286C Golden-FDR causal-chain typed-retention recorder',
  'behavior_change':False,'register_writes_added':False,'recovery_changed':False,
+ 'recorder_change':'admit P287 and fold exact M0/M1/M2/R varargs into the Phase286C final-32 typed timeout tail',
+ 'previous_failure_addressed':'P287 evidence is not trusted merely because a52_ackfr_record was called; admission, overwrite retention, and compact replay are all audited',
  'question':'If SW trigger really executes but DMA_DONE never asserts, is the command-memory IOVA/length/content coherent and does hardware retain the same DMA descriptor at trigger time?',
  'golden_repack_source':'phase286-out/package/boot.img','repacker':'scripts/38_repack_a52_p1_boot.py'}
 (r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
@@ -100,10 +148,17 @@ PY
 python3 - <<'PY'
 from pathlib import Path
 img=Path('phase287-out/compile/Image').read_bytes()
-for m in ['P287 M0 c=%d i=%llx va=%llx pre=%u add=%u','P287 M1 c=%d i=%llx len=%u last=1','P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x','P287 R c=%d ro=%x rl=%x ax=%x vb=%x','P286 HT c=%d sw=1','P286 T c=%d st=%x done=%d irq=%d']:
+for m in [
+ 'P287 M0 c=%d i=%llx va=%llx pre=%u add=%u',
+ 'P287 M1 c=%d i=%llx len=%u last=1',
+ 'P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x',
+ 'P287 R c=%d ro=%x rl=%x ax=%x vb=%x',
+ 'P286 HT c=%d sw=1','P286 T c=%d st=%x done=%d irq=%d',
+ 'P286 R0 %llx %x %x %llx %llx','P286 R1 %llx %llx %llx']:
  if m.encode() not in img: raise SystemExit('Phase287 marker missing from Image: '+m)
-print('Phase287 compiled marker audit: PASS')
+print('Phase287B compiled producer + retained replay marker audit: PASS')
 PY
 python3 scripts/287_apply_dsi_dma_fetch_provenance.py --root "$ROOT" --check-only
+python3 scripts/287b_apply_retained_fetch_provenance.py --root "$ROOT" --check-only
 trap - EXIT
-echo 'Phase287 DSI DMA fetch provenance build/repack: PASS'
+echo 'Phase287B DSI DMA fetch provenance build/repack: PASS'

--- a/scripts/287_ci_build.sh
+++ b/scripts/287_ci_build.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report(){
+  set +e
+  rm -rf phase287-failure
+  mkdir -p phase287-failure/{source,logs,audit,config}
+  cp phase287-compile.log phase287-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$HW" "$REC"; do [ -f "$f" ] && cp "$f" phase287-failure/source/ || true; done
+  cp scripts/287_apply_dsi_dma_fetch_provenance.py phase287-failure/audit/ 2>/dev/null || true
+  cp /tmp/p287-*.config /tmp/p287-*.diff phase287-failure/config/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Build the complete Phase286 causal recorder first, then add only read-only
+# command-buffer provenance and post-trigger register readbacks.
+bash scripts/286_ci_build.sh
+test -s phase286-out/package/boot.img
+for f in "$DSI" "$HW" "$REC"; do test -s "$f"; done
+cp "$OUT/.config" /tmp/p287-base.config
+cp "$DSI" /tmp/p287-dsi-before.c
+cp "$HW" /tmp/p287-hw-before.c
+cp "$REC" /tmp/p287-rec-before.c
+
+python3 -m py_compile scripts/287_apply_dsi_dma_fetch_provenance.py
+python3 scripts/287_apply_dsi_dma_fetch_provenance.py --root "$ROOT"
+python3 scripts/287_apply_dsi_dma_fetch_provenance.py --root "$ROOT" --check-only
+cmp -s /tmp/p287-rec-before.c "$REC"
+! cmp -s /tmp/p287-dsi-before.c "$DSI"
+! cmp -s /tmp/p287-hw-before.c "$HW"
+cmp -s /tmp/p287-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p287-base.config "$OUT/.config"
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase287-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase287-out
+mkdir -p phase287-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase287-out/compile/Image
+cp "$OUT/.config" phase287-out/config/final.config
+cp /tmp/p287-base.config phase287-out/audit/phase286-final.config
+cp /tmp/p287-dsi-before.c phase287-out/audit/dsi-ctrl-before.c
+cp /tmp/p287-hw-before.c phase287-out/audit/dsi-ctrl-hw-cmn-before.c
+cp /tmp/p287-rec-before.c phase287-out/audit/recorder-before.c
+cp phase287-compile.log phase287-out/audit/
+cp scripts/287_apply_dsi_dma_fetch_provenance.py phase287-out/audit/
+cp "$DSI" phase287-out/source/dsi_ctrl.c
+cp "$HW" phase287-out/source/dsi_ctrl_hw_cmn.c
+cp "$REC" phase287-out/source/a52_ack_secure_flight_recorder.c
+
+gzip -n -c "$IMAGE" > phase287-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase286-out/package/boot.img \
+  --kernel phase287-out/package/Image.gz \
+  --output phase287-out/package/boot.img \
+  --report phase287-out/package/repack-report.json
+test -s phase287-out/package/boot.img
+file phase287-out/package/boot.img | tee phase287-out/package/boot-file.txt
+
+cat > phase287-out/PHASE287-RECORD-SCHEMA.txt <<'EOF'
+Phase287 DMA fetch provenance additions
+=======================================
+M0 command-memory mapping at normal post-msm_gem_sync point:
+   controller, command IOVA, CPU vaddr, existing batch length, bytes being appended
+M1 final LASTCOMMAND DMA descriptor:
+   controller, IOVA/offset, final DMA length
+M2 first 8 bytes read back from the actual mapped command buffer after CPU copy
+R  hardware DMA offset/length plus AXI2AHB and VBIF register readback strictly
+   after the normal SW trigger write, for both immediate and deferred trigger paths
+
+All Phase286 A/B/HK/D/DX/HT/E/G/W/T records remain present.
+EOF
+
+python3 - <<'PY'
+import hashlib,json,os
+from pathlib import Path
+r=Path('phase287-out')
+idn={
+ 'phase':'287','name':'DSI-DMA-FETCH-PROVENANCE','git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,'base':'Phase286 Golden-FDR causal-chain recorder',
+ 'behavior_change':False,'register_writes_added':False,'recovery_changed':False,
+ 'question':'If SW trigger really executes but DMA_DONE never asserts, is the command-memory IOVA/length/content coherent and does hardware retain the same DMA descriptor at trigger time?',
+ 'golden_repack_source':'phase286-out/package/boot.img','repacker':'scripts/38_repack_a52_p1_boot.py'}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=[p.relative_to(r) for p in sorted(r.rglob('*')) if p.is_file() and p.name!='SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files:f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+str(n)+'\n')
+PY
+(cd phase287-out && sha256sum -c SHA256SUMS)
+python3 - <<'PY'
+from pathlib import Path
+img=Path('phase287-out/compile/Image').read_bytes()
+for m in ['P287 M0 c=%d i=%llx va=%llx pre=%u add=%u','P287 M1 c=%d i=%llx len=%u last=1','P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x','P287 R c=%d ro=%x rl=%x ax=%x vb=%x','P286 HT c=%d sw=1','P286 T c=%d st=%x done=%d irq=%d']:
+ if m.encode() not in img: raise SystemExit('Phase287 marker missing from Image: '+m)
+print('Phase287 compiled marker audit: PASS')
+PY
+python3 scripts/287_apply_dsi_dma_fetch_provenance.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase287 DSI DMA fetch provenance build/repack: PASS'

--- a/scripts/287b_apply_retained_fetch_provenance.py
+++ b/scripts/287b_apply_retained_fetch_provenance.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE287B_RETAINED_FETCH_PROVENANCE_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+BLOCK = r'''
+/* A52_PHASE287B_RETAINED_FETCH_PROVENANCE_V1
+ * Fold Phase287 provenance into the already-retained Phase286 causal tail.
+ * Types 14..17 extend the Phase286 replay type map. No second retention path
+ * is introduced, so Phase287 inherits the same pre-freeze overwrite guarantee.
+ */
+static void a52_p287_capture_fmt(const char *fmt, va_list src)
+{
+	va_list ap;
+	u64 v[A52_P286_VALUES] = { 0 };
+	u8 type = 0, n = 0;
+	unsigned int i;
+
+	if (!fmt || strncmp(fmt, "P287 ", 5))
+		return;
+	va_copy(ap, src);
+	if (!strcmp(fmt, "P287 M0 c=%d i=%llx va=%llx pre=%u add=%u")) {
+		type = 14; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned long long);
+		v[2] = va_arg(ap, unsigned long long);
+		v[3] = va_arg(ap, unsigned int); v[4] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P287 M1 c=%d i=%llx len=%u last=1")) {
+		type = 15; n = 3;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned long long); v[2] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x")) {
+		type = 16; n = 2;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		for (i = 0; i < 8; i++)
+			v[1] |= ((u64)(u8)va_arg(ap, int)) << (i * 8);
+	} else if (!strcmp(fmt, "P287 R c=%d ro=%x rl=%x ax=%x vb=%x")) {
+		type = 17; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int); v[4] = va_arg(ap, unsigned int);
+	}
+	va_end(ap);
+	if (type)
+		a52_p286_store(type, n, v);
+}
+'''
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    for token in ['A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1',
+                  'A52_PHASE286C_PACKED_REPLAY_WIDTH_V1',
+                  'a52_p286_store(type, n, v);',
+                  'a52_p286_capture_fmt(fmt, args);']:
+        if token not in text:
+            raise SystemExit('Phase287B requires retained Phase286C recorder: ' + token)
+    anchor = '''\tif (type)\n\t\ta52_p286_store(type, n, v);\n}\n\nvoid a52_p286_flush_timeout_chain(void)\n'''
+    repl = '''\tif (type)\n\t\ta52_p286_store(type, n, v);\n}\n''' + BLOCK + '''\nvoid a52_p286_flush_timeout_chain(void)\n'''
+    text = one(text, anchor, repl, 'Phase287 typed capture insertion')
+    text = one(text,
+               'return !strncmp(message, "P286 ", 5) ||\n       !strncmp(message, "P285 ", 5) ||',
+               'return !strncmp(message, "P287 ", 5) ||\n       !strncmp(message, "P286 ", 5) ||\n       !strncmp(message, "P285 ", 5) ||',
+               'critical P287 admission')
+    text = one(text,
+               'if (strncmp(fmt, "P286", 4) &&\n    strncmp(fmt, "P285", 4) &&',
+               'if (strncmp(fmt, "P287", 4) &&\n    strncmp(fmt, "P286", 4) &&\n    strncmp(fmt, "P285", 4) &&',
+               'focused P287 admission')
+    text = one(text,
+               '\tva_start(args, fmt);\n\ta52_p286_capture_fmt(fmt, args);\n\ta52_p285_capture_fmt(fmt, args);',
+               '\tva_start(args, fmt);\n\ta52_p287_capture_fmt(fmt, args);\n\ta52_p286_capture_fmt(fmt, args);\n\ta52_p285_capture_fmt(fmt, args);',
+               'P287 capture before packing')
+    return text
+
+
+def validate(text: str) -> None:
+    for token in [
+        MARK, 'a52_p287_capture_fmt(fmt, args);',
+        'return !strncmp(message, "P287 ", 5)', 'strncmp(fmt, "P287", 4)',
+        'type = 14; n = 5;', 'type = 15; n = 3;', 'type = 16; n = 2;',
+        'type = 17; n = 5;', 'a52_p286_store(type, n, v);',
+        'P286 R0 %llx %x %x %llx %llx', 'P286 R1 %llx %llx %llx'
+    ]:
+        if token not in text:
+            raise SystemExit('Phase287B marker missing: ' + token)
+    for fmt in [
+        'P287 M0 c=%d i=%llx va=%llx pre=%u add=%u',
+        'P287 M1 c=%d i=%llx len=%u last=1',
+        'P287 M2 c=%d b=%02x%02x%02x%02x%02x%02x%02x%02x',
+        'P287 R c=%d ro=%x rl=%x ax=%x vb=%x']:
+        if fmt not in text:
+            raise SystemExit('Phase287B format capture missing: ' + fmt)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    path = args.root / REC
+    if not path.is_file():
+        raise SystemExit('missing recorder source')
+    text = path.read_text()
+    if not args.check_only:
+        text = patch(text)
+        path.write_text(text)
+    validate(text)
+    print('Phase287B retained DMA fetch provenance: PASS')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Follow-on passive discriminator for the branch where Phase286 proves the SW trigger occurred but DMA_DONE still does not assert. Records command-buffer IOVA/CPU mapping, final LASTCOMMAND DMA descriptor, first mapped command bytes, and post-trigger DMA/AXI/VBIF register readbacks. No forced trigger, reset, recovery, or display behavior changes. Uses the same Golden FDR boot-image repack lineage.