### PR TITLE
Phase 295 R2: isolate dsi_panel_get ENODATA source

### DIFF
--- a/.github/workflows/295-a52-gki-display-probe-enodata.yml
+++ b/.github/workflows/295-a52-gki-display-probe-enodata.yml
@@ -1,0 +1,110 @@
+name: 295 - A52 GKI display probe ENODATA frontier
+run-name: Phase 295 - passive dsi_display_dev_probe ENODATA frontier
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase295-gki-display-probe-enodata-v1
+    paths:
+      - .github/workflows/295-a52-gki-display-probe-enodata.yml
+      - scripts/295_apply_gki_display_probe_enodata.py
+      - scripts/295_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase293-gki-fetch-memory-dma-done-reference-v1
+    paths:
+      - .github/workflows/295-a52-gki-display-probe-enodata.yml
+      - scripts/295_apply_gki_display_probe_enodata.py
+      - scripts/295_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase295-gki-display-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Reconstruct Phase293 and trace display-probe ENODATA frontier
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase295 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build Phase295 passive ENODATA frontier probe
+        run: bash scripts/295_ci_build.sh
+
+      - name: Upload complete Phase295 evidence package
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase295-GKI-DISPLAY-PROBE-ENODATA-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase295-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload flash-ready boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase295-GKI-DISPLAY-PROBE-ENODATA-${{ github.run_number }}-BOOT-IMG
+          path: phase295-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase295-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: phase295-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/295-a52-gki-display-probe-enodata.yml
+++ b/.github/workflows/295-a52-gki-display-probe-enodata.yml
@@ -108,3 +108,5 @@ jobs:
           path: phase295-failure/
           if-no-files-found: warn
           retention-days: 30
+
+# Phase295 branch-trigger refresh: workflow already exists before this push.

--- a/scripts/295_apply_gki_display_probe_enodata.py
+++ b/scripts/295_apply_gki_display_probe_enodata.py
@@ -73,15 +73,23 @@ def patch(text: str) -> str:
 
     before_behavior = behavioral_counts(text)
 
+    display_mark_anchor = (
+        '#include "dsi_parser.h"\n'
+        + REC_INCLUDE
+        + "\n#if defined(CONFIG_DISPLAY_SAMSUNG)\n"
+    )
     text = one(
         text,
-        REC_INCLUDE,
-        REC_INCLUDE + "\n/* " + MARK + "\n"
+        display_mark_anchor,
+        '#include "dsi_parser.h"\n'
+        + REC_INCLUDE
+        + "\n/* " + MARK + "\n"
         " * Passive Phase293 follow-up. The preserved hardware capture proved\n"
         " * dsi_display_dev_probe returns -ENODATA before the target memory-DMA\n"
         " * transaction is admitted. These probes only read existing software\n"
         " * state and append R48/RS48 records through the existing recorder.\n"
-        " */\n",
+        " */\n\n"
+        "#if defined(CONFIG_DISPLAY_SAMSUNG)\n",
         "marker insertion",
     )
 

