### PR TITLE
Phase293: passive GKI fetch-memory DMA_DONE reference recorder

### DIFF
--- a/.github/workflows/293-a52-gki-fetch-memory-dma-done-reference.yml
+++ b/.github/workflows/293-a52-gki-fetch-memory-dma-done-reference.yml
@@ -1,0 +1,96 @@
+name: 293 - A52 GKI fetch-memory DMA_DONE reference
+run-name: Phase 293 - clean Phase280 memory-DMA Golden mirror
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase293-gki-fetch-memory-dma-done-reference-v1
+    paths:
+      - .github/workflows/293-a52-gki-fetch-memory-dma-done-reference.yml
+      - scripts/293_apply_gki_dma_done_reference.py
+      - scripts/293_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase280-phase279-evidence-visible-v1
+    paths:
+      - .github/workflows/293-a52-gki-fetch-memory-dma-done-reference.yml
+      - scripts/293_apply_gki_dma_done_reference.py
+      - scripts/293_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase293-gki-memory-dma-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Reconstruct Phase280 and build passive GKI GDM reference
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase293 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build clean Phase280-based Phase293 reference
+        run: bash scripts/293_ci_build.sh
+      - name: Upload complete Phase293 evidence package
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase293-GKI-FETCH-MEMORY-DMA-DONE-REFERENCE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase293-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload flash-ready boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase293-GKI-FETCH-MEMORY-DMA-DONE-REFERENCE-${{ github.run_number }}-BOOT-IMG
+          path: phase293-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase293-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase*-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/293_apply_gki_dma_done_reference.py
+++ b/scripts/293_apply_gki_dma_done_reference.py
@@ -9,6 +9,32 @@ HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
 MARK_CTRL = 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1'
 MARK_HW = 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1'
 
+FETCH_MEMORY_CLEAR = '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY'
+
+
+def assert_no_fetch_memory_fifo_reroute(text: str) -> None:
+    """Allow only the stock secure-session FETCH_MEMORY -> FIFO safeguard."""
+    if text.count(FETCH_MEMORY_CLEAR) != 1:
+        raise SystemExit(
+            'Phase293 refuses later behavioral lineage: unexpected '
+            f'FETCH_MEMORY clear count ({text.count(FETCH_MEMORY_CLEAR)})'
+        )
+
+    fn_start = text.find('void dsi_message_setup_tx_mode(')
+    fn_end = text.find('\nint dsi_message_validate_tx_mode(', fn_start)
+    if fn_start < 0 or fn_end < 0:
+        raise SystemExit('Phase293 stock dsi_message_setup_tx_mode boundary missing')
+    fn = text[fn_start:fn_end]
+    secure = fn.find('if (dsi_ctrl->secure_mode) {')
+    clear = fn.find(FETCH_MEMORY_CLEAR)
+    fifo = fn.find('*flags |= DSI_CTRL_CMD_FIFO_STORE', clear)
+    ret = fn.find('return;', fifo)
+    if not (0 <= secure < clear < fifo < ret):
+        raise SystemExit(
+            'Phase293 refuses later behavioral lineage: stock secure-mode '
+            'FETCH_MEMORY -> FIFO safeguard moved or altered'
+        )
+
 
 def one(text: str, old: str, new: str, label: str) -> str:
     n = text.count(old)
@@ -34,10 +60,10 @@ def patch_ctrl(text: str) -> str:
         'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1',
         'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1',
         'A52_PHASE292_DSI_CHAIN_TAPS_V1',
-        '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY',
     ]:
         if forbidden in text:
             raise SystemExit('Phase293 refuses later behavioral lineage: ' + forbidden)
