### PR TITLE
Phase295: passive F05A5A admission witness

### DIFF
--- a/.github/workflows/295-a52-gki-f05a5a-admission-witness.yml
+++ b/.github/workflows/295-a52-gki-f05a5a-admission-witness.yml
@@ -1,0 +1,97 @@
+name: 295 - A52 GKI F05A5A admission witness
+run-name: Phase 295 - passive F05A5A admission witness on Phase293
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase295-gki-f05a5a-admission-witness-v1
+    paths:
+      - .github/workflows/295-a52-gki-f05a5a-admission-witness.yml
+      - scripts/295_apply_gki_f05a5a_admission_witness.py
+      - scripts/295_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase293-gki-fetch-memory-dma-done-reference-v1
+    paths:
+      - .github/workflows/295-a52-gki-f05a5a-admission-witness.yml
+      - scripts/295_apply_gki_f05a5a_admission_witness.py
+      - scripts/295_ci_build.sh
+permissions:
+  contents: read
+  actions: read
+concurrency:
+  group: a52-phase295-gki-f05a5a-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+jobs:
+  build:
+    name: Build Phase293 plus passive F05A5A admission witness
+    runs-on: ubuntu-22.04
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase295 branch
+        uses: actions/checkout@v4
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates unzip make gcc g++ python3 bc bison flex clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+      - name: Build passive Phase295 admission witness
+        run: bash scripts/295_ci_build.sh
+      - name: Upload complete Phase295 evidence package
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase295-GKI-F05A5A-ADMISSION-WITNESS-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase295-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+      - name: Upload flash-ready boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase295-GKI-F05A5A-ADMISSION-WITNESS-${{ github.run_number }}-BOOT-IMG
+          path: phase295-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase295-FAILURE-DIAGNOSTICS-${{ github.run_number }}
+          path: |
+            phase293-failure/
+            phase295-out/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/295_apply_gki_f05a5a_admission_witness.py
+++ b/scripts/295_apply_gki_f05a5a_admission_witness.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+MARK = 'A52_PHASE295_F05A5A_ADMISSION_WITNESS_V1'
+PHASE293 = 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase295 {label}: expected exactly 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def behavioral_counts(text: str) -> dict[str, int]:
+    return {k: text.count(k) for k in [
+        'DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
+        'wait_for_completion_timeout(', 'msleep(', 'usleep_range(',
+        'DSI_CTRL_CMD_FIFO_STORE', 'DSI_CTRL_CMD_FETCH_MEMORY',
+    ]}
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    if PHASE293 not in text:
+        raise SystemExit('Phase295 requires the exact Phase293 passive GDM source')
+
+    state = 'static atomic_t a52_p293_gdm_state = ATOMIC_INIT(0); /* 0 idle, 1 exact target */\n'
+    state_new = '''/* A52_PHASE295_F05A5A_ADMISSION_WITNESS_V1
+ * One-shot passive admission witness. It observes the first ctrl0 DSI message
+ * whose payload begins F0 5A 5A, regardless of incoming controller flags,
+ * MIPI flags, packet type or total length. It writes only to the existing A52
+ * flight recorder and does not mutate the DSI message or controller state.
+ */
+static atomic_t a52_p295_f05a5a_seen = ATOMIC_INIT(0);
+static atomic_t a52_p293_gdm_state = ATOMIC_INIT(0); /* 0 idle, 1 exact target */
+'''
+    text = one(text, state, state_new, 'witness state insertion')
+
+    old = '''\tconst u8 *p;\n\n\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n\tp = msg->tx_buf;\n'''
+    new = '''\tconst u8 *p;\n\n\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    msg->tx_len < 3 || !msg->tx_buf)\n\t\treturn;\n\tp = msg->tx_buf;\n\tif (p[0] == 0xf0 && p[1] == 0x5a && p[2] == 0x5a &&\n\t    atomic_cmpxchg(&a52_p295_f05a5a_seen, 0, 1) == 0)\n\t\ta52_ackfr_record("GDM W00 c=0 in=%x mf=%x t=%x l=%u p=%02x%02x%02x",\n\t\t\t*flags, msg->flags, msg->type, (unsigned int)msg->tx_len,\n\t\t\tp[0], p[1], p[2]);\n\n\t/* Preserve the Phase293 exact-target admission semantics unchanged. */\n\tif (*flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n'''
+    text = one(text, old, new, 'admission witness insertion')
+    return text
+
+
+def validate(text: str) -> None:
+    for token in [
+        PHASE293, MARK,
+        'GDM W00 c=0 in=%x mf=%x t=%x l=%u p=%02x%02x%02x',
+        'GDM S00 c=0 in=%x mf=%x t=%x l=%u',
+        'GDM DONE success=0 target=0/8/20/29/3',
+        'P276 280Z q=2',
+    ]:
+        if token not in text:
+            raise SystemExit('Phase295 validation missing: ' + token)
+    if text.count('a52_p295_f05a5a_seen') != 2:
+        raise SystemExit('Phase295 witness atomic use count changed unexpectedly')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    cp = args.root / CTRL
+    if not cp.is_file():
+        raise SystemExit('Phase295 reconstructed dsi_ctrl.c missing')
+    before = cp.read_text()
+    counts_before = behavioral_counts(before)
+    if not args.check_only:
+        cp.write_text(patch(before))
+    after = cp.read_text()
+    validate(after)
+    if not args.check_only:
+        counts_after = behavioral_counts(after)
+        # One additional textual FETCH_MEMORY comparison is expected; all
+        # behavioral/write/wait/clock/FIFO token counts must remain unchanged.
+        expected = dict(counts_before)
+        expected['DSI_CTRL_CMD_FETCH_MEMORY'] += 1
+        if counts_after != expected:
+            raise SystemExit(f'Phase295 behavioral-token count changed: {counts_before} -> {counts_after}')
+    print('Phase295 passive F05A5A admission witness: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/295_apply_gki_f05a5a_admission_witness.py
+++ b/scripts/295_apply_gki_f05a5a_admission_witness.py
@@ -78,11 +78,10 @@ def main() -> None:
     validate(after)
     if not args.check_only:
         counts_after = behavioral_counts(after)
-        # One additional textual FETCH_MEMORY comparison is expected; all
-        # behavioral/write/wait/clock/FIFO token counts must remain unchanged.
-        expected = dict(counts_before)
-        expected['DSI_CTRL_CMD_FETCH_MEMORY'] += 1
-        if counts_after != expected:
+        # The witness broadens only the payload observation. The exact Phase293
+        # FETCH_MEMORY comparison is moved into the preserved admission check,
+        # so every behavioral/write/wait/clock/FIFO token count stays identical.
+        if counts_after != counts_before:
             raise SystemExit(f'Phase295 behavioral-token count changed: {counts_before} -> {counts_after}')
     print('Phase295 passive F05A5A admission witness: PASS')
 

--- a/scripts/295_ci_build.sh
+++ b/scripts/295_ci_build.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+python3 -m py_compile scripts/295_apply_gki_f05a5a_admission_witness.py
+
+# Reuse the already-audited Phase293 reconstruction/build pipeline, but insert
+# the Phase295 one-shot witness immediately after Phase293 source staging and
+# before olddefconfig/compilation. The Phase293 target admission and all DSI
+# behavior remain unchanged.
+TMP="$(mktemp -t a52-p295-ci.XXXXXX.sh)"
+trap 'rm -f "$TMP"' EXIT
+python3 - <<'PY' > "$TMP"
+from pathlib import Path
+src = Path('scripts/293_ci_build.sh').read_text()
+needle = '''python3 scripts/293_apply_gki_dma_done_reference.py --root "$ROOT" --check-only\n\n# Phase293 may touch only the DSI controller and common HW source. SMMU and the\n'''
+replacement = '''python3 scripts/293_apply_gki_dma_done_reference.py --root "$ROOT" --check-only\npython3 scripts/295_apply_gki_f05a5a_admission_witness.py --root "$ROOT"\npython3 scripts/295_apply_gki_f05a5a_admission_witness.py --root "$ROOT" --check-only\n\n# Phase293 may touch only the DSI controller and common HW source. SMMU and the\n'''
+if src.count(needle) != 1:
+    raise SystemExit('Phase295 could not locate Phase293 pre-build insertion point')
+print(src.replace(needle, replacement, 1), end='')
+PY
+chmod +x "$TMP"
+bash "$TMP"
+
+# Phase293 CI has already validated the reconstructed Phase280 lineage, fixed
+# 96 MiB repack, configuration identity, forbidden-behavior absence, and all
+# original GDM runtime markers. Promote that exact output with the additional
+# Phase295 passive witness identity/audit.
+rm -rf phase295-out
+cp -a phase293-out phase295-out
+cp scripts/295_apply_gki_f05a5a_admission_witness.py phase295-out/audit/
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase295-out')
+idp = r / 'BUILD-IDENTITY.json'
+idn = json.loads(idp.read_text())
+idn.update({
+    'phase': '295',
+    'name': 'GKI-F05A5A-ADMISSION-WITNESS',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase293 passive GDM reference on clean Phase280 reconstruction',
+    'admission_witness': {
+        'marker': 'GDM W00',
+        'scope': 'first ctrl0 DSI message with tx_len>=3 and payload prefix F0 5A 5A',
+        'controller_flags_filter': 'none',
+        'mipi_flags_filter': 'none',
+        'packet_type_filter': 'none',
+        'writes_or_transport_changes': False,
+    },
+    'hardware_question': (
+        'Does GKI ever present F0 5A 5A to dsi_message_setup_tx_mode, and if so '
+        'which incoming flags/msg.flags/type/length differ from Golden before the Phase293 S00 gate?'
+    ),
+})
+idp.write_text(json.dumps(idn, indent=2, sort_keys=True) + '\n')
+
+# Replace the inherited Phase293 checksum manifest with a complete Phase295 one.
+manifest = r / 'SHA256SUMS'
+files = sorted(p for p in r.rglob('*') if p.is_file() and p != manifest)
+with manifest.open('w') as f:
+    for p in files:
+        rel = p.relative_to(r)
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest() + '  ./' + str(rel) + '\n')
+PY
+(cd phase295-out && sha256sum -c SHA256SUMS)
+
+test "$(stat -c '%s' phase295-out/package/boot.img)" -eq 100663296
+cmp -s phase295-out/config/final.config phase295-out/audit/phase280-final.config
+
+grep -Fq 'A52_PHASE295_F05A5A_ADMISSION_WITNESS_V1' phase295-out/source/dsi_ctrl.c
+grep -Fq 'GDM W00 c=0 in=%x mf=%x t=%x l=%u p=%02x%02x%02x' phase295-out/source/dsi_ctrl.c
+python3 - <<'PY'
+from pathlib import Path
+img = Path('phase295-out/compile/Image').read_bytes()
+for marker in [
+    b'GDM W00 c=0 in=%x mf=%x t=%x l=%u p=%02x%02x%02x',
+    b'GDM S00 c=0 in=%x mf=%x t=%x l=%u',
+    b'GDM DONE success=0 target=0/8/20/29/3',
+    b'P276 280Z q=2',
+]:
+    if marker not in img:
+        raise SystemExit('Phase295 runtime marker missing: ' + marker.decode())
+print('Phase295 compiled admission-witness audit: PASS')
+PY
+
+# No later experimental lineage is allowed back into this diagnostic.
+for marker in \
+  'A52_PHASE281_DSI_DMA_CONSUMPTION_TRACE_V1' \
+  'A52_PHASE292_DSI_CHAIN_TAPS_V1' \
+  'A52_PHASE291_CONT_SPLASH_ZERO_RATE_RECOVERY_V1'; do
+  if grep -Fq "$marker" phase295-out/source/dsi_ctrl.c; then
+    echo "Phase295 refuses later behavioral lineage: $marker" >&2
+    exit 1
+  fi
+done
+
+python3 scripts/295_apply_gki_f05a5a_admission_witness.py --root "$PWD/gki/common" --check-only
+trap - EXIT
+rm -f "$TMP"
+echo 'Phase295 passive GKI F05A5A admission-witness build/repack: PASS'


### PR DESCRIPTION
Phase293 hardware capture preserved correctly but produced no GDM S00-S09 records. The retained R48/RS48 timeline shows the GKI system continuing through userspace while dsi_display_dev_probe retries with kd=-61 around 17.8s and later. Phase295 keeps the exact Phase293 transport/target logic and adds only one passive recorder write: the first ctrl0 DSI message whose payload begins F0 5A 5A is recorded as GDM W00 with incoming flags, MIPI flags, packet type and length regardless of those admission fields. This distinguishes a flag/type mismatch before S00 from complete absence of the Golden unlock command. No DSI register writes, flag mutation, retries, sleeps, resets, clock changes, panel traffic or brightness changes are added.