### PR TITLE
Phase288: retained DSI FIFO causal-chain recorder

### DIFF
--- a/.github/workflows/288-a52-retained-fifo-causal-chain.yml
+++ b/.github/workflows/288-a52-retained-fifo-causal-chain.yml
@@ -1,0 +1,99 @@
+name: 288B - A52 retained DSI FIFO causal chain
+run-name: Phase 288B - Retained DSI FIFO causal chain
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase288-retained-fifo-causal-chain-v1
+    paths:
+      - .github/workflows/288-a52-retained-fifo-causal-chain.yml
+      - scripts/288_apply_retained_fifo_causal_chain.py
+      - scripts/288b_apply_fifo_typed_retention.py
+      - scripts/288_ci_build.sh
+      - scripts/287_ci_build.sh
+      - scripts/287_apply_dsi_dma_fetch_provenance.py
+      - scripts/287b_apply_retained_fetch_provenance.py
+      - scripts/286_ci_build.sh
+      - scripts/286b_apply_dma_chain_retention.py
+      - scripts/286c_fix_dma_replay_width.py
+  pull_request:
+    branches:
+      - agent/a52-phase287-dsi-dma-fetch-provenance-v1
+    paths:
+      - .github/workflows/288-a52-retained-fifo-causal-chain.yml
+      - scripts/288_apply_retained_fifo_causal_chain.py
+      - scripts/288b_apply_fifo_typed_retention.py
+      - scripts/288_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase288-retained-fifo-causal-chain-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build Phase288B retained FIFO causal-chain recorder
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    steps:
+      - name: Check out Phase288B branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build Phase288B candidate
+        run: bash scripts/288_ci_build.sh
+      - name: Verify real boot image
+        run: |
+          set -Eeuo pipefail
+          test -s phase288-out/package/boot.img
+          test "$(stat -c '%s' phase288-out/package/boot.img)" -gt 1000000
+          file phase288-out/package/boot.img
+          sha256sum phase288-out/package/boot.img
+      - name: Upload Phase288B candidate
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase288B-RETAINED-FIFO-CAUSAL-CHAIN-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase288-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase288B-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/288-a52-retained-fifo-causal-chain.yml
+++ b/.github/workflows/288-a52-retained-fifo-causal-chain.yml
@@ -40,6 +40,8 @@ jobs:
     name: Build Phase288B retained FIFO causal-chain recorder
     runs-on: ubuntu-22.04
     timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Check out Phase288B branch
         uses: actions/checkout@v4