+    assert_no_fetch_memory_fifo_reroute(text)
 
     text = one(text, '#include "dsi_ctrl_hw.h"\n',
                '#include "dsi_ctrl_hw.h"\n#include "dsi_ctrl_reg.h"\n#include "dsi_hw.h"\n',
@@ -121,14 +147,9 @@ static void a52_p293_gdm_arm_snapshot(struct dsi_ctrl *dsi_ctrl, unsigned int st
 '''
     text = one(text, hwflags, hwflags + state, 'selected flags/state/target clocks')
 
-    arm0 = '\t\tatomic_set(&dsi_ctrl->dma_irq_trig, 0);\n'
-    text = one(text, arm0,
-               '\t\ta52_p293_gdm_arm_snapshot(dsi_ctrl, 0);\n' + arm0,
-               'pre IRQ-arm snapshot')
-
-    arm1 = '\t\treinit_completion(&dsi_ctrl->irq_info.cmd_dma_done);\n'
-    text = one(text, arm1, arm1 + '\t\ta52_p293_gdm_arm_snapshot(dsi_ctrl, 1);\n',
-               'post IRQ-arm snapshot')
+    irq_arm = '''\t\tdsi_ctrl_mask_overflow(dsi_ctrl, true);\n\n\t\tatomic_set(&dsi_ctrl->dma_irq_trig, 0);\n\t\tdsi_ctrl_enable_status_interrupt(dsi_ctrl,\n\t\t\t\t\tDSI_SINT_CMD_MODE_DMA_DONE, NULL);\n\t\treinit_completion(&dsi_ctrl->irq_info.cmd_dma_done);\n'''
+    irq_arm_rec = '''\t\tdsi_ctrl_mask_overflow(dsi_ctrl, true);\n\n\t\ta52_p293_gdm_arm_snapshot(dsi_ctrl, 0);\n\t\tatomic_set(&dsi_ctrl->dma_irq_trig, 0);\n\t\tdsi_ctrl_enable_status_interrupt(dsi_ctrl,\n\t\t\t\t\tDSI_SINT_CMD_MODE_DMA_DONE, NULL);\n\t\treinit_completion(&dsi_ctrl->irq_info.cmd_dma_done);\n\t\ta52_p293_gdm_arm_snapshot(dsi_ctrl, 1);\n'''
+    text = one(text, irq_arm, irq_arm_rec, 'command-DMA IRQ-arm snapshots')
 
     wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n'''
     wait_rec = r'''	if (a52_p293_gdm_armed(dsi_ctrl)) {
@@ -252,8 +273,7 @@ def validate(ctrl: str, hw: str) -> None:
                   'GDM S06b tg=%x in=%x']:
         if token not in hw:
             raise SystemExit('Phase293 HW validation missing: ' + token)
-    if '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY' in ctrl:
-        raise SystemExit('Phase293 FIFO reroute detected')
+    assert_no_fetch_memory_fifo_reroute(ctrl)
     if ctrl.index('GDM S09 st=%x fs=%x ln=%x ck=%x') > ctrl.index('P276 280Z q=2'):
         raise SystemExit('Phase293 final GDM snapshot is after Phase280 retention latch')
 

--- a/scripts/293_apply_gki_dma_done_reference.py
+++ b/scripts/293_apply_gki_dma_done_reference.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+MARK_CTRL = 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1'
+MARK_HW = 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase293 {label}: expected exactly 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def behavioral_counts(text: str) -> dict[str, int]:
+    return {k: text.count(k) for k in [
+        'DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
+        'wait_for_completion_timeout(', 'msleep(', 'usleep_range(',
+        'DSI_CTRL_CMD_FIFO_STORE',
+    ]}
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK_CTRL in text:
+        return text
+    if 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' not in text:
+        raise SystemExit('Phase293 requires exact Phase280 retained-timeout DSI source')
+    for forbidden in [
+        'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1',
+        'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1',
+        'A52_PHASE292_DSI_CHAIN_TAPS_V1',
+        '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY',
+    ]:
+        if forbidden in text:
+            raise SystemExit('Phase293 refuses later behavioral lineage: ' + forbidden)
+
+    text = one(text, '#include "dsi_ctrl_hw.h"\n',
+               '#include "dsi_ctrl_hw.h"\n#include "dsi_ctrl_reg.h"\n#include "dsi_hw.h"\n',
+               'read-only register headers')
+
+    anchor = 'static DEFINE_MUTEX(dsi_ctrl_list_lock);\n\n'
+    helper = r'''static DEFINE_MUTEX(dsi_ctrl_list_lock);
+
+/* A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1
+ * Passive mirror of the hardware-validated Golden GDM recorder on the clean
+ * Phase280 GKI memory-fetch path. The only operations added here are RAM
+ * atomics, MMIO reads and writes to the existing A52 flight recorder. No DSI
+ * register write, command flag mutation, wait, reset, recovery, clock change,
+ * panel packet or brightness operation is added.
+ */
+static atomic_t a52_p293_gdm_state = ATOMIC_INIT(0); /* 0 idle, 1 exact target */
+
+static bool a52_p293_gdm_armed(struct dsi_ctrl *dsi_ctrl)
+{
+	return dsi_ctrl && dsi_ctrl->cell_index == 0 &&
+		atomic_read(&a52_p293_gdm_state) == 1;
+}
+
+bool a52_p293_gdm_trace_active(void)
+{
+	return atomic_read(&a52_p293_gdm_state) == 1;
+}
+
+static void a52_p293_gdm_try_arm(struct dsi_ctrl *dsi_ctrl,
+		const struct mipi_dsi_msg *msg, u32 *flags)
+{
+	const u8 *p;
+
+	if (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||
+	    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||
+	    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)
+		return;
+	if (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)
+		return;
+	p = msg->tx_buf;
+	a52_ackfr_record("GDM S00 c=0 in=%x mf=%x t=%x l=%u",
+		*flags, msg->flags, msg->type, (unsigned int)msg->tx_len);
+	a52_ackfr_record("GDM S00p p=%02x%02x%02x", p[0], p[1], p[2]);
+}
+
+static void a52_p293_gdm_arm_snapshot(struct dsi_ctrl *dsi_ctrl, unsigned int stage)
+{
+	if (!a52_p293_gdm_armed(dsi_ctrl) || !dsi_ctrl->hw.base)
+		return;
+	a52_ackfr_record(stage ? "GDM S04 irq=%d in=%x st=%x" : "GDM S03 irq=%d in=%x st=%x",
+		atomic_read(&dsi_ctrl->dma_irq_trig),
+		DSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL),
+		DSI_R32(&dsi_ctrl->hw, DSI_STATUS));
+	a52_ackfr_record(stage ? "GDM S04b ln=%x ck=%x" : "GDM S03b ln=%x ck=%x",
+		DSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),
+		DSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS));
+}
+
+'''
+    text = one(text, anchor, helper, 'helper insertion')
+
+    target = '''\tif (a52_p276r_deep_active())\n\t\ta52_ackfr_record("P276 D M s=0 f=%x mt=%u l=%u", flags ? *flags : 0, (unsigned int)msg->type, (unsigned int)msg->tx_len);\n'''
+    text = one(text, target, target + '\ta52_p293_gdm_try_arm(dsi_ctrl, msg, flags);\n', 'exact target arm')
+
+    hwflags = '''\thw_flags |= (flags & DSI_CTRL_CMD_DEFER_TRIGGER) ?\n\t\t\tDSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER : 0;\n'''
+    state = r'''	if (a52_p293_gdm_armed(dsi_ctrl)) {
+		a52_ackfr_record("GDM S01 sel=%x hw=%x pm=%u pwr=%u",
+			flags, hw_flags, dsi_ctrl->host_config.panel_mode,
+			dsi_ctrl->current_state.power_state);
+		a52_ackfr_record("GDM S01b hi=%u ce=%u me=%u ve=%u",
+			dsi_ctrl->current_state.host_initialized,
+			dsi_ctrl->current_state.controller_state,
+			dsi_ctrl->current_state.cmd_engine_state,
+			dsi_ctrl->current_state.vid_engine_state);
+		a52_ackfr_record("GDM S02 ct=%u,%u,%u,%u ca=na",
+			dsi_ctrl->clk_freq.byte_clk_rate,
+			dsi_ctrl->clk_freq.pix_clk_rate,
+			dsi_ctrl->clk_freq.byte_intf_clk_rate,
+			dsi_ctrl->clk_freq.esc_clk_rate);
+	}
+'''
+    text = one(text, hwflags, hwflags + state, 'selected flags/state/target clocks')
+
+    arm0 = '\t\tatomic_set(&dsi_ctrl->dma_irq_trig, 0);\n'
+    text = one(text, arm0,
+               '\t\ta52_p293_gdm_arm_snapshot(dsi_ctrl, 0);\n' + arm0,
+               'pre IRQ-arm snapshot')
+
+    arm1 = '\t\treinit_completion(&dsi_ctrl->irq_info.cmd_dma_done);\n'
+    text = one(text, arm1, arm1 + '\t\ta52_p293_gdm_arm_snapshot(dsi_ctrl, 1);\n',
+               'post IRQ-arm snapshot')
+
+    wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n'''
+    wait_rec = r'''	if (a52_p293_gdm_armed(dsi_ctrl)) {
+		a52_ackfr_record("GDM S08 ret=%d irq=%d in=%x st=%x", ret,
+			atomic_read(&dsi_ctrl->dma_irq_trig),
+			DSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL),
+			DSI_R32(&dsi_ctrl->hw, DSI_STATUS));
+	}
+'''
+    text = one(text, wait, wait + wait_rec, 'completion wait result')
+
+    isr = '''\tif (status & DSI_CMD_MODE_DMA_DONE) {\n\t\tatomic_set(&dsi_ctrl->dma_irq_trig, 1);\n'''
+    isr_new = r'''	if (status & DSI_CMD_MODE_DMA_DONE) {
+		if (a52_p293_gdm_armed(dsi_ctrl)) {
+			a52_ackfr_record("GDM S07 seen=1 st=%x in=%x irq0=%d", status,
+				DSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL),
+				atomic_read(&dsi_ctrl->dma_irq_trig));
+			a52_ackfr_record("GDM S07e ack=%x to=%x",
+				DSI_R32(&dsi_ctrl->hw, DSI_ACK_ERR_STATUS),
+				DSI_R32(&dsi_ctrl->hw, DSI_TIMEOUT_STATUS));
+		}
+		atomic_set(&dsi_ctrl->dma_irq_trig, 1);
+'''
+    text = one(text, isr, isr_new, 'DMA_DONE ISR')
+
+    retain = '''\t\tif (a52_p276r_deep_active()) {\n\t\t\ta52_ackfr_record("P276 280Z q=2");\n\t\t\ta52_ackfr_retain_timeout_snapshot();\n\t\t}\n'''
+    final = r'''		if (a52_p293_gdm_armed(dsi_ctrl)) {
+			a52_ackfr_record("GDM S09 st=%x fs=%x ln=%x ck=%x",
+				DSI_R32(&dsi_ctrl->hw, DSI_STATUS),
+				DSI_R32(&dsi_ctrl->hw, DSI_FIFO_STATUS),
+				DSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),
+				DSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS));
+			a52_ackfr_record("GDM S09e ack=%x to=%x phy=%x ctl=%x",
+				DSI_R32(&dsi_ctrl->hw, DSI_ACK_ERR_STATUS),
+				DSI_R32(&dsi_ctrl->hw, DSI_TIMEOUT_STATUS),
+				DSI_R32(&dsi_ctrl->hw, DSI_DLN0_PHY_ERR),
+				DSI_R32(&dsi_ctrl->hw, DSI_CTRL));
+			a52_ackfr_record("GDM DONE success=0 target=0/8/20/29/3");
+		}
+'''
+    text = one(text, retain, final + retain, 'final snapshot before Phase280 latch')
+    return text
+
+
+def patch_hw(text: str) -> str:
+    if MARK_HW in text:
+        return text
+    for token in [
+        'void dsi_ctrl_hw_cmn_kickoff_command(',
+        'void dsi_ctrl_hw_cmn_trigger_command_dma(',
+        'DSI_W32(ctrl, DSI_DMA_CMD_OFFSET, cmd->offset);',
+        'DSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);',
+    ]:
+        if token not in text:
+            raise SystemExit('Phase293 HW prerequisite missing: ' + token)
+
+    inc = '#include "sde_dbg.h"\n'
+    decl = '''#include "sde_dbg.h"\n\n/* A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1 */\nextern bool a52_p293_gdm_trace_active(void);\nextern void a52_ackfr_record(const char *fmt, ...);\n'''
+    text = one(text, inc, decl, 'HW declarations')
+
+    old = '''\t/* wait for writes to complete before kick off */\n\twmb();\n\n\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER))\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n}\n'''
+    new = r'''	/* wait for writes to complete before kick off */
+	wmb();
+
+	if (a52_p293_gdm_trace_active()) {
+		a52_ackfr_record("GDM S05 dc=%x off=%x len=%x fc=%x",
+			DSI_R32(ctrl, DSI_COMMAND_MODE_DMA_CTRL),
+			DSI_R32(ctrl, DSI_DMA_CMD_OFFSET),
+			DSI_R32(ctrl, DSI_DMA_CMD_LENGTH),
+			DSI_R32(ctrl, DSI_DMA_FIFO_CTRL));
+		a52_ackfr_record("GDM S05b tr=%x sw=%x cc=%x",
+			DSI_R32(ctrl, DSI_TRIG_CTRL),
+			DSI_R32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER),
+			DSI_R32(ctrl, DSI_CLK_CTRL));
+	}
+
+	if (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER)) {
+		DSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);
+		if (a52_p293_gdm_trace_active()) {
+			a52_ackfr_record("GDM S06 st=%x fs=%x ln=%x ck=%x",
+				DSI_R32(ctrl, DSI_STATUS), DSI_R32(ctrl, DSI_FIFO_STATUS),
+				DSI_R32(ctrl, DSI_LANE_STATUS), DSI_R32(ctrl, DSI_CLK_STATUS));
+			a52_ackfr_record("GDM S06b tg=%x in=%x",
+				DSI_R32(ctrl, DSI_TPG_DMA_FIFO_STATUS), DSI_R32(ctrl, DSI_INT_CTRL));
+		}
+	}
+}
+'''
+    text = one(text, old, new, 'memory kickoff snapshots')
+
+    trig = '''void dsi_ctrl_hw_cmn_trigger_command_dma(struct dsi_ctrl_hw *ctrl)\n{\n\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n}\n'''
+    trig_new = r'''void dsi_ctrl_hw_cmn_trigger_command_dma(struct dsi_ctrl_hw *ctrl)
+{
+	DSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);
+	if (a52_p293_gdm_trace_active()) {
+		a52_ackfr_record("GDM S06 st=%x fs=%x ln=%x ck=%x",
+			DSI_R32(ctrl, DSI_STATUS), DSI_R32(ctrl, DSI_FIFO_STATUS),
+			DSI_R32(ctrl, DSI_LANE_STATUS), DSI_R32(ctrl, DSI_CLK_STATUS));
+		a52_ackfr_record("GDM S06b tg=%x in=%x",
+			DSI_R32(ctrl, DSI_TPG_DMA_FIFO_STATUS), DSI_R32(ctrl, DSI_INT_CTRL));
+	}
+}
+'''
+    text = one(text, trig, trig_new, 'deferred trigger post snapshot')
+    return text
+
+
+def validate(ctrl: str, hw: str) -> None:
+    for token in [
+        MARK_CTRL, 'GDM S00 c=0 in=%x mf=%x t=%x l=%u', 'GDM S00p p=%02x%02x%02x',
+        'GDM S01 sel=%x hw=%x pm=%u pwr=%u', 'GDM S02 ct=%u,%u,%u,%u ca=na',
+        'GDM S03 irq=%d in=%x st=%x', 'GDM S04 irq=%d in=%x st=%x',
+        'GDM S07 seen=1 st=%x in=%x irq0=%d', 'GDM S08 ret=%d irq=%d in=%x st=%x',
+        'GDM S09 st=%x fs=%x ln=%x ck=%x', 'GDM DONE success=0 target=0/8/20/29/3',
+        'P276 280Z q=2', 'a52_ackfr_retain_timeout_snapshot();',
+    ]:
+        if token not in ctrl:
+            raise SystemExit('Phase293 dsi_ctrl validation missing: ' + token)
+    for token in [MARK_HW, 'GDM S05 dc=%x off=%x len=%x fc=%x',
+                  'GDM S05b tr=%x sw=%x cc=%x', 'GDM S06 st=%x fs=%x ln=%x ck=%x',
+                  'GDM S06b tg=%x in=%x']:
+        if token not in hw:
+            raise SystemExit('Phase293 HW validation missing: ' + token)
+    if '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY' in ctrl:
+        raise SystemExit('Phase293 FIFO reroute detected')
+    if ctrl.index('GDM S09 st=%x fs=%x ln=%x ck=%x') > ctrl.index('P276 280Z q=2'):
+        raise SystemExit('Phase293 final GDM snapshot is after Phase280 retention latch')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    cp, hp = args.root / CTRL, args.root / HW
+    if not cp.is_file() or not hp.is_file():
+        raise SystemExit('Phase293 reconstructed DSI sources missing')
+    c0, h0 = cp.read_text(), hp.read_text()
+    bc, bh = behavioral_counts(c0), behavioral_counts(h0)
+    if not args.check_only:
+        cp.write_text(patch_ctrl(c0))
+        hp.write_text(patch_hw(h0))
+    c1, h1 = cp.read_text(), hp.read_text()
+    validate(c1, h1)
+    if not args.check_only:
+        ac, ah = behavioral_counts(c1), behavioral_counts(h1)
+        if bc != ac:
+            raise SystemExit(f'Phase293 dsi_ctrl behavioral-token count changed: {bc} -> {ac}')
+        if bh != ah:
+            raise SystemExit(f'Phase293 dsi_ctrl_hw behavioral-token count changed: {bh} -> {ah}')
+    print('Phase293 passive GKI DMA_DONE reference recorder: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/293_ci_build.sh
+++ b/scripts/293_ci_build.sh
@@ -38,11 +38,17 @@ cp "$SMMU" /tmp/p293-smmu-before.c
 cp "$REC" /tmp/p293-rec-before.c
 
 # Refuse accidental inheritance of the experiments this comparison is meant
-# to remove.
-! grep -Fq 'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1' "$DSI"
-! grep -Fq 'A52_PHASE292_DSI_CHAIN_TAPS_V1' "$DSI"
-! grep -Fq '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY' "$DSI"
-! grep -Fq 'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1' "$DSI"
+# to remove. The stock secure-session FETCH_MEMORY -> FIFO safeguard is
+# validated structurally by the Phase293 patcher immediately below.
+for marker in \
+  'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1' \
+  'A52_PHASE292_DSI_CHAIN_TAPS_V1' \
+  'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1'; do
+  if grep -Fq "$marker" "$DSI"; then
+    echo "Phase293 refuses later behavioral lineage: $marker" >&2
+    exit 1
+  fi
+done
 
 grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$DSI"
 grep -Fq 'P276 280Z q=2' "$DSI"
@@ -142,7 +148,7 @@ python3 - <<'PY'
 from pathlib import Path
 r=Path('phase293-out')
 d=(r/'source/dsi_ctrl.c').read_text(); h=(r/'source/dsi_ctrl_hw_cmn.c').read_text(); img=(r/'compile/Image').read_bytes()
-for bad in ['A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1','A52_PHASE292_DSI_CHAIN_TAPS_V1','*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY']:
+for bad in ['A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1','A52_PHASE292_DSI_CHAIN_TAPS_V1','A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1']:
  if bad in d: raise SystemExit('Phase293 forbidden inherited behavior: '+bad)
 for m in ['A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1','GDM S00 c=0 in=%x mf=%x t=%x l=%u','GDM S01 sel=%x hw=%x pm=%u pwr=%u','GDM S02 ct=%u,%u,%u,%u ca=na','GDM S03 irq=%d in=%x st=%x','GDM S04 irq=%d in=%x st=%x','GDM S07 seen=1 st=%x in=%x irq0=%d','GDM S08 ret=%d irq=%d in=%x st=%x','GDM S09 st=%x fs=%x ln=%x ck=%x','GDM DONE success=0 target=0/8/20/29/3','P276 280Z q=2']:
  if m not in d: raise SystemExit('Phase293 source marker missing: '+m)

--- a/scripts/293_ci_build.sh
+++ b/scripts/293_ci_build.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DSI="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+SMMU="$ROOT/drivers/iommu/arm/arm-smmu/arm-smmu.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report(){
+  set +e
+  rm -rf phase293-failure
+  mkdir -p phase293-failure/{source,logs,audit}
+  cp phase293-compile.log phase293-failure/logs/ 2>/dev/null || true
+  for f in "$DSI" "$HW" "$SMMU" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase293-failure/source/ || true
+  done
+  cp scripts/293_apply_gki_dma_done_reference.py phase293-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Phase293 deliberately reconstructs the clean Phase280 lineage. It does not
+# call Phase281..292 and therefore cannot inherit the Phase282 FIFO reroute or
+# Phase291 zero-rate recovery. Phase280 also supplies the proven timeout
+# retention latch needed to preserve this failing early display transaction.
+bash scripts/280_ci_build.sh
+test -s phase280-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DSI" "$HW" "$SMMU" "$REC"; do test -s "$f"; done
+
+# The repack chain must remain the established fixed-size A52 boot container.
+test "$(stat -c '%s' phase280-out/package/boot.img)" -eq 100663296
+
+cp "$OUT/.config" /tmp/p293-base.config
+cp "$DSI" /tmp/p293-dsi-before.c
+cp "$HW" /tmp/p293-hw-before.c
+cp "$SMMU" /tmp/p293-smmu-before.c
+cp "$REC" /tmp/p293-rec-before.c
+
+# Refuse accidental inheritance of the experiments this comparison is meant
+# to remove.
+! grep -Fq 'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1' "$DSI"
+! grep -Fq 'A52_PHASE292_DSI_CHAIN_TAPS_V1' "$DSI"
+! grep -Fq '*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY' "$DSI"
+! grep -Fq 'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1' "$DSI"
+
+grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$DSI"
+grep -Fq 'P276 280Z q=2' "$DSI"
+
+python3 -m py_compile scripts/293_apply_gki_dma_done_reference.py
+python3 scripts/293_apply_gki_dma_done_reference.py --root "$ROOT"
+python3 scripts/293_apply_gki_dma_done_reference.py --root "$ROOT" --check-only
+
+# Phase293 may touch only the DSI controller and common HW source. SMMU and the
+# Phase280 retention backend must remain byte-for-byte unchanged.
+cmp -s /tmp/p293-smmu-before.c "$SMMU"
+cmp -s /tmp/p293-rec-before.c "$REC"
+
+# Preserve the exact Phase280 kernel configuration.
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p293-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase293-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase293-out
+mkdir -p phase293-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase293-out/compile/Image
+cp "$OUT/.config" phase293-out/config/final.config
+cp /tmp/p293-base.config phase293-out/audit/phase280-final.config
+cp /tmp/p293-dsi-before.c phase293-out/audit/dsi-ctrl-before.c
+cp /tmp/p293-hw-before.c phase293-out/audit/dsi-ctrl-hw-before.c
+cp /tmp/p293-smmu-before.c phase293-out/audit/arm-smmu-before.c
+cp /tmp/p293-rec-before.c phase293-out/audit/recorder-before.c
+cp phase293-compile.log phase293-out/audit/
+cp scripts/293_apply_gki_dma_done_reference.py phase293-out/audit/
+cp "$DSI" phase293-out/source/dsi_ctrl.c
+cp "$HW" phase293-out/source/dsi_ctrl_hw_cmn.c
+cp "$SMMU" phase293-out/source/arm-smmu.c
+cp "$REC" phase293-out/source/a52_ack_secure_flight_recorder.c
+
+gzip -n -c "$IMAGE" > phase293-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase280-out/package/boot.img \
+  --kernel phase293-out/package/Image.gz \
+  --output phase293-out/package/boot.img \
+  --report phase293-out/package/repack-report.json
+
+test "$(stat -c '%s' phase293-out/package/boot.img)" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase293-out')
+idn={
+ 'phase':'293',
+ 'name':'GKI-FETCH-MEMORY-DMA-DONE-REFERENCE',
+ 'git_sha':os.getenv('GITHUB_SHA'),
+ 'hardware_validated':False,
+ 'base':'exact Phase280 retained-timeout GKI reconstruction',
+ 'target':'ctrl0 / incoming DSI_CTRL_CMD_FETCH_MEMORY(0x20) / msg.flags=0x8 / type=0x29 / tx_len=3 / payload expected F05A5A',
+ 'transport_change':False,
+ 'fifo_reroute':False,
+ 'clock_recovery':False,
+ 'clk_set_rate_added':False,
+ 'dsi_register_writes_added':False,
+ 'wait_or_timeout_change':False,
+ 'panel_or_brightness_change':False,
+ 'retention':'inherited Phase280 timeout snapshot latch; GDM records emitted before P276 280Z',
+ 'gdm_schema':{
+   'S00':'target identity and first three payload bytes',
+   'S01':'selected controller/hw flags plus panel/controller engine state',
+   'S02':'cached target byte/pixel/byte-intf/esc rates; CCF leaf objects are not owned by this GKI dsi_ctrl path',
+   'S03':'pre DMA_DONE arm raw INT/STATUS/LANE/CLK',
+   'S04':'post arm/reinit raw INT/STATUS/LANE/CLK',
+   'S05':'pre production SW-trigger DMA_CTRL/OFFSET/LENGTH/FIFO/TRIG/SW/CLK',
+   'S06':'immediately post production SW-trigger STATUS/FIFO/LANE/CLK/TPG/INT',
+   'S07':'DMA_DONE ISR translated status/raw INT/error/irq-before, if observed',
+   'S08':'normal completion wait return/irq/raw INT/STATUS',
+   'S09':'timeout-final STATUS/FIFO/LANE/CLK/ACK/TIMEOUT/PHY/CTRL before retention latch'
+ },
+ 'hardware_question':'On the same unmodified 0x20 memory-fetch transport that succeeds on Golden, what is the first GKI register/IRQ state that diverges before DMA_DONE fails to assert?'
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=[
+ 'compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json',
+ 'audit/phase280-final.config','audit/dsi-ctrl-before.c','audit/dsi-ctrl-hw-before.c',
+ 'audit/arm-smmu-before.c','audit/recorder-before.c','audit/phase293-compile.log',
+ 'audit/293_apply_gki_dma_done_reference.py','source/dsi_ctrl.c','source/dsi_ctrl_hw_cmn.c',
+ 'source/arm-smmu.c','source/a52_ack_secure_flight_recorder.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+ for n in files:
+  f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase293-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+r=Path('phase293-out')
+d=(r/'source/dsi_ctrl.c').read_text(); h=(r/'source/dsi_ctrl_hw_cmn.c').read_text(); img=(r/'compile/Image').read_bytes()
+for bad in ['A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1','A52_PHASE292_DSI_CHAIN_TAPS_V1','*flags &= ~DSI_CTRL_CMD_FETCH_MEMORY']:
+ if bad in d: raise SystemExit('Phase293 forbidden inherited behavior: '+bad)
+for m in ['A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1','GDM S00 c=0 in=%x mf=%x t=%x l=%u','GDM S01 sel=%x hw=%x pm=%u pwr=%u','GDM S02 ct=%u,%u,%u,%u ca=na','GDM S03 irq=%d in=%x st=%x','GDM S04 irq=%d in=%x st=%x','GDM S07 seen=1 st=%x in=%x irq0=%d','GDM S08 ret=%d irq=%d in=%x st=%x','GDM S09 st=%x fs=%x ln=%x ck=%x','GDM DONE success=0 target=0/8/20/29/3','P276 280Z q=2']:
+ if m not in d: raise SystemExit('Phase293 source marker missing: '+m)
+for m in ['A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1','GDM S05 dc=%x off=%x len=%x fc=%x','GDM S06 st=%x fs=%x ln=%x ck=%x']:
+ if m not in h: raise SystemExit('Phase293 HW source marker missing: '+m)
+for m in ['GDM S00 c=0 in=%x mf=%x t=%x l=%u','GDM S00p p=%02x%02x%02x','GDM S05 dc=%x off=%x len=%x fc=%x','GDM S06 st=%x fs=%x ln=%x ck=%x','GDM S08 ret=%d irq=%d in=%x st=%x','GDM S09 st=%x fs=%x ln=%x ck=%x','GDM DONE success=0 target=0/8/20/29/3','P276 280Z q=2']:
+ if m.encode() not in img: raise SystemExit('Phase293 runtime marker missing from Image: '+m)
+print('Phase293 compiled passive GDM audit: PASS')
+PY
+
+python3 scripts/293_apply_gki_dma_done_reference.py --root "$ROOT" --check-only
+
+trap - EXIT
+echo 'Phase293 clean-Phase280 GKI memory-DMA reference build/repack: PASS'


### PR DESCRIPTION
Phase293 reconstructs exact Phase280 and adds only a passive Golden-style recorder for the exact ctrl0 / flags=0x20 / msg.flags=0x8 / type=0x29 / len=3 command. It preserves the normal memory-fetch path, adds no FIFO reroute, no clock recovery, no DSI writes, no waits/recovery, and retains the snapshot through the inherited Phase280 timeout latch. CI must produce an exact 96 MiB boot.img via the established repack chain before hardware testing.