--- a/scripts/295_apply_gki_display_probe_enodata.py
+++ b/scripts/295_apply_gki_display_probe_enodata.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+DISPLAY = Path("drivers/a52_display/msm/dsi/dsi_display.c")
+CTRL = Path("drivers/a52_display/msm/dsi/dsi_ctrl.c")
+MARK = "A52_PHASE295_DISPLAY_PROBE_ENODATA_V1"
+REC_INCLUDE = "#include <linux/a52_ack_secure_flight_recorder.h>\n"
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"Phase295 {label}: expected exactly 1 anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def behavioral_counts(text: str) -> dict[str, int]:
+    tokens = (
+        "DSI_W32(", "writel(", "writel_relaxed(", "clk_set_rate(",
+        "wait_for_completion", "msleep(", "usleep_range(", "udelay(",
+        "gpio_set_value(", "dsi_ctrl_cmd_transfer(", "dsi_panel_tx_cmd_set(",
+    )
+    return {token: text.count(token) for token in tokens}
+
+
+def verify(text: str) -> None:
+    required = (
+        MARK,
+        'P276 295P s=0 i=%d be=%d pn=%d fr=%d',
+        'P276 295P s=1 rc=%d',
+        'P276 295I s=0',
+        'P276 295I s=1 rc=%d',
+        'P276 295I s=2',
+        'P276 295I s=3 rc=%d',
+        'P276 295D s=0 fw=%d pn=%d',
+        'P276 295D s=1 rc=%d cc=%d',
+        'P276 295D s=2 rc=%d',
+        'P276 295T s=0 cc=%d pc=%u',
+        'P276 295T s=1 i=%d ix=%d n=%d',
+        'P276 295T s=2 i=%d ix=%d n=%d',
+        'P276 295T s=3 rc=%d eb=%d',
+        'P276 295R s=0 i=%d e=%d',
+        'P276 295R s=1 i=%d e=%d',
+        'P276 295R s=2 e=%d',
+        'P276 295R s=3 rc=%d',
+        'P276 295R s=4 rc=%d',
+        'P276 295R s=5 rc=0',
+        'P276 295R s=9 rc=%d i=%d',
+        'P276 295C s=0 n=%d',
+        'P276 295C s=1 i=%d e=%d n=%.24s',
+        'P276 295C s=2 rc=0',
+        'P276 295C s=9 rc=%d',
+    )
+    for marker in required:
+        if text.count(marker) != 1:
+            raise SystemExit(f"Phase295 audit marker count failed: {marker!r}: {text.count(marker)}")
+    if REC_INCLUDE not in text:
+        raise SystemExit("Phase295 recorder include missing")
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        verify(text)
+        return text
+
+    if REC_INCLUDE not in text:
+        raise SystemExit("Phase295 requires inherited display lifecycle recorder include")
+    if 'A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_dev_probe");' not in text:
+        raise SystemExit("Phase295 requires inherited dsi_display_dev_probe lifecycle scope")
+
+    before_behavior = behavioral_counts(text)
+
+    text = one(
+        text,
+        REC_INCLUDE,
+        REC_INCLUDE + "\n/* " + MARK + "\n"
+        " * Passive Phase293 follow-up. The preserved hardware capture proved\n"
+        " * dsi_display_dev_probe returns -ENODATA before the target memory-DMA\n"
+        " * transaction is admitted. These probes only read existing software\n"
+        " * state and append R48/RS48 records through the existing recorder.\n"
+        " */\n",
+        "marker insertion",
+    )
+
+    # dsi_display_dev_probe -> dsi_display_init boundary.
+    old = '''\tplatform_set_drvdata(pdev, display);\n\n\n\t/* initialize display in firmware callback */\n'''
+    new = '''\tplatform_set_drvdata(pdev, display);\n\ta52_ackfr_record("P276 295P s=0 i=%d be=%d pn=%d fr=%d",\n\t\tindex, boot_disp->boot_disp_en, !!panel_node, firm_req);\n\n\n\t/* initialize display in firmware callback */\n'''
+    text = one(text, old, new, "probe pre-init snapshot")
+
+    old = '''\tif (!firm_req) {\n\t\trc = dsi_display_init(display);\n\t\tif (rc)\n\t\t\tgoto end;\n\t}\n'''
+    new = '''\tif (!firm_req) {\n\t\trc = dsi_display_init(display);\n\t\ta52_ackfr_record("P276 295P s=1 rc=%d", rc);\n\t\tif (rc)\n\t\t\tgoto end;\n\t}\n'''
+    text = one(text, old, new, "probe init return")
+
+    # dsi_display_init -> _dev_init -> component_add.
+    old = '''\tmutex_init(&display->display_lock);\n\n\trc = _dsi_display_dev_init(display);\n\tif (rc) {\n'''
+    new = '''\tmutex_init(&display->display_lock);\n\n\ta52_ackfr_record("P276 295I s=0");\n\trc = _dsi_display_dev_init(display);\n\ta52_ackfr_record("P276 295I s=1 rc=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "display init dev-init return")
+
+    old = '''\trc = component_add(&pdev->dev, &dsi_display_comp_ops);\n\tif (rc)\n\t\tDSI_ERR("component add failed, rc=%d\\n", rc);\n'''
+    new = '''\ta52_ackfr_record("P276 295I s=2");\n\trc = component_add(&pdev->dev, &dsi_display_comp_ops);\n\ta52_ackfr_record("P276 295I s=3 rc=%d", rc);\n\tif (rc)\n\t\tDSI_ERR("component add failed, rc=%d\\n", rc);\n'''
+    text = one(text, old, new, "component add return")
+
+    # _dsi_display_dev_init -> parse_dt -> res_init.
+    old = '''\tif (display->fw && display->parser)\n\t\tdisplay->parser_node = dsi_parser_get_head_node(\n\t\t\t\tdisplay->parser, display->fw->data,\n\t\t\t\tdisplay->fw->size);\n\n\trc = dsi_display_parse_dt(display);\n'''
+    new = '''\tif (display->fw && display->parser)\n\t\tdisplay->parser_node = dsi_parser_get_head_node(\n\t\t\t\tdisplay->parser, display->fw->data,\n\t\t\t\tdisplay->fw->size);\n\n\ta52_ackfr_record("P276 295D s=0 fw=%d pn=%d", !!display->fw,\n\t\t!!display->panel_node);\n\trc = dsi_display_parse_dt(display);\n\ta52_ackfr_record("P276 295D s=1 rc=%d cc=%d", rc, display->ctrl_count);\n'''
+    text = one(text, old, new, "dev-init parse return")
+
+    old = '''\trc = dsi_display_res_init(display);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_display_res_init(display);\n\ta52_ackfr_record("P276 295D s=2 rc=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "dev-init resource return")
+
+    # dsi_display_parse_dt: counts and resolved ctrl/phy handles.
+    old = '''\tdisplay->ctrl_count = dsi_display_get_phandle_count(display,\n\t\t\t\t\tdsi_ctrl_name);\n\tphy_count = dsi_display_get_phandle_count(display, dsi_phy_name);\n\n\tDSI_DEBUG("ctrl count=%d, phy count=%d\\n",\n'''
+    new = '''\tdisplay->ctrl_count = dsi_display_get_phandle_count(display,\n\t\t\t\t\tdsi_ctrl_name);\n\tphy_count = dsi_display_get_phandle_count(display, dsi_phy_name);\n\ta52_ackfr_record("P276 295T s=0 cc=%d pc=%u",\n\t\tdisplay->ctrl_count, phy_count);\n\n\tDSI_DEBUG("ctrl count=%d, phy count=%d\\n",\n'''
+    text = one(text, old, new, "dt count snapshot")
+
+    old = '''\t\tctrl->ctrl_of_node = of_parse_phandle(of_node,\n\t\t\t\t"qcom,dsi-ctrl", index);\n\t\tof_node_put(ctrl->ctrl_of_node);\n\n\t\tindex = dsi_display_get_phandle_index(display, dsi_phy_name,\n'''
+    new = '''\t\tctrl->ctrl_of_node = of_parse_phandle(of_node,\n\t\t\t\t"qcom,dsi-ctrl", index);\n\t\tof_node_put(ctrl->ctrl_of_node);\n\t\ta52_ackfr_record("P276 295T s=1 i=%d ix=%d n=%d",\n\t\t\ti, index, !!ctrl->ctrl_of_node);\n\n\t\tindex = dsi_display_get_phandle_index(display, dsi_phy_name,\n'''
+    text = one(text, old, new, "dt controller phandle")
+
+    old = '''\t\tctrl->phy_of_node = of_parse_phandle(of_node,\n\t\t\t\t"qcom,dsi-phy", index);\n\t\tof_node_put(ctrl->phy_of_node);\n\t}\n\n\t/* Parse TE data */\n'''
+    new = '''\t\tctrl->phy_of_node = of_parse_phandle(of_node,\n\t\t\t\t"qcom,dsi-phy", index);\n\t\tof_node_put(ctrl->phy_of_node);\n\t\ta52_ackfr_record("P276 295T s=2 i=%d ix=%d n=%d",\n\t\t\ti, index, !!ctrl->phy_of_node);\n\t}\n\n\t/* Parse TE data */\n'''
+    text = one(text, old, new, "dt phy phandle")
+
+    old = '''\tDSI_DEBUG("success\\n");\nerror:\n\treturn rc;\n}\n\nstatic int dsi_display_res_init(struct dsi_display *display)\n'''
+    new = '''\tDSI_DEBUG("success\\n");\nerror:\n\ta52_ackfr_record("P276 295T s=3 rc=%d eb=%d", rc,\n\t\tdisplay->ext_bridge_cnt);\n\treturn rc;\n}\n\nstatic int dsi_display_res_init(struct dsi_display *display)\n'''
+    text = one(text, old, new, "dt final return")
+
+    # dsi_display_res_init: identify the exact acquisition that propagates rc.
+    old = '''\t\tctrl->ctrl = dsi_ctrl_get(ctrl->ctrl_of_node);\n\t\tif (IS_ERR_OR_NULL(ctrl->ctrl)) {\n'''
+    new = '''\t\tctrl->ctrl = dsi_ctrl_get(ctrl->ctrl_of_node);\n\t\ta52_ackfr_record("P276 295R s=0 i=%d e=%d", i,\n\t\t\tIS_ERR(ctrl->ctrl) ? (int)PTR_ERR(ctrl->ctrl) :\n\t\t\t(ctrl->ctrl ? 0 : -1));\n\t\tif (IS_ERR_OR_NULL(ctrl->ctrl)) {\n'''
+    text = one(text, old, new, "resource controller get")
+
+    old = '''\t\tctrl->phy = dsi_phy_get(ctrl->phy_of_node);\n\t\tif (IS_ERR_OR_NULL(ctrl->phy)) {\n'''
+    new = '''\t\tctrl->phy = dsi_phy_get(ctrl->phy_of_node);\n\t\ta52_ackfr_record("P276 295R s=1 i=%d e=%d", i,\n\t\t\tIS_ERR(ctrl->phy) ? (int)PTR_ERR(ctrl->phy) :\n\t\t\t(ctrl->phy ? 0 : -1));\n\t\tif (IS_ERR_OR_NULL(ctrl->phy)) {\n'''
+    text = one(text, old, new, "resource phy get")
+
+    old = '''\tdisplay->panel = dsi_panel_get(&display->pdev->dev,\n\t\t\t\tdisplay->panel_node,\n\t\t\t\tdisplay->parser_node,\n\t\t\t\tdisplay->display_type,\n\t\t\t\tdisplay->cmdline_topology);\n\tif (IS_ERR_OR_NULL(display->panel)) {\n'''
+    new = '''\tdisplay->panel = dsi_panel_get(&display->pdev->dev,\n\t\t\t\tdisplay->panel_node,\n\t\t\t\tdisplay->parser_node,\n\t\t\t\tdisplay->display_type,\n\t\t\t\tdisplay->cmdline_topology);\n\ta52_ackfr_record("P276 295R s=2 e=%d",\n\t\tIS_ERR(display->panel) ? (int)PTR_ERR(display->panel) :\n\t\t(display->panel ? 0 : -1));\n\tif (IS_ERR_OR_NULL(display->panel)) {\n'''
+    text = one(text, old, new, "resource panel get")
+
+    old = '''\trc = dsi_display_parse_lane_map(display);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_display_parse_lane_map(display);\n\ta52_ackfr_record("P276 295R s=3 rc=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "resource lane map")
+
+    old = '''\trc = dsi_display_clocks_init(display);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_display_clocks_init(display);\n\ta52_ackfr_record("P276 295R s=4 rc=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "resource clocks")
+
+    old = '''\treturn 0;\nerror_ctrl_put:\n\tfor (i = i - 1; i >= 0; i--) {\n'''
+    new = '''\ta52_ackfr_record("P276 295R s=5 rc=0");\n\treturn 0;\nerror_ctrl_put:\n\ta52_ackfr_record("P276 295R s=9 rc=%d i=%d", rc, i);\n\tfor (i = i - 1; i >= 0; i--) {\n'''
+    text = one(text, old, new, "resource final return")
+
+    # dsi_display_clocks_init: enough detail if the resource failure is a clk.
+    old = '''\tnum_clk = dsi_display_get_clocks_count(display, dsi_clock_name);\n\n\tDSI_DEBUG("clk count=%d\\n", num_clk);\n'''
+    new = '''\tnum_clk = dsi_display_get_clocks_count(display, dsi_clock_name);\n\ta52_ackfr_record("P276 295C s=0 n=%d", num_clk);\n\n\tDSI_DEBUG("clk count=%d\\n", num_clk);\n'''
+    text = one(text, old, new, "clock count")
+
+    old = '''\t\tdsi_clk = devm_clk_get(&display->pdev->dev, clk_name);\n\t\tif (IS_ERR_OR_NULL(dsi_clk)) {\n'''
+    new = '''\t\tdsi_clk = devm_clk_get(&display->pdev->dev, clk_name);\n\t\ta52_ackfr_record("P276 295C s=1 i=%d e=%d n=%.24s", i,\n\t\t\tIS_ERR(dsi_clk) ? (int)PTR_ERR(dsi_clk) :\n\t\t\t(dsi_clk ? 0 : -1), clk_name ? clk_name : "null");\n\t\tif (IS_ERR_OR_NULL(dsi_clk)) {\n'''
+    text = one(text, old, new, "clock acquisition")
+
+    old = '''\treturn 0;\nerror:\n\t(void)dsi_display_clocks_deinit(display);\n\treturn rc;\n}\n\nstatic int dsi_display_clk_ctrl_cb'''
+    new = '''\ta52_ackfr_record("P276 295C s=2 rc=0");\n\treturn 0;\nerror:\n\ta52_ackfr_record("P276 295C s=9 rc=%d", rc);\n\t(void)dsi_display_clocks_deinit(display);\n\treturn rc;\n}\n\nstatic int dsi_display_clk_ctrl_cb'''
+    text = one(text, old, new, "clock final return")
+
+    after_behavior = behavioral_counts(text)
+    if before_behavior != after_behavior:
+        raise SystemExit(
+            "Phase295 refuses functional display changes; behavioral token counts changed: "
+            f"before={before_behavior} after={after_behavior}"
+        )
+
+    verify(text)
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--check-only", action="store_true")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    display_path = root / DISPLAY
+    ctrl_path = root / CTRL
+    if not display_path.is_file() or not ctrl_path.is_file():
+        raise SystemExit("Phase295 active A52 display source missing")
+    ctrl = ctrl_path.read_text(encoding="utf-8", errors="strict")
+    if "A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1" not in ctrl:
+        raise SystemExit("Phase295 requires reconstructed Phase293 controller source")
+
+    original = display_path.read_text(encoding="utf-8", errors="strict")
+    if args.check_only:
+        verify(original)
+        print("Phase295 passive display-probe ENODATA audit: PASS")
+        return 0
+
+    patched = patch(original)
+    if patched == original:
+        raise SystemExit("Phase295 patch unexpectedly made no change")
+    display_path.write_text(patched, encoding="utf-8")
+    print("Phase295 passive display-probe ENODATA instrumentation staged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/295_apply_gki_display_probe_enodata.py
+++ b/scripts/295_apply_gki_display_probe_enodata.py
@@ -5,8 +5,10 @@ import argparse
 from pathlib import Path
 
 DISPLAY = Path("drivers/a52_display/msm/dsi/dsi_display.c")
+PANEL = Path("drivers/a52_display/msm/dsi/dsi_panel.c")
 CTRL = Path("drivers/a52_display/msm/dsi/dsi_ctrl.c")
 MARK = "A52_PHASE295_DISPLAY_PROBE_ENODATA_V1"
+PANEL_MARK = "A52_PHASE295_PANEL_GET_ENODATA_R2"
 REC_INCLUDE = "#include <linux/a52_ack_secure_flight_recorder.h>\n"
 
 
@@ -93,7 +95,6 @@ def patch(text: str) -> str:
         "marker insertion",
     )
 
-    # dsi_display_dev_probe -> dsi_display_init boundary.
     old = '''\tplatform_set_drvdata(pdev, display);\n\n\n\t/* initialize display in firmware callback */\n'''
     new = '''\tplatform_set_drvdata(pdev, display);\n\ta52_ackfr_record("P276 295P s=0 i=%d be=%d pn=%d fr=%d",\n\t\tindex, boot_disp->boot_disp_en, !!panel_node, firm_req);\n\n\n\t/* initialize display in firmware callback */\n'''
     text = one(text, old, new, "probe pre-init snapshot")
@@ -102,25 +103,22 @@ def patch(text: str) -> str:
     new = '''\tif (!firm_req) {\n\t\trc = dsi_display_init(display);\n\t\ta52_ackfr_record("P276 295P s=1 rc=%d", rc);\n\t\tif (rc)\n\t\t\tgoto end;\n\t}\n'''
     text = one(text, old, new, "probe init return")
 
-    # dsi_display_init -> _dev_init -> component_add.
     old = '''\tmutex_init(&display->display_lock);\n\n\trc = _dsi_display_dev_init(display);\n\tif (rc) {\n'''
     new = '''\tmutex_init(&display->display_lock);\n\n\ta52_ackfr_record("P276 295I s=0");\n\trc = _dsi_display_dev_init(display);\n\ta52_ackfr_record("P276 295I s=1 rc=%d", rc);\n\tif (rc) {\n'''
     text = one(text, old, new, "display init dev-init return")
 
-    old = '''\trc = component_add(&pdev->dev, &dsi_display_comp_ops);\n\tif (rc)\n\t\tDSI_ERR("component add failed, rc=%d\\n", rc);\n'''
-    new = '''\ta52_ackfr_record("P276 295I s=2");\n\trc = component_add(&pdev->dev, &dsi_display_comp_ops);\n\ta52_ackfr_record("P276 295I s=3 rc=%d", rc);\n\tif (rc)\n\t\tDSI_ERR("component add failed, rc=%d\\n", rc);\n'''
+    old = '''\ta52_ackfr_record("DRMCOMP component-add enter dev=%s display=%s",\n\t\t\t dev_name(&pdev->dev), display->name ? display->name : "-");\n\trc = component_add(&pdev->dev, &dsi_display_comp_ops);\n\ta52_ackfr_record("DRMCOMP component-add exit dev=%s rc=%d",\n\t\t\t dev_name(&pdev->dev), rc);\n\tif (rc)\n\t\tDSI_ERR("component add failed, rc=%d\\n", rc);\n'''
+    new = '''\ta52_ackfr_record("DRMCOMP component-add enter dev=%s display=%s",\n\t\t\t dev_name(&pdev->dev), display->name ? display->name : "-");\n\ta52_ackfr_record("P276 295I s=2");\n\trc = component_add(&pdev->dev, &dsi_display_comp_ops);\n\ta52_ackfr_record("DRMCOMP component-add exit dev=%s rc=%d",\n\t\t\t dev_name(&pdev->dev), rc);\n\ta52_ackfr_record("P276 295I s=3 rc=%d", rc);\n\tif (rc)\n\t\tDSI_ERR("component add failed, rc=%d\\n", rc);\n'''
     text = one(text, old, new, "component add return")
 
-    # _dsi_display_dev_init -> parse_dt -> res_init.
     old = '''\tif (display->fw && display->parser)\n\t\tdisplay->parser_node = dsi_parser_get_head_node(\n\t\t\t\tdisplay->parser, display->fw->data,\n\t\t\t\tdisplay->fw->size);\n\n\trc = dsi_display_parse_dt(display);\n'''
     new = '''\tif (display->fw && display->parser)\n\t\tdisplay->parser_node = dsi_parser_get_head_node(\n\t\t\t\tdisplay->parser, display->fw->data,\n\t\t\t\tdisplay->fw->size);\n\n\ta52_ackfr_record("P276 295D s=0 fw=%d pn=%d", !!display->fw,\n\t\t!!display->panel_node);\n\trc = dsi_display_parse_dt(display);\n\ta52_ackfr_record("P276 295D s=1 rc=%d cc=%d", rc, display->ctrl_count);\n'''
     text = one(text, old, new, "dev-init parse return")
 
-    old = '''\trc = dsi_display_res_init(display);\n\tif (rc) {\n'''
-    new = '''\trc = dsi_display_res_init(display);\n\ta52_ackfr_record("P276 295D s=2 rc=%d", rc);\n\tif (rc) {\n'''
+    old = '''\trc = dsi_display_res_init(display);\n\ta52_ackfr_record("DISP DEV res rc=%d cmd=%u clk=%u", rc,\n\t\tdisplay->cmd_master_idx, display->clk_master_idx);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_display_res_init(display);\n\ta52_ackfr_record("DISP DEV res rc=%d cmd=%u clk=%u", rc,\n\t\tdisplay->cmd_master_idx, display->clk_master_idx);\n\ta52_ackfr_record("P276 295D s=2 rc=%d", rc);\n\tif (rc) {\n'''
     text = one(text, old, new, "dev-init resource return")
 
-    # dsi_display_parse_dt: counts and resolved ctrl/phy handles.
     old = '''\tdisplay->ctrl_count = dsi_display_get_phandle_count(display,\n\t\t\t\t\tdsi_ctrl_name);\n\tphy_count = dsi_display_get_phandle_count(display, dsi_phy_name);\n\n\tDSI_DEBUG("ctrl count=%d, phy count=%d\\n",\n'''
     new = '''\tdisplay->ctrl_count = dsi_display_get_phandle_count(display,\n\t\t\t\t\tdsi_ctrl_name);\n\tphy_count = dsi_display_get_phandle_count(display, dsi_phy_name);\n\ta52_ackfr_record("P276 295T s=0 cc=%d pc=%u",\n\t\tdisplay->ctrl_count, phy_count);\n\n\tDSI_DEBUG("ctrl count=%d, phy count=%d\\n",\n'''
     text = one(text, old, new, "dt count snapshot")
@@ -137,7 +135,6 @@ def patch(text: str) -> str:
     new = '''\tDSI_DEBUG("success\\n");\nerror:\n\ta52_ackfr_record("P276 295T s=3 rc=%d eb=%d", rc,\n\t\tdisplay->ext_bridge_cnt);\n\treturn rc;\n}\n\nstatic int dsi_display_res_init(struct dsi_display *display)\n'''
     text = one(text, old, new, "dt final return")
 
-    # dsi_display_res_init: identify the exact acquisition that propagates rc.
     old = '''\t\tctrl->ctrl = dsi_ctrl_get(ctrl->ctrl_of_node);\n\t\tif (IS_ERR_OR_NULL(ctrl->ctrl)) {\n'''
     new = '''\t\tctrl->ctrl = dsi_ctrl_get(ctrl->ctrl_of_node);\n\t\ta52_ackfr_record("P276 295R s=0 i=%d e=%d", i,\n\t\t\tIS_ERR(ctrl->ctrl) ? (int)PTR_ERR(ctrl->ctrl) :\n\t\t\t(ctrl->ctrl ? 0 : -1));\n\t\tif (IS_ERR_OR_NULL(ctrl->ctrl)) {\n'''
     text = one(text, old, new, "resource controller get")
@@ -162,7 +159,6 @@ def patch(text: str) -> str:
     new = '''\ta52_ackfr_record("P276 295R s=5 rc=0");\n\treturn 0;\nerror_ctrl_put:\n\ta52_ackfr_record("P276 295R s=9 rc=%d i=%d", rc, i);\n\tfor (i = i - 1; i >= 0; i--) {\n'''
     text = one(text, old, new, "resource final return")
 
-    # dsi_display_clocks_init: enough detail if the resource failure is a clk.
     old = '''\tnum_clk = dsi_display_get_clocks_count(display, dsi_clock_name);\n\n\tDSI_DEBUG("clk count=%d\\n", num_clk);\n'''
     new = '''\tnum_clk = dsi_display_get_clocks_count(display, dsi_clock_name);\n\ta52_ackfr_record("P276 295C s=0 n=%d", num_clk);\n\n\tDSI_DEBUG("clk count=%d\\n", num_clk);\n'''
     text = one(text, old, new, "clock count")
@@ -186,6 +182,84 @@ def patch(text: str) -> str:
     return text
 
 
+def verify_panel(text: str) -> None:
+    required = (
+        PANEL_MARK,
+        'P276 295G s=0 pr=%d bp=%d bl=%d br=%d bv=%u',
+        'P276 295G s=1 tp=%d tl=%d tr=%d tv=%u',
+        'P276 295G s=2 host=%d',
+        'P276 295G s=3 mode=%d pm=%d',
+        'P276 295G s=4 phy=%d',
+        'P276 295G s=5 gpio=%d',
+        'P276 295G s=6 modes=%d n=%d',
+        'P276 295G s=7 ok=1',
+        'P276 295G s=9 rc=%d',
+    )
+    for marker in required:
+        if text.count(marker) != 1:
+            raise SystemExit(
+                f"Phase295 panel audit marker count failed: {marker!r}: "
+                f"{text.count(marker)}"
+            )
+    if REC_INCLUDE not in text:
+        raise SystemExit("Phase295 panel recorder include missing")
+
+
+def patch_panel(text: str) -> str:
+    if PANEL_MARK in text:
+        verify_panel(text)
+        return text
+
+    if REC_INCLUDE not in text:
+        raise SystemExit("Phase295 requires inherited dsi_panel recorder include")
+    if 'A52_ACKFR_SCOPE("DISP", "a52.life.dsi_panel_get");' not in text:
+        raise SystemExit("Phase295 requires inherited dsi_panel_get lifecycle scope")
+
+    before_behavior = behavioral_counts(text)
+
+    signature = '''struct dsi_panel *dsi_panel_get(struct device *parent,\n\t\t\t\tstruct device_node *of_node,\n\t\t\t\tstruct device_node *parser_node,\n\t\t\t\tconst char *type,\n\t\t\t\tint topology_override)\n'''
+    helper = '''/* A52_PHASE295_PANEL_GET_ENODATA_R2\n * Passive active-parser witness for the dsi_panel_get() -ENODATA frontier.\n * Reads only parser metadata/properties and records them in the preserved\n * flight recorder. No panel, command, GPIO, regulator, clock or timing state\n * is changed.\n */\nstatic void a52_phase295_probe_parser(struct dsi_parser_utils *utils,\n\t\t\t\t      bool parser_node)\n{\n\tstruct property *prop;\n\tu32 value = 0;\n\tint len = -1;\n\tint rc;\n\n\tprop = utils->find_property(utils->data, "qcom,mdss-dsi-bpp", &len);\n\trc = utils->read_u32(utils->data, "qcom,mdss-dsi-bpp", &value);\n\ta52_ackfr_record("P276 295G s=0 pr=%d bp=%d bl=%d br=%d bv=%u",\n\t\tparser_node, !!prop, len, rc, rc ? 0 : value);\n\n\tprop = NULL;\n\tvalue = 0;\n\tlen = -1;\n\tprop = utils->find_property(utils->data,\n\t\t\t"qcom,mdss-dsi-te-dcs-command", &len);\n\trc = utils->read_u32(utils->data,\n\t\t\t"qcom,mdss-dsi-te-dcs-command", &value);\n\ta52_ackfr_record("P276 295G s=1 tp=%d tl=%d tr=%d tv=%u",\n\t\t!!prop, len, rc, rc ? 0 : value);\n}\n\n'''
+    text = one(text, signature, helper + signature, "panel helper insertion")
+
+    old = '''\tdsi_panel_update_util(panel, parser_node);\n\tutils = &panel->utils;\n\n\tpanel->name = utils->get_property(utils->data,\n'''
+    new = '''\tdsi_panel_update_util(panel, parser_node);\n\tutils = &panel->utils;\n\ta52_phase295_probe_parser(utils, !!parser_node);\n\n\tpanel->name = utils->get_property(utils->data,\n'''
+    text = one(text, old, new, "active parser witness")
+
+    old = '''\trc = dsi_panel_parse_host_config(panel);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_panel_parse_host_config(panel);\n\ta52_ackfr_record("P276 295G s=2 host=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "host config return")
+
+    old = '''\trc = dsi_panel_parse_panel_mode(panel);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_panel_parse_panel_mode(panel);\n\ta52_ackfr_record("P276 295G s=3 mode=%d pm=%d", rc, panel->panel_mode);\n\tif (rc) {\n'''
+    text = one(text, old, new, "panel mode return")
+
+    old = '''\trc = dsi_panel_parse_phy_props(panel);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_panel_parse_phy_props(panel);\n\ta52_ackfr_record("P276 295G s=4 phy=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "phy props return")
+
+    old = '''\trc = dsi_panel_parse_gpios(panel);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_panel_parse_gpios(panel);\n\ta52_ackfr_record("P276 295G s=5 gpio=%d", rc);\n\tif (rc) {\n'''
+    text = one(text, old, new, "gpio parse return")
+
+    old = '''\trc = dsi_panel_get_mode_count(panel);\n\tif (rc) {\n'''
+    new = '''\trc = dsi_panel_get_mode_count(panel);\n\ta52_ackfr_record("P276 295G s=6 modes=%d n=%d",\n\t\trc, panel->num_display_modes);\n\tif (rc) {\n'''
+    text = one(text, old, new, "mode count return")
+
+    old = '''\tmutex_init(&panel->panel_lock);\n\n\treturn panel;\nerror:\n\tkfree(panel);\n\treturn ERR_PTR(rc);\n}\n'''
+    new = '''\tmutex_init(&panel->panel_lock);\n\n\ta52_ackfr_record("P276 295G s=7 ok=1");\n\treturn panel;\nerror:\n\ta52_ackfr_record("P276 295G s=9 rc=%d", rc);\n\tkfree(panel);\n\treturn ERR_PTR(rc);\n}\n'''
+    text = one(text, old, new, "panel final return")
+
+    after_behavior = behavioral_counts(text)
+    if before_behavior != after_behavior:
+        raise SystemExit(
+            "Phase295 refuses functional panel changes; behavioral token counts changed: "
+            f"before={before_behavior} after={after_behavior}"
+        )
+
+    verify_panel(text)
+    return text
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path, required=True)
@@ -194,24 +268,36 @@ def main() -> int:
 
     root = args.root.resolve()
     display_path = root / DISPLAY
+    panel_path = root / PANEL
     ctrl_path = root / CTRL
-    if not display_path.is_file() or not ctrl_path.is_file():
+    if (not display_path.is_file() or not panel_path.is_file()
+            or not ctrl_path.is_file()):
         raise SystemExit("Phase295 active A52 display source missing")
+
     ctrl = ctrl_path.read_text(encoding="utf-8", errors="strict")
     if "A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1" not in ctrl:
         raise SystemExit("Phase295 requires reconstructed Phase293 controller source")
 
-    original = display_path.read_text(encoding="utf-8", errors="strict")
+    display_original = display_path.read_text(encoding="utf-8", errors="strict")
+    panel_original = panel_path.read_text(encoding="utf-8", errors="strict")
+
     if args.check_only:
-        verify(original)
-        print("Phase295 passive display-probe ENODATA audit: PASS")
+        verify(display_original)
+        verify_panel(panel_original)
+        print("Phase295 R2 display/panel ENODATA audit: PASS")
         return 0
 
-    patched = patch(original)
-    if patched == original:
-        raise SystemExit("Phase295 patch unexpectedly made no change")
-    display_path.write_text(patched, encoding="utf-8")
-    print("Phase295 passive display-probe ENODATA instrumentation staged")
+    display_patched = patch(display_original)
+    panel_patched = patch_panel(panel_original)
+
+    if display_patched == display_original:
+        raise SystemExit("Phase295 display patch unexpectedly made no change")
+    if panel_patched == panel_original:
+        raise SystemExit("Phase295 panel patch unexpectedly made no change")
+
+    display_path.write_text(display_patched, encoding="utf-8")
+    panel_path.write_text(panel_patched, encoding="utf-8")
+    print("Phase295 R2 display/panel ENODATA instrumentation staged")
     return 0
 
 

--- a/scripts/295_ci_build.sh
+++ b/scripts/295_ci_build.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 ROOT="$PWD/gki/common"
 OUT="$PWD/workspace/gki-phase199-out"
 DISPLAY="$ROOT/drivers/a52_display/msm/dsi/dsi_display.c"
+PANEL="$ROOT/drivers/a52_display/msm/dsi/dsi_panel.c"
 CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
 HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
 REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
@@ -13,28 +14,31 @@ fail_report() {
   rm -rf phase295-failure
   mkdir -p phase295-failure/{source,logs,audit}
   cp phase295-compile.log phase295-failure/logs/ 2>/dev/null || true
-  for f in "$DISPLAY" "$CTRL" "$HW" "$REC"; do
+  for f in "$DISPLAY" "$PANEL" "$CTRL" "$HW" "$REC"; do
     [ -f "$f" ] && cp "$f" phase295-failure/source/ || true
   done
   cp scripts/295_apply_gki_display_probe_enodata.py phase295-failure/audit/ 2>/dev/null || true
 }
 trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
 
-# Reconstruct the exact successful Phase293 software image first. Phase295 is
-# observation-only and changes only dsi_display.c after that reconstruction.
+# Reconstruct the exact successful Phase293 software image first. Phase295 R2
+# is observation-only and changes only dsi_display.c and dsi_panel.c after
+# that reconstruction.
 bash scripts/293_ci_build.sh
 
 test -s phase293-out/package/boot.img
 test "$(stat -c '%s' phase293-out/package/boot.img)" -eq 100663296
 test -s "$OUT/arch/arm64/boot/Image"
-for f in "$DISPLAY" "$CTRL" "$HW" "$REC"; do test -s "$f"; done
+for f in "$DISPLAY" "$PANEL" "$CTRL" "$HW" "$REC"; do test -s "$f"; done
 
 grep -Fq 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' "$CTRL"
 grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$CTRL"
 grep -Fq 'A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_dev_probe");' "$DISPLAY"
+grep -Fq 'A52_ACKFR_SCOPE("DISP", "a52.life.dsi_panel_get");' "$PANEL"
 
 cp "$OUT/.config" /tmp/p295-base.config
 cp "$DISPLAY" /tmp/p295-display-before.c
+cp "$PANEL" /tmp/p295-panel-before.c
 cp "$CTRL" /tmp/p295-ctrl-before.c
 cp "$HW" /tmp/p295-hw-before.c
 cp "$REC" /tmp/p295-rec-before.c
@@ -43,9 +47,11 @@ python3 -m py_compile scripts/295_apply_gki_display_probe_enodata.py
 python3 scripts/295_apply_gki_display_probe_enodata.py --root "$ROOT"
 python3 scripts/295_apply_gki_display_probe_enodata.py --root "$ROOT" --check-only
 
-# Phase295 may modify only dsi_display.c. The Phase293 controller/HW recorder,
-# timeout-retention backend, and kernel config remain byte-for-byte identical.
+# Phase295 R2 may modify only dsi_display.c and dsi_panel.c. The Phase293
+# controller/HW recorder, timeout-retention backend, and kernel config remain
+# byte-for-byte identical.
 ! cmp -s /tmp/p295-display-before.c "$DISPLAY"
+! cmp -s /tmp/p295-panel-before.c "$PANEL"
 cmp -s /tmp/p295-ctrl-before.c "$CTRL"
 cmp -s /tmp/p295-hw-before.c "$HW"
 cmp -s /tmp/p295-rec-before.c "$REC"
@@ -56,7 +62,7 @@ for marker in \
   'A52_PHASE282' \
   'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1' \
   'A52_PHASE292_DSI_CHAIN_TAPS_V1'; do
-  if grep -Fq "$marker" "$DISPLAY"; then
+  if grep -Fq "$marker" "$DISPLAY" || grep -Fq "$marker" "$PANEL"; then
     echo "Phase295 refuses unrelated display behavior: $marker" >&2
     exit 1
   fi
@@ -80,12 +86,14 @@ cp "$IMAGE" phase295-out/compile/Image
 cp "$OUT/.config" phase295-out/config/final.config
 cp /tmp/p295-base.config phase295-out/audit/phase293-final.config
 cp /tmp/p295-display-before.c phase295-out/audit/dsi-display-before.c
+cp /tmp/p295-panel-before.c phase295-out/audit/dsi-panel-before.c
 cp /tmp/p295-ctrl-before.c phase295-out/audit/dsi-ctrl-before.c
 cp /tmp/p295-hw-before.c phase295-out/audit/dsi-ctrl-hw-before.c
 cp /tmp/p295-rec-before.c phase295-out/audit/recorder-before.c
 cp phase295-compile.log phase295-out/audit/
 cp scripts/295_apply_gki_display_probe_enodata.py phase295-out/audit/
 cp "$DISPLAY" phase295-out/source/dsi_display.c
+cp "$PANEL" phase295-out/source/dsi_panel.c
 cp "$CTRL" phase295-out/source/dsi_ctrl.c
 cp "$HW" phase295-out/source/dsi_ctrl_hw_cmn.c
 cp "$REC" phase295-out/source/a52_ack_secure_flight_recorder.c
@@ -108,7 +116,8 @@ from pathlib import Path
 out = Path('phase295-out')
 identity = {
     'phase': 295,
-    'name': 'GKI-DISPLAY-PROBE-ENODATA-FRONTIER',
+    'revision': 'R2',
+    'name': 'GKI-PANEL-GET-ENODATA-FRONTIER',
     'git_sha': os.getenv('GITHUB_SHA'),
     'run_id': os.getenv('GITHUB_RUN_ID'),
     'hardware_validated': False,
@@ -140,19 +149,22 @@ identity = {
         '295T': 'parse_dt controller/PHY counts and phandle resolution',
         '295R': 'resource init: dsi_ctrl_get, dsi_phy_get, dsi_panel_get, lane-map and clocks',
         '295C': 'clock count and individual devm_clk_get results',
+        '295G': 'dsi_panel_get active parser property witnesses and fatal parse-stage returns',
     },
-    'hardware_question': 'Which exact dsi_display_dev_probe subcall first produces the preserved -ENODATA before Phase293 can reach the target memory-DMA transaction?',
+    'hardware_question': 'Inside dsi_panel_get, which active-parser property or fatal parse stage first produces the preserved -ENODATA?',
 }
 (out / 'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True) + '\n')
 
 files = [
     'compile/Image', 'config/final.config', 'package/Image.gz', 'package/boot.img',
     'package/repack-report.json', 'audit/phase293-final.config',
-    'audit/dsi-display-before.c', 'audit/dsi-ctrl-before.c',
-    'audit/dsi-ctrl-hw-before.c', 'audit/recorder-before.c',
-    'audit/phase295-compile.log', 'audit/295_apply_gki_display_probe_enodata.py',
-    'source/dsi_display.c', 'source/dsi_ctrl.c', 'source/dsi_ctrl_hw_cmn.c',
-    'source/a52_ack_secure_flight_recorder.c', 'BUILD-IDENTITY.json',
+    'audit/dsi-display-before.c', 'audit/dsi-panel-before.c',
+    'audit/dsi-ctrl-before.c', 'audit/dsi-ctrl-hw-before.c',
+    'audit/recorder-before.c', 'audit/phase295-compile.log',
+    'audit/295_apply_gki_display_probe_enodata.py',
+    'source/dsi_display.c', 'source/dsi_panel.c', 'source/dsi_ctrl.c',
+    'source/dsi_ctrl_hw_cmn.c', 'source/a52_ack_secure_flight_recorder.c',
+    'BUILD-IDENTITY.json',
 ]
 with (out / 'SHA256SUMS').open('w') as handle:
     for name in files:
@@ -165,9 +177,11 @@ python3 - <<'PY'
 from pathlib import Path
 
 root = Path('phase295-out')
-src = (root / 'source/dsi_display.c').read_text()
+display = (root / 'source/dsi_display.c').read_text()
+panel = (root / 'source/dsi_panel.c').read_text()
 img = (root / 'compile/Image').read_bytes()
-required = [
+
+display_required = [
     'A52_PHASE295_DISPLAY_PROBE_ENODATA_V1',
     'P276 295P s=0 i=%d be=%d pn=%d fr=%d',
     'P276 295P s=1 rc=%d',
@@ -185,26 +199,49 @@ required = [
     'P276 295C s=1 i=%d e=%d n=%.24s',
     'P276 295C s=9 rc=%d',
 ]
-for marker in required:
-    if marker not in src:
-        raise SystemExit('Phase295 source marker missing: ' + marker)
-for marker in required[1:]:
+panel_required = [
+    'A52_PHASE295_PANEL_GET_ENODATA_R2',
+    'P276 295G s=0 pr=%d bp=%d bl=%d br=%d bv=%u',
+    'P276 295G s=1 tp=%d tl=%d tr=%d tv=%u',
+    'P276 295G s=2 host=%d',
+    'P276 295G s=3 mode=%d pm=%d',
+    'P276 295G s=4 phy=%d',
+    'P276 295G s=5 gpio=%d',
+    'P276 295G s=6 modes=%d n=%d',
+    'P276 295G s=7 ok=1',
+    'P276 295G s=9 rc=%d',
+]
+
+for marker in display_required:
+    if marker not in display:
+        raise SystemExit('Phase295 display source marker missing: ' + marker)
+for marker in panel_required:
+    if marker not in panel:
+        raise SystemExit('Phase295 panel source marker missing: ' + marker)
+for marker in display_required[1:] + panel_required[1:]:
     if marker.encode() not in img:
         raise SystemExit('Phase295 runtime marker missing from Image: ' + marker)
 
-before = (root / 'audit/dsi-display-before.c').read_text()
 behavior = [
     'DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
     'wait_for_completion', 'msleep(', 'usleep_range(', 'udelay(',
     'gpio_set_value(', 'dsi_ctrl_cmd_transfer(', 'dsi_panel_tx_cmd_set(',
 ]
-for token in behavior:
-    if before.count(token) != src.count(token):
-        raise SystemExit(f'Phase295 functional token changed: {token}: {before.count(token)} -> {src.count(token)}')
-print('Phase295 compiled passive ENODATA frontier audit: PASS')
+for before_name, after_text, label in [
+    ('audit/dsi-display-before.c', display, 'display'),
+    ('audit/dsi-panel-before.c', panel, 'panel'),
+]:
+    before = (root / before_name).read_text()
+    for token in behavior:
+        if before.count(token) != after_text.count(token):
+            raise SystemExit(
+                f'Phase295 functional {label} token changed: {token}: '
+                f'{before.count(token)} -> {after_text.count(token)}'
+            )
+print('Phase295 R2 compiled passive panel-get ENODATA frontier audit: PASS')
 PY
 
 python3 scripts/295_apply_gki_display_probe_enodata.py --root "$ROOT" --check-only
 
 trap - EXIT
-echo 'Phase295 passive display-probe ENODATA build/repack: PASS'
+echo 'Phase295 R2 passive panel-get ENODATA build/repack: PASS'

--- a/scripts/295_ci_build.sh
+++ b/scripts/295_ci_build.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+DISPLAY="$ROOT/drivers/a52_display/msm/dsi/dsi_display.c"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase295-failure
+  mkdir -p phase295-failure/{source,logs,audit}
+  cp phase295-compile.log phase295-failure/logs/ 2>/dev/null || true
+  for f in "$DISPLAY" "$CTRL" "$HW" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase295-failure/source/ || true
+  done
+  cp scripts/295_apply_gki_display_probe_enodata.py phase295-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact successful Phase293 software image first. Phase295 is
+# observation-only and changes only dsi_display.c after that reconstruction.
+bash scripts/293_ci_build.sh
+
+test -s phase293-out/package/boot.img
+test "$(stat -c '%s' phase293-out/package/boot.img)" -eq 100663296
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$DISPLAY" "$CTRL" "$HW" "$REC"; do test -s "$f"; done
+
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' "$CTRL"
+grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$CTRL"
+grep -Fq 'A52_ACKFR_SCOPE("DISP", "a52.life.dsi_display_dev_probe");' "$DISPLAY"
+
+cp "$OUT/.config" /tmp/p295-base.config
+cp "$DISPLAY" /tmp/p295-display-before.c
+cp "$CTRL" /tmp/p295-ctrl-before.c
+cp "$HW" /tmp/p295-hw-before.c
+cp "$REC" /tmp/p295-rec-before.c
+
+python3 -m py_compile scripts/295_apply_gki_display_probe_enodata.py
+python3 scripts/295_apply_gki_display_probe_enodata.py --root "$ROOT"
+python3 scripts/295_apply_gki_display_probe_enodata.py --root "$ROOT" --check-only
+
+# Phase295 may modify only dsi_display.c. The Phase293 controller/HW recorder,
+# timeout-retention backend, and kernel config remain byte-for-byte identical.
+! cmp -s /tmp/p295-display-before.c "$DISPLAY"
+cmp -s /tmp/p295-ctrl-before.c "$CTRL"
+cmp -s /tmp/p295-hw-before.c "$HW"
+cmp -s /tmp/p295-rec-before.c "$REC"
+
+# Refuse any accidental display behavior experiment.
+for marker in \
+  'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1' \
+  'A52_PHASE282' \
+  'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1' \
+  'A52_PHASE292_DSI_CHAIN_TAPS_V1'; do
+  if grep -Fq "$marker" "$DISPLAY"; then
+    echo "Phase295 refuses unrelated display behavior: $marker" >&2
+    exit 1
+  fi
+done
+
+# Preserve exact Phase293 configuration.
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p295-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase295-compile.log
+
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf phase295-out
+mkdir -p phase295-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase295-out/compile/Image
+cp "$OUT/.config" phase295-out/config/final.config
+cp /tmp/p295-base.config phase295-out/audit/phase293-final.config
+cp /tmp/p295-display-before.c phase295-out/audit/dsi-display-before.c
+cp /tmp/p295-ctrl-before.c phase295-out/audit/dsi-ctrl-before.c
+cp /tmp/p295-hw-before.c phase295-out/audit/dsi-ctrl-hw-before.c
+cp /tmp/p295-rec-before.c phase295-out/audit/recorder-before.c
+cp phase295-compile.log phase295-out/audit/
+cp scripts/295_apply_gki_display_probe_enodata.py phase295-out/audit/
+cp "$DISPLAY" phase295-out/source/dsi_display.c
+cp "$CTRL" phase295-out/source/dsi_ctrl.c
+cp "$HW" phase295-out/source/dsi_ctrl_hw_cmn.c
+cp "$REC" phase295-out/source/a52_ack_secure_flight_recorder.c
+
+gzip -n -c "$IMAGE" > phase295-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase293-out/package/boot.img \
+  --kernel phase295-out/package/Image.gz \
+  --output phase295-out/package/boot.img \
+  --report phase295-out/package/repack-report.json
+
+test "$(stat -c '%s' phase295-out/package/boot.img)" -eq 100663296
+
+python3 - <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+
+out = Path('phase295-out')
+identity = {
+    'phase': 295,
+    'name': 'GKI-DISPLAY-PROBE-ENODATA-FRONTIER',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'run_id': os.getenv('GITHUB_RUN_ID'),
+    'hardware_validated': False,
+    'base': 'exact successful Phase293 reconstruction',
+    'functional_change': 'instrumentation-only',
+    'display_control_flow_changed': False,
+    'panel_packets_changed': False,
+    'dsi_register_writes_added': False,
+    'clock_changes_added': False,
+    'waits_or_delays_added': False,
+    'reset_or_recovery_added': False,
+    'recorder_transport': 'existing R48/RS48; Phase295 records intentionally use admitted P276 prefix',
+    'hardware_evidence_20260821': {
+        'preserved_raw_sha256': '3bde7a6b9d3c91ca7249c868fee056b85df4ccda2b596087b5593342b6913f48',
+        'raw_snapshot_bytes': 1048576,
+        'crc32c_valid_unique_records': 1027,
+        'sequence_range': '982..2028',
+        'phase293_gdm_records': 0,
+        'phase276_deep_target_records': 0,
+        'display_probe_exit_rc': -61,
+        'display_probe_exit_errno': 'ENODATA',
+        'display_probe_failure_monotonic_ms': 'about 17827.7',
+        'finding': 'GKI exits dsi_display_dev_probe with -ENODATA before the Phase293 FETCH_MEMORY transaction is admitted.',
+    },
+    'trace_schema': {
+        '295P': 'dsi_display_dev_probe boundary and dsi_display_init return',
+        '295I': 'dsi_display_init: _dev_init and component_add returns',
+        '295D': '_dsi_display_dev_init: parse_dt and resource-init returns',
+        '295T': 'parse_dt controller/PHY counts and phandle resolution',
+        '295R': 'resource init: dsi_ctrl_get, dsi_phy_get, dsi_panel_get, lane-map and clocks',
+        '295C': 'clock count and individual devm_clk_get results',
+    },
+    'hardware_question': 'Which exact dsi_display_dev_probe subcall first produces the preserved -ENODATA before Phase293 can reach the target memory-DMA transaction?',
+}
+(out / 'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True) + '\n')
+
+files = [
+    'compile/Image', 'config/final.config', 'package/Image.gz', 'package/boot.img',
+    'package/repack-report.json', 'audit/phase293-final.config',
+    'audit/dsi-display-before.c', 'audit/dsi-ctrl-before.c',
+    'audit/dsi-ctrl-hw-before.c', 'audit/recorder-before.c',
+    'audit/phase295-compile.log', 'audit/295_apply_gki_display_probe_enodata.py',
+    'source/dsi_display.c', 'source/dsi_ctrl.c', 'source/dsi_ctrl_hw_cmn.c',
+    'source/a52_ack_secure_flight_recorder.c', 'BUILD-IDENTITY.json',
+]
+with (out / 'SHA256SUMS').open('w') as handle:
+    for name in files:
+        path = out / name
+        handle.write(hashlib.sha256(path.read_bytes()).hexdigest() + '  ./' + name + '\n')
+PY
+(cd phase295-out && sha256sum -c SHA256SUMS)
+
+python3 - <<'PY'
+from pathlib import Path
+
+root = Path('phase295-out')
+src = (root / 'source/dsi_display.c').read_text()
+img = (root / 'compile/Image').read_bytes()
+required = [
+    'A52_PHASE295_DISPLAY_PROBE_ENODATA_V1',
+    'P276 295P s=0 i=%d be=%d pn=%d fr=%d',
+    'P276 295P s=1 rc=%d',
+    'P276 295I s=1 rc=%d',
+    'P276 295D s=1 rc=%d cc=%d',
+    'P276 295D s=2 rc=%d',
+    'P276 295T s=0 cc=%d pc=%u',
+    'P276 295R s=0 i=%d e=%d',
+    'P276 295R s=1 i=%d e=%d',
+    'P276 295R s=2 e=%d',
+    'P276 295R s=3 rc=%d',
+    'P276 295R s=4 rc=%d',
+    'P276 295R s=9 rc=%d i=%d',
+    'P276 295C s=0 n=%d',
+    'P276 295C s=1 i=%d e=%d n=%.24s',
+    'P276 295C s=9 rc=%d',
+]
+for marker in required:
+    if marker not in src:
+        raise SystemExit('Phase295 source marker missing: ' + marker)
+for marker in required[1:]:
+    if marker.encode() not in img:
+        raise SystemExit('Phase295 runtime marker missing from Image: ' + marker)
+
+before = (root / 'audit/dsi-display-before.c').read_text()
+behavior = [
+    'DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
+    'wait_for_completion', 'msleep(', 'usleep_range(', 'udelay(',
+    'gpio_set_value(', 'dsi_ctrl_cmd_transfer(', 'dsi_panel_tx_cmd_set(',
+]
+for token in behavior:
+    if before.count(token) != src.count(token):
+        raise SystemExit(f'Phase295 functional token changed: {token}: {before.count(token)} -> {src.count(token)}')
+print('Phase295 compiled passive ENODATA frontier audit: PASS')
+PY
+
+python3 scripts/295_apply_gki_display_probe_enodata.py --root "$ROOT" --check-only
+
+trap - EXIT
+echo 'Phase295 passive display-probe ENODATA build/repack: PASS'


### PR DESCRIPTION
## Hardware evidence

The preserved Phase293 R48/RS48 snapshot shows `dsi_display_dev_probe()` exits with `-ENODATA (-61)` before the Phase293 `FETCH_MEMORY` target is admitted. There are 0 Phase293 GDM records and no evidence that the normal DSI command-transfer path becomes usable.

## R2 target

Phase295 R2 keeps the exact successful Phase293 functional baseline and narrows the failure inside `dsi_panel_get()`.

The existing passive `dsi_display.c` breadcrumbs remain. R2 additionally instruments `dsi_panel.c` through the existing persistent recorder to capture:

- whether `parser_node` firmware parsing is active
- active-parser `qcom,mdss-dsi-bpp` property presence, length, `read_u32()` return code and value
- active-parser `qcom,mdss-dsi-te-dcs-command` presence, length, `read_u32()` return code and value
- return from `dsi_panel_parse_host_config()`
- return from `dsi_panel_parse_panel_mode()` and resolved panel mode
- return from physical-property parsing
- return from GPIO parsing
- return from mode-count parsing
- final `dsi_panel_get()` success/error return

## Why the parser-mode bit matters

Exact TouchGrass source shows the firmware parser's custom `dsi_parser_read_u32()` does not generate `-ENODATA`: absent properties return `-EINVAL`, while a parsed property with no value returns the unchanged `0` status. Standard OF `read_u32()` can return `-ENODATA` for a present property with no data. Therefore `295G pr=` immediately separates the OF-property hypothesis from the firmware-parser path.

For host config, exact TouchGrass source also shows `-61` can only propagate from the required `qcom,mdss-dsi-bpp` pixel-format read. For command-mode parsing, `qcom,mdss-dsi-te-dcs-command` has a return-code leak capable of propagating its parser error unchanged.

## Scope controls

This remains instrumentation-only. R2 adds no DSI register writes, panel packets, waits, delays, retries, resets, regulator changes, clock changes or recovery behavior. CI audits both modified files against hardware-affecting token counts and requires controller, controller-HW, recorder and kernel configuration to remain byte-for-byte identical to the reconstructed Phase293 baseline.

Draft and not hardware validated.