--- a/scripts/288_apply_retained_fifo_causal_chain.py
+++ b/scripts/288_apply_retained_fifo_causal_chain.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+MARK = 'A52_PHASE288_FIFO_CAUSAL_CHAIN_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected exactly 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    for token in [
+        'A52_PHASE286_LOWLEVEL_SW_TRIGGER_V1',
+        'A52_PHASE287_DSI_DMA_FETCH_PROVENANCE_V1',
+        'extern bool a52_p286_dma_trace_active(void);',
+        'extern void a52_ackfr_record(const char *fmt, ...);',
+        'void dsi_ctrl_hw_cmn_kickoff_fifo_command(',
+        'void dsi_ctrl_hw_cmn_reset_cmd_fifo(',
+    ]:
+        if token not in text:
+            raise SystemExit('Phase288 prerequisite missing: ' + token)
+
+    start = text.index('void dsi_ctrl_hw_cmn_kickoff_fifo_command(')
+    end = text.index('\nvoid dsi_ctrl_hw_cmn_reset_cmd_fifo(', start)
+    fn = text[start:end]
+
+    fn = one(fn,
+        '\tu32 *ptr = cmd->command;\n',
+        '\tu32 *ptr = cmd->command;\n'
+        '\t/* ' + MARK + '\n'
+        '\t * Passive causal trace of the already-selected FIFO/TPG transport.\n'
+        '\t * All records are read-only and occur around existing production writes.\n'
+        '\t */\n'
+        '\tif (a52_p286_dma_trace_active())\n'
+        '\t\ta52_ackfr_record("P288 F0 c=%d s=%u f=%x cfg=%x",\n'
+        '\t\t\tctrl->index, cmd->size, flags,\n'
+        '\t\t\t(cmd->en_broadcast ? 1U : 0U) |\n'
+        '\t\t\t(cmd->is_master ? 2U : 0U) |\n'
+        '\t\t\t(cmd->use_lpm ? 4U : 0U));\n',
+        'FIFO entry')
+
+    fn = one(fn,
+        '\tDSI_W32(ctrl, DSI_TEST_PATTERN_GEN_CTRL, reg);\n\n\t/*\n\t * Program the FIFO with command buffer.',
+        '\tDSI_W32(ctrl, DSI_TEST_PATTERN_GEN_CTRL, reg);\n'
+        '\tif (a52_p286_dma_trace_active())\n'
+        '\t\ta52_ackfr_record("P288 F1 c=%d tg=%x w0=%x w1=%x",\n'
+        '\t\t\tctrl->index, DSI_R32(ctrl, DSI_TEST_PATTERN_GEN_CTRL),\n'
+        '\t\t\t(cmd->command && cmd->size >= 4) ? cmd->command[0] : 0,\n'
+        '\t\t\t(cmd->command && cmd->size >= 8) ? cmd->command[1] : 0);\n\n'
+        '\t/*\n\t * Program the FIFO with command buffer.',
+        'TPG setup + encoded words')
+
+    fn = one(fn,
+        '\tif ((cmd->size / 4) & 0x1)\n\t\tDSI_W32(ctrl, DSI_TEST_PATTERN_GEN_CMD_DMA_INIT_VAL, 0);\n\n\t/*Set BROADCAST_EN and EMBEDDED_MODE */',
+        '\tif ((cmd->size / 4) & 0x1)\n\t\tDSI_W32(ctrl, DSI_TEST_PATTERN_GEN_CMD_DMA_INIT_VAL, 0);\n'
+        '\tif (a52_p286_dma_trace_active())\n'
+        '\t\ta52_ackfr_record("P288 F2 c=%d st=%x fs=%x tg=%x",\n'
+        '\t\t\tctrl->index, DSI_R32(ctrl, DSI_STATUS),\n'
+        '\t\t\tDSI_R32(ctrl, DSI_FIFO_STATUS),\n'
+        '\t\t\tDSI_R32(ctrl, DSI_TEST_PATTERN_GEN_CTRL));\n\n'
+        '\t/*Set BROADCAST_EN and EMBEDDED_MODE */',
+        'post FIFO fill snapshot')
+
+    old = '''\tDSI_W32(ctrl, DSI_DMA_CMD_LENGTH, (cmd->size & 0xFFFFFFFF));\n\t/* Finish writes before command trigger */\n\twmb();\n\n\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER))\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n'''
+    new = '''\tDSI_W32(ctrl, DSI_DMA_CMD_LENGTH, (cmd->size & 0xFFFFFFFF));\n\t/* Finish writes before command trigger */\n\twmb();\n\tif (a52_p286_dma_trace_active())\n\t\ta52_ackfr_record("P288 F3 c=%d dc=%x dl=%x fs=%x in=%x",\n\t\t\tctrl->index, DSI_R32(ctrl, DSI_COMMAND_MODE_DMA_CTRL),\n\t\t\tDSI_R32(ctrl, DSI_DMA_CMD_LENGTH),\n\t\t\tDSI_R32(ctrl, DSI_FIFO_STATUS), DSI_R32(ctrl, DSI_INT_CTRL));\n\n\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER)) {\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\t\tif (a52_p286_dma_trace_active())\n\t\t\ta52_ackfr_record("P288 F4 c=%d sw=%u st=%x fs=%x in=%x",\n\t\t\t\tctrl->index, 1U, DSI_R32(ctrl, DSI_STATUS),\n\t\t\t\tDSI_R32(ctrl, DSI_FIFO_STATUS), DSI_R32(ctrl, DSI_INT_CTRL));\n\t} else if (a52_p286_dma_trace_active()) {\n\t\ta52_ackfr_record("P288 F4 c=%d sw=%u st=%x fs=%x in=%x",\n\t\t\tctrl->index, 0U, DSI_R32(ctrl, DSI_STATUS),\n\t\t\tDSI_R32(ctrl, DSI_FIFO_STATUS), DSI_R32(ctrl, DSI_INT_CTRL));\n\t}\n'''
+    fn = one(fn, old, new, 'FIFO programmed + trigger causal trace')
+    return text[:start] + fn + text[end:]
+
+
+def validate(text: str) -> None:
+    required = [
+        MARK,
+        'P288 F0 c=%d s=%u f=%x cfg=%x',
+        'P288 F1 c=%d tg=%x w0=%x w1=%x',
+        'P288 F2 c=%d st=%x fs=%x tg=%x',
+        'P288 F3 c=%d dc=%x dl=%x fs=%x in=%x',
+        'P288 F4 c=%d sw=%u st=%x fs=%x in=%x',
+    ]
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase288 FIFO marker missing: ' + token)
+    if text.count('P288 F4 c=%d sw=%u st=%x fs=%x in=%x') != 2:
+        raise SystemExit('Phase288 F4 must cover both immediate and deferred FIFO paths')
+    start = text.index('void dsi_ctrl_hw_cmn_kickoff_fifo_command(')
+    end = text.index('\nvoid dsi_ctrl_hw_cmn_reset_cmd_fifo(', start)
+    fn = text[start:end]
+    order = [fn.index(x) for x in [
+        'P288 F0 c=%d s=%u f=%x cfg=%x',
+        'P288 F1 c=%d tg=%x w0=%x w1=%x',
+        'P288 F2 c=%d st=%x fs=%x tg=%x',
+        'P288 F3 c=%d dc=%x dl=%x fs=%x in=%x',
+    ]]
+    if order != sorted(order):
+        raise SystemExit('Phase288 FIFO causal markers out of order')
+    trig = fn.index('DSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);')
+    f4 = fn.index('P288 F4 c=%d sw=%u st=%x fs=%x in=%x', trig)
+    if f4 < trig:
+        raise SystemExit('Phase288 immediate F4 must be after the production SW trigger write')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    path = args.root / HW
+    if not path.is_file():
+        raise SystemExit('missing DSI common HW source')
+    text = path.read_text()
+    if not args.check_only:
+        text = patch(text)
+        path.write_text(text)
+    validate(text)
+    print('Phase288 passive FIFO causal-chain producer hooks: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/288_ci_build.sh
+++ b/scripts/288_ci_build.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report(){
+  set +e
+  rm -rf phase288-failure
+  mkdir -p phase288-failure/{source,logs,audit,config}
+  cp phase288-compile.log phase288-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$HW" "$REC"; do [ -f "$f" ] && cp "$f" phase288-failure/source/ || true; done
+  cp scripts/288*.py phase288-failure/audit/ 2>/dev/null || true
+  cp /tmp/p288-*.config /tmp/p288-*.diff phase288-failure/config/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+bash scripts/287_ci_build.sh
+test -s phase287-out/package/boot.img
+for f in "$DSI" "$HW" "$REC"; do test -s "$f"; done
+grep -Fq 'A52_PHASE287_DSI_DMA_FETCH_PROVENANCE_V1' "$HW"
+grep -Fq 'A52_PHASE287B_RETAINED_FETCH_PROVENANCE_V1' "$REC"
+grep -Fq 'A52_PHASE286C_PACKED_REPLAY_WIDTH_V1' "$REC"
+grep -Fq 'P276 282A m=fifo f=%x' "$DSI"
+
+cp "$OUT/.config" /tmp/p288-base.config
+cp "$DSI" /tmp/p288-dsi-before.c
+cp "$HW" /tmp/p288-hw-before.c
+cp "$REC" /tmp/p288-rec-before.c
+
+python3 -m py_compile scripts/288_apply_retained_fifo_causal_chain.py scripts/288b_apply_fifo_typed_retention.py
+python3 scripts/288_apply_retained_fifo_causal_chain.py --root "$ROOT"
+python3 scripts/288b_apply_fifo_typed_retention.py --root "$ROOT"
+python3 scripts/288_apply_retained_fifo_causal_chain.py --root "$ROOT" --check-only
+python3 scripts/288b_apply_fifo_typed_retention.py --root "$ROOT" --check-only
+
+cmp -s /tmp/p288-dsi-before.c "$DSI"
+! cmp -s /tmp/p288-hw-before.c "$HW"
+! cmp -s /tmp/p288-rec-before.c "$REC"
+cmp -s /tmp/p288-base.config "$OUT/.config"
+
+for token in \
+  'A52_PHASE288_FIFO_CAUSAL_CHAIN_V1' \
+  'P288 F0 c=%d s=%u f=%x cfg=%x' \
+  'P288 F1 c=%d tg=%x w0=%x w1=%x' \
+  'P288 F2 c=%d st=%x fs=%x tg=%x' \
+  'P288 F3 c=%d dc=%x dl=%x fs=%x in=%x' \
+  'P288 F4 c=%d sw=%u st=%x fs=%x in=%x'; do grep -Fq "$token" "$HW"; done
+test "$(grep -Fc 'P288 F4 c=%d sw=%u st=%x fs=%x in=%x' "$HW")" -eq 2
+for token in \
+  'A52_PHASE288B_RETAINED_FIFO_CHAIN_V1' \
+  'a52_p288_capture_fmt(fmt, args);' \
+  'return !strncmp(message, "P288 ", 5)' \
+  'strncmp(fmt, "P288", 4)' \
+  'type = 18; n = 4;' 'type = 19; n = 4;' 'type = 20; n = 4;' \
+  'type = 21; n = 5;' 'type = 22; n = 5;' \
+  'P286 R0 %llx %x %x %llx %llx' 'P286 R1 %llx %llx %llx'; do grep -Fq "$token" "$REC"; done
+
+python3 - "$DSI" "$HW" "$REC" <<'PY'
+from pathlib import Path
+import sys
+dsi, hw, rec = map(lambda p: Path(p).read_text(), sys.argv[1:])
+fn0=hw.index('void dsi_ctrl_hw_cmn_kickoff_fifo_command(')
+fn1=hw.index('\nvoid dsi_ctrl_hw_cmn_reset_cmd_fifo(',fn0)
+fn=hw[fn0:fn1]
+marks=['P288 F0 c=%d s=%u f=%x cfg=%x','P288 F1 c=%d tg=%x w0=%x w1=%x','P288 F2 c=%d st=%x fs=%x tg=%x','P288 F3 c=%d dc=%x dl=%x fs=%x in=%x']
+pos=[fn.index(m) for m in marks]
+if pos != sorted(pos): raise SystemExit('Phase288 FIFO producer order audit failed')
+trig=fn.index('DSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);')
+f4=fn.index('P288 F4 c=%d sw=%u st=%x fs=%x in=%x',trig)
+if f4 < trig: raise SystemExit('Phase288 F4 precedes production trigger')
+cap=rec.index('a52_p288_capture_fmt(fmt, args);')
+pack=rec.find('vscnprintf',cap)
+if pack < 0 or cap > pack: raise SystemExit('Phase288 typed capture occurs after text packing')
+pt=dsi.index('P286 T c=%d st=%x done=%d irq=%d')
+flush=dsi.index('a52_p286_flush_timeout_chain();',pt)
+z=dsi.index('P276 280Z q=2',flush)
+freeze=dsi.index('a52_ackfr_retain_timeout_snapshot();',z)
+if not (pt < flush < z < freeze): raise SystemExit('retained replay is not immediately pre-freeze')
+u=(1<<64)-1
+lines=[f'P286 RH {u:x} {u:x}',f'P286 R0 {u:x} {22:x} {5:x} {u:x} {u:x}',f'P286 R1 {u:x} {u:x} {u:x}']
+for line in lines:
+    if len(line)>72: raise SystemExit(f'packed replay width {len(line)}>72: {line}')
+print('Phase288 ordering, typed retention, and packed-width audits: PASS')
+PY
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+if ! cmp -s /tmp/p288-base.config "$OUT/.config"; then
+  diff -u /tmp/p288-base.config "$OUT/.config" > /tmp/p288-config.diff || true
+  echo '::error::Phase288 changed kernel config'; cat /tmp/p288-config.diff; exit 1
+fi
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image 2>&1 | tee phase288-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase288-out
+mkdir -p phase288-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase288-out/compile/Image
+cp "$OUT/.config" phase288-out/config/final.config
+cp /tmp/p288-base.config phase288-out/audit/phase287b-final.config
+cp /tmp/p288-dsi-before.c phase288-out/audit/dsi-ctrl-before.c
+cp /tmp/p288-hw-before.c phase288-out/audit/dsi-ctrl-hw-cmn-before.c
+cp /tmp/p288-rec-before.c phase288-out/audit/recorder-before.c
+cp phase288-compile.log phase288-out/audit/
+cp scripts/288_apply_retained_fifo_causal_chain.py phase288-out/audit/
+cp scripts/288b_apply_fifo_typed_retention.py phase288-out/audit/
+cp "$DSI" phase288-out/source/dsi_ctrl.c
+cp "$HW" phase288-out/source/dsi_ctrl_hw_cmn.c
+cp "$REC" phase288-out/source/a52_ack_secure_flight_recorder.c
+
+gzip -n -c "$IMAGE" > phase288-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py --source phase287-out/package/boot.img --kernel phase288-out/package/Image.gz --output phase288-out/package/boot.img --report phase288-out/package/repack-report.json
+test -s phase288-out/package/boot.img
+file phase288-out/package/boot.img | tee phase288-out/package/boot-file.txt
+
+cat > phase288-out/PHASE288-RECORD-SCHEMA.txt <<'EOF'
+Phase288 retained FIFO causal-chain recorder
+============================================
+F0: FIFO function entry: controller, encoded size, hw flags, cfg bits (broadcast/master/LPM).
+F1: after TPG/FIFO mode control write: TPG control readback + first two encoded DWORDs.
+F2: after command DWORDs and pad are written to TPG DMA FIFO: DSI_STATUS/FIFO_STATUS/TPG control.
+F3: after DMA control + DMA length programming and wmb: DMA control/length/FIFO status/INT control.
+F4: immediate path strictly after existing SW trigger (sw=1), or deferred path without adding a trigger (sw=0), plus DSI/FIFO/INT state.
+Retained types: 18=F0, 19=F1, 20=F2, 21=F3, 22=F4.
+P288 is captured as exact typed varargs before text packing into the same final-32 tail used by Phase286C/287B. It is replayed using compact P286 R0/R1 immediately before the Phase280 ramoops retention freeze. Existing retained P286 W/T/G/HT provide wait, timeout, DMA_DONE ISR and deferred-trigger evidence.
+EOF
+
+python3 - <<'PY'
+import hashlib,json,os
+from pathlib import Path
+r=Path('phase288-out')
+idn={'phase':'288B','name':'RETAINED-DSI-FIFO-CAUSAL-CHAIN','git_sha':os.getenv('GITHUB_SHA'),'hardware_validated':False,'base':'green Phase287B retained DMA provenance lineage','phase282_fifo_ab_preserved':True,'behavior_change':False,'register_writes_added':False,'trigger_policy_changed':False,'recovery_changed':False,'brightness_changed_from_base':False,'source_scope':'dsi_ctrl_hw_cmn.c passive readbacks/records + Golden-FDR typed capture/admission only','recorder_change':'admit P288 and fold exact F0..F4 varargs into existing final-32 typed timeout tail','previous_recorder_failures_addressed':['P288 explicitly admitted by both filters','typed capture occurs before fixed-width text packing','tail replay occurs immediately before retention freeze','compact R0/R1 replay remains <=72 bytes'],'question':'For the Phase282 FIFO-routed failing command, does FIFO/TPG programming execute, does the normal SW trigger execute or defer, and how do DSI/FIFO/interrupt states change at each causal boundary before the inherited 200 ms timeout?','golden_repack_source':'phase287-out/package/boot.img','repacker':'scripts/38_repack_a52_p1_boot.py'}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=[p.relative_to(r) for p in sorted(r.rglob('*')) if p.is_file() and p.name!='SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files:f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+str(n)+'\n')
+PY
+(cd phase288-out && sha256sum -c SHA256SUMS)
+python3 - <<'PY'
+from pathlib import Path
+img=Path('phase288-out/compile/Image').read_bytes()
+for m in ['P288 F0 c=%d s=%u f=%x cfg=%x','P288 F1 c=%d tg=%x w0=%x w1=%x','P288 F2 c=%d st=%x fs=%x tg=%x','P288 F3 c=%d dc=%x dl=%x fs=%x in=%x','P288 F4 c=%d sw=%u st=%x fs=%x in=%x','P286 W c=%d r=%d irq=%d','P286 T c=%d st=%x done=%d irq=%d','P286 G c=%d st=%x irq0=%d','P286 HT c=%d sw=1','P286 R0 %llx %x %x %llx %llx','P286 R1 %llx %llx %llx']:
+ if m.encode() not in img: raise SystemExit('Phase288 marker missing from Image: '+m)
+print('Phase288 compiled FIFO producer + retained replay marker audit: PASS')
+PY
+python3 scripts/288_apply_retained_fifo_causal_chain.py --root "$ROOT" --check-only
+python3 scripts/288b_apply_fifo_typed_retention.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase288B retained FIFO causal-chain build/repack: PASS'

--- a/scripts/288b_apply_fifo_typed_retention.py
+++ b/scripts/288b_apply_fifo_typed_retention.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE288B_RETAINED_FIFO_CHAIN_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'{label}: expected exactly 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+BLOCK = r'''
+/* A52_PHASE288B_RETAINED_FIFO_CHAIN_V1
+ * Fold exact Phase288 FIFO causal events into the same final-32 typed tail
+ * that Phase286C replays immediately before the Phase280 ramoops freeze.
+ * Types 18..22 extend the existing causal type map without adding another ring.
+ */
+static void a52_p288_capture_fmt(const char *fmt, va_list src)
+{
+	va_list ap;
+	u64 v[A52_P286_VALUES] = { 0 };
+	u8 type = 0, n = 0;
+
+	if (!fmt || strncmp(fmt, "P288 ", 5))
+		return;
+	va_copy(ap, src);
+	if (!strcmp(fmt, "P288 F0 c=%d s=%u f=%x cfg=%x")) {
+		type = 18; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P288 F1 c=%d tg=%x w0=%x w1=%x")) {
+		type = 19; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P288 F2 c=%d st=%x fs=%x tg=%x")) {
+		type = 20; n = 4;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P288 F3 c=%d dc=%x dl=%x fs=%x in=%x")) {
+		type = 21; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int); v[4] = va_arg(ap, unsigned int);
+	} else if (!strcmp(fmt, "P288 F4 c=%d sw=%u st=%x fs=%x in=%x")) {
+		type = 22; n = 5;
+		v[0] = (u64)(s64)va_arg(ap, int);
+		v[1] = va_arg(ap, unsigned int); v[2] = va_arg(ap, unsigned int);
+		v[3] = va_arg(ap, unsigned int); v[4] = va_arg(ap, unsigned int);
+	}
+	va_end(ap);
+	if (type)
+		a52_p286_store(type, n, v);
+}
+'''
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    for token in [
+        'A52_PHASE286B_DMA_CHAIN_TYPED_RETENTION_V1',
+        'A52_PHASE286C_PACKED_REPLAY_WIDTH_V1',
+        'A52_PHASE287B_RETAINED_FETCH_PROVENANCE_V1',
+        'static void a52_p287_capture_fmt(const char *fmt, va_list src)',
+        'a52_p286_store(type, n, v);',
+        'P286 R0 %llx %x %x %llx %llx',
+        'P286 R1 %llx %llx %llx',
+    ]:
+        if token not in text:
+            raise SystemExit('Phase288B retained-recorder prerequisite missing: ' + token)
+
+    anchor = 'static void a52_p287_capture_fmt(const char *fmt, va_list src)\n'
+    text = one(text, anchor, BLOCK + '\n' + anchor, 'Phase288 typed capture insertion')
+    text = one(text,
+        'return !strncmp(message, "P287 ", 5) ||\n       !strncmp(message, "P286 ", 5) ||',
+        'return !strncmp(message, "P288 ", 5) ||\n       !strncmp(message, "P287 ", 5) ||\n       !strncmp(message, "P286 ", 5) ||',
+        'critical P288 admission')
+    text = one(text,
+        'if (strncmp(fmt, "P287", 4) &&\n    strncmp(fmt, "P286", 4) &&',
+        'if (strncmp(fmt, "P288", 4) &&\n    strncmp(fmt, "P287", 4) &&\n    strncmp(fmt, "P286", 4) &&',
+        'focused P288 admission')
+    text = one(text,
+        '\tva_start(args, fmt);\n\ta52_p287_capture_fmt(fmt, args);\n\ta52_p286_capture_fmt(fmt, args);',
+        '\tva_start(args, fmt);\n\ta52_p288_capture_fmt(fmt, args);\n\ta52_p287_capture_fmt(fmt, args);\n\ta52_p286_capture_fmt(fmt, args);',
+        'P288 typed capture before packing')
+    return text
+
+
+def validate(text: str) -> None:
+    for token in [
+        MARK,
+        'a52_p288_capture_fmt(fmt, args);',
+        'return !strncmp(message, "P288 ", 5)',
+        'strncmp(fmt, "P288", 4)',
+        'type = 18; n = 4;', 'type = 19; n = 4;', 'type = 20; n = 4;',
+        'type = 21; n = 5;', 'type = 22; n = 5;',
+        'P286 R0 %llx %x %x %llx %llx', 'P286 R1 %llx %llx %llx',
+    ]:
+        if token not in text:
+            raise SystemExit('Phase288B retention marker missing: ' + token)
+    for fmt in [
+        'P288 F0 c=%d s=%u f=%x cfg=%x',
+        'P288 F1 c=%d tg=%x w0=%x w1=%x',
+        'P288 F2 c=%d st=%x fs=%x tg=%x',
+        'P288 F3 c=%d dc=%x dl=%x fs=%x in=%x',
+        'P288 F4 c=%d sw=%u st=%x fs=%x in=%x',
+    ]:
+        if fmt not in text:
+            raise SystemExit('Phase288B format capture missing: ' + fmt)
+    cap = text.index('a52_p288_capture_fmt(fmt, args);')
+    pack = text.find('vscnprintf', cap)
+    if pack < 0 or cap > pack:
+        raise SystemExit('Phase288 typed capture is not before recorder text packing')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    path = args.root / REC
+    if not path.is_file():
+        raise SystemExit('missing recorder source')
+    text = path.read_text()
+    if not args.check_only:
+        text = patch(text)
+        path.write_text(text)
+    validate(text)
+    print('Phase288B retained FIFO causal-chain capture: PASS')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Builds on the green Phase287B lineage. Adds passive hooks inside the actual TouchGrass FIFO/TPG command kickoff used by the preserved Phase282 one-shot FIFO A/B command. P288 F0..F4 capture FIFO entry, encoded words, FIFO fill state, programmed DMA control/length state, and immediate/deferred trigger state. Exact P288 varargs are admitted and captured before text packing into the existing Phase286C final-32 typed tail, then replayed immediately before the Phase280 retention freeze. No new DSI writes, trigger-policy changes, recovery changes, or brightness changes are introduced.