### PR TITLE
Phase297: exact-source QEMU DRM/ftrace lab

### DIFF
--- a/.github/workflows/297-a52-phase296-qemu-trace-lab.yml
+++ b/.github/workflows/297-a52-phase296-qemu-trace-lab.yml
@@ -47,7 +47,10 @@ jobs:
       - name: Check out Phase297 lab branch
         uses: actions/checkout@v4
 
-      - name: Prepare runner
+      # This package set deliberately matches the green Phase296 production
+      # workflow. Do not install ARM64 libc headers or QEMU before the exact
+      # phone reconstruction: those can change Kconfig compiler-link probes.
+      - name: Prepare exact Phase296 runner environment
         run: |
           set -Eeuo pipefail
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
@@ -55,10 +58,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
             clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
-            libc6-dev-arm64-cross libssl-dev libelf-dev rsync cpio gzip lz4 \
-            file dwarves qemu-system-arm
-          qemu-system-aarch64 --version
-          aarch64-linux-gnu-gcc --version | head -n 1
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
 
       - name: Restore pinned GKI source
         uses: actions/cache/restore@v4
@@ -84,6 +84,40 @@ jobs:
           git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
           git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
           git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Reconstruct exact Phase296 before virtual dependencies
+        run: |
+          set -Eeuo pipefail
+          bash scripts/296_ci_build.sh
+          test -s phase296-out/package/boot.img
+          test -s workspace/gki-phase199-out/arch/arm64/boot/Image
+          cp scripts/296_ci_build.sh /tmp/phase296_ci_build.real.sh
+
+      - name: Install QEMU and ARM64 userspace dependencies
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get install -y --no-install-recommends \
+            libc6-dev-arm64-cross qemu-system-arm
+          qemu-system-aarch64 --version
+          aarch64-linux-gnu-gcc --version | head -n 1
+
+      # The Phase297 driver reuses the already-reconstructed exact source tree.
+      # Replace only its nested production-script invocation with an assertion
+      # stub so the newly installed libc headers cannot rerun olddefconfig and
+      # perturb the phone Kconfig. No source/config/output is modified here.
+      - name: Freeze exact phone reconstruction for virtual phase
+        run: |
+          set -Eeuo pipefail
+          cat > scripts/296_ci_build.sh <<'SH'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+          test -s phase296-out/package/boot.img
+          test -s phase296-out/compile/Image
+          test -s workspace/gki-phase199-out/arch/arm64/boot/Image
+          test -s workspace/gki-phase199-out/.config
+          echo 'Phase297: reusing frozen exact Phase296 reconstruction'
+          SH
+          chmod +x scripts/296_ci_build.sh
 
       - name: Run exact-source QEMU trace lab
         run: bash scripts/297_qemu_trace_lab.sh

--- a/.github/workflows/297-a52-phase296-qemu-trace-lab.yml
+++ b/.github/workflows/297-a52-phase296-qemu-trace-lab.yml
@@ -12,6 +12,15 @@ on:
       - tests/qemu/phase297_trace_init.c
       - scripts/296_apply_userspace_drm_atomic_frontier.py
       - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/297-a52-phase296-qemu-trace-lab.yml
+      - scripts/297_qemu_trace_lab.sh
+      - tests/qemu/phase297_trace_init.c
+      - scripts/296_apply_userspace_drm_atomic_frontier.py
+      - scripts/296_ci_build.sh
 
 permissions:
   contents: read

--- a/.github/workflows/297-a52-phase296-qemu-trace-lab.yml
+++ b/.github/workflows/297-a52-phase296-qemu-trace-lab.yml
@@ -1,0 +1,90 @@
+name: 297 - Phase296 exact-source QEMU trace lab
+run-name: Phase 297 - exact Phase296 source QEMU DRM/ftrace lab
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase296-qemu-trace-lab-v1
+    paths:
+      - .github/workflows/297-a52-phase296-qemu-trace-lab.yml
+      - scripts/297_qemu_trace_lab.sh
+      - tests/qemu/phase297_trace_init.c
+      - scripts/296_apply_userspace_drm_atomic_frontier.py
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase297-qemu-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  trace-lab:
+    name: Exact Phase296 phone audit + QEMU DRM/ftrace boot
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase297 lab branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libc6-dev-arm64-cross libssl-dev libelf-dev rsync cpio gzip lz4 \
+            file dwarves qemu-system-arm
+          qemu-system-aarch64 --version
+          aarch64-linux-gnu-gcc --version | head -n 1
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Run exact-source QEMU trace lab
+        run: bash scripts/297_qemu_trace_lab.sh
+
+      - name: Upload Phase297 trace evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase297-QEMU-TRACE-LAB-${{ github.run_number }}-NON-FLASHABLE
+          path: phase297-lab-out/
+          if-no-files-found: warn
+          compression-level: 1
+          retention-days: 30

--- a/.github/workflows/298-a52-qemu-kbuild-isolation.yml
+++ b/.github/workflows/298-a52-qemu-kbuild-isolation.yml
@@ -1,0 +1,118 @@
+name: 298 - QEMU Kbuild isolation retry
+run-name: Phase 298 - exact Phase296 audit plus isolated QEMU DRM/ftrace lab
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase296-qemu-trace-lab-v1
+    paths:
+      - .github/workflows/298-a52-qemu-kbuild-isolation.yml
+      - scripts/298_qemu_trace_lab.sh
+      - scripts/297_qemu_trace_lab.sh
+      - tests/qemu/phase297_trace_init.c
+      - scripts/296_apply_userspace_drm_atomic_frontier.py
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase298-qemu-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  trace-lab:
+    name: Exact Phase296 audit + isolated QEMU DRM/ftrace boot
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase298 lab branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 runner environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Reconstruct exact Phase296 before virtual dependencies
+        run: |
+          set -Eeuo pipefail
+          bash scripts/296_ci_build.sh
+          test -s phase296-out/package/boot.img
+          test -s workspace/gki-phase199-out/arch/arm64/boot/Image
+          cp scripts/296_ci_build.sh /tmp/phase296_ci_build.real.sh
+
+      - name: Install QEMU and ARM64 userspace dependencies
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get install -y --no-install-recommends \
+            libc6-dev-arm64-cross qemu-system-arm
+          qemu-system-aarch64 --version
+          aarch64-linux-gnu-gcc --version | head -n 1
+
+      - name: Freeze exact phone reconstruction for virtual phase
+        run: |
+          set -Eeuo pipefail
+          cat > scripts/296_ci_build.sh <<'SH'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+          test -s phase296-out/package/boot.img
+          test -s phase296-out/compile/Image
+          test -s workspace/gki-phase199-out/arch/arm64/boot/Image
+          test -s workspace/gki-phase199-out/.config
+          echo 'Phase298: reusing frozen exact Phase296 reconstruction'
+          SH
+          chmod +x scripts/296_ci_build.sh
+
+      - name: Run Phase298 isolated QEMU trace lab
+        run: bash scripts/298_qemu_trace_lab.sh
+
+      - name: Upload Phase298 trace evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase298-QEMU-TRACE-LAB-${{ github.run_number }}-NON-FLASHABLE
+          path: phase297-lab-out/
+          if-no-files-found: warn
+          compression-level: 1
+          retention-days: 30

--- a/.github/workflows/298r-a52-qemu-smmu-isolation.yml
+++ b/.github/workflows/298r-a52-qemu-smmu-isolation.yml
@@ -1,0 +1,119 @@
+name: 298R - QEMU SMMU isolation repair
+run-name: Phase 298R - exact Phase296 audit plus QEMU DRM/ftrace with ARM SMMU isolated
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase296-qemu-trace-lab-v1
+    paths:
+      - .github/workflows/298r-a52-qemu-smmu-isolation.yml
+      - scripts/298r_qemu_smmu_isolation.sh
+      - scripts/298_qemu_trace_lab.sh
+      - scripts/297_qemu_trace_lab.sh
+      - tests/qemu/phase297_trace_init.c
+      - scripts/296_apply_userspace_drm_atomic_frontier.py
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase298r-qemu-trace-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  trace-lab:
+    name: Exact Phase296 audit + SMMU-isolated QEMU DRM/ftrace boot
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase298R lab branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 runner environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Reconstruct exact Phase296 before virtual dependencies
+        run: |
+          set -Eeuo pipefail
+          bash scripts/296_ci_build.sh
+          test -s phase296-out/package/boot.img
+          test -s workspace/gki-phase199-out/arch/arm64/boot/Image
+          cp scripts/296_ci_build.sh /tmp/phase296_ci_build.real.sh
+
+      - name: Install QEMU and ARM64 userspace dependencies
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get install -y --no-install-recommends \
+            libc6-dev-arm64-cross qemu-system-arm
+          qemu-system-aarch64 --version
+          aarch64-linux-gnu-gcc --version | head -n 1
+
+      - name: Freeze exact phone reconstruction for virtual phase
+        run: |
+          set -Eeuo pipefail
+          cat > scripts/296_ci_build.sh <<'SH'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+          test -s phase296-out/package/boot.img
+          test -s phase296-out/compile/Image
+          test -s workspace/gki-phase199-out/arch/arm64/boot/Image
+          test -s workspace/gki-phase199-out/.config
+          echo 'Phase298R: reusing frozen exact Phase296 reconstruction'
+          SH
+          chmod +x scripts/296_ci_build.sh
+
+      - name: Run Phase298R SMMU-isolated QEMU trace lab
+        run: bash scripts/298r_qemu_smmu_isolation.sh
+
+      - name: Upload Phase298R trace evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase298R-QEMU-TRACE-LAB-${{ github.run_number }}-NON-FLASHABLE
+          path: phase297-lab-out/
+          if-no-files-found: warn
+          compression-level: 1
+          retention-days: 30

--- a/.github/workflows/299-a52-touchgrass-vs-gki-deep-audit.yml
+++ b/.github/workflows/299-a52-touchgrass-vs-gki-deep-audit.yml
@@ -1,0 +1,120 @@
+name: 299 - TouchGrass vs Phase296 GKI deep audit
+run-name: Phase 299 - exhaustive display and lower-layer source audit
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase296-qemu-trace-lab-v1
+    paths:
+      - .github/workflows/299-a52-touchgrass-vs-gki-deep-audit.yml
+      - scripts/299_touchgrass_vs_gki_deep_audit.py
+      - scripts/296_ci_build.sh
+      - scripts/296_apply_userspace_drm_atomic_frontier.py
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase299-source-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  audit:
+    name: Reconstruct exact Phase296 and compare against TouchGrass
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase299 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+
+      - name: Restore pinned official GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Validate pinned GKI
+        run: |
+          set -Eeuo pipefail
+          test -d gki/common/.git
+          test "$(git -C gki/common rev-parse HEAD)" = "$GKI_COMMON_SHA"
+          test "$(make -s -C gki/common kernelversion)" = 5.10.252
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Validate exact TouchGrass
+        run: |
+          set -Eeuo pipefail
+          test "$(git -C workspace/touchgrass-a52xq rev-parse HEAD)" = "$TOUCHGRASS_COMMIT"
+          test -d workspace/touchgrass-a52xq/techpack/display/msm
+
+      - name: Reconstruct exact Phase296 port
+        run: |
+          set -Eeuo pipefail
+          bash scripts/296_ci_build.sh
+          test -s phase296-out/package/boot.img
+          test -s phase296-out/config/final.config
+          test -d gki/common/drivers/a52_display/msm
+
+      - name: Run exhaustive source and semantic comparison
+        run: |
+          set -Eeuo pipefail
+          rm -rf phase299-source-audit
+          python3 scripts/299_touchgrass_vs_gki_deep_audit.py \
+            --touchgrass workspace/touchgrass-a52xq \
+            --gki gki/common \
+            --gki-config phase296-out/config/final.config \
+            --output phase299-source-audit
+          test -s phase299-source-audit/REPORT.md
+          test -s phase299-source-audit/display-file-parity.tsv
+          test -s phase299-source-audit/critical-file-parity.json
+          test -s phase299-source-audit/lower-layer-fingerprint.json
+          test -s phase299-source-audit/risk-ranking.json
+          (cd phase299-source-audit && sha256sum -c SHA256SUMS)
+
+      - name: Upload Phase299 deep source evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase299-TOUCHGRASS-VS-GKI-DEEP-AUDIT-${{ github.run_number }}-NON-FLASHABLE
+          path: phase299-source-audit/
+          if-no-files-found: warn
+          compression-level: 1
+          retention-days: 30

--- a/.github/workflows/299r-a52-rpmh-solver-contract-audit.yml
+++ b/.github/workflows/299r-a52-rpmh-solver-contract-audit.yml
@@ -1,0 +1,113 @@
+name: 299R - Phase296 RPMh solver contract audit
+run-name: Phase 299R - exact Phase296 SDE RSC to RPMh solver contract audit
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase296-qemu-trace-lab-v1
+    paths:
+      - .github/workflows/299r-a52-rpmh-solver-contract-audit.yml
+      - scripts/299r_rpmh_solver_contract_audit.py
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/299r-a52-rpmh-solver-contract-audit.yml
+      - scripts/299r_rpmh_solver_contract_audit.py
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase299r-rpmh-solver-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  audit:
+    name: Reconstruct Phase296 and resolve SDE RSC RPMh contract
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase299R branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Reconstruct exact Phase296
+        run: |
+          set -Eeuo pipefail
+          bash scripts/296_ci_build.sh
+          test -s phase296-out/package/boot.img
+          test -s phase296-out/config/final.config
+          test -d gki/common/drivers/a52_display/msm
+          test -s gki/common/drivers/a52_display/msm/sde_rsc.c
+
+      - name: Run SDE RSC to RPMh solver contract audit
+        run: |
+          set -Eeuo pipefail
+          rm -rf phase299r-rpmh-audit
+          python3 scripts/299r_rpmh_solver_contract_audit.py \
+            --touchgrass workspace/touchgrass-a52xq \
+            --gki gki/common \
+            --gki-config phase296-out/config/final.config \
+            --build-out workspace/gki-phase199-out \
+            --output phase299r-rpmh-audit
+          test -s phase299r-rpmh-audit/REPORT.md
+          test -s phase299r-rpmh-audit/rpmh-solver-contract.json
+          test -s phase299r-rpmh-audit/symbol-locations.tsv
+          (cd phase299r-rpmh-audit && sha256sum -c SHA256SUMS)
+
+      - name: Upload Phase299R RPMh solver evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase299R-RPMH-SOLVER-CONTRACT-${{ github.run_number }}-NON-FLASHABLE
+          path: phase299r-rpmh-audit/
+          if-no-files-found: warn
+          compression-level: 1
+          retention-days: 30

--- a/.github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
+++ b/.github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
@@ -30,6 +30,7 @@ env:
   GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
   TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
   TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
 
 jobs:
   audit:

--- a/.github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
+++ b/.github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
@@ -1,0 +1,111 @@
+name: 299S - Phase296 Phase13 RPMh runtime-shim audit
+run-name: Phase 299S - prove Phase13 rpmh solver/flush semantic erasure
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase296-qemu-trace-lab-v1
+    paths:
+      - .github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
+      - scripts/299s_phase13_rpmh_runtime_shim_audit.py
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
+      - scripts/299s_phase13_rpmh_runtime_shim_audit.py
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase299s-phase13-rpmh-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+
+jobs:
+  audit:
+    name: Reconstruct Phase296 and prove Phase13 RPMh shims
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    steps:
+      - name: Check out Phase299S branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/299s_phase13_rpmh_runtime_shim_audit.py
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Reconstruct exact Phase296
+        run: |
+          set -Eeuo pipefail
+          bash scripts/296_ci_build.sh
+          test -s phase296-out/package/boot.img
+          test -s workspace/gki-phase199-out/drivers/a52_display/msm/sde_rsc.o
+          test -s workspace/gki-phase199-out/vmlinux
+          test -s gki/common/a52-port-compat.h
+
+      - name: Audit Phase13 solver and flush shims
+        run: |
+          set -Eeuo pipefail
+          rm -rf phase299s-rpmh-audit
+          python3 scripts/299s_phase13_rpmh_runtime_shim_audit.py \
+            --touchgrass workspace/touchgrass-a52xq \
+            --gki gki/common \
+            --build-out workspace/gki-phase199-out \
+            --output phase299s-rpmh-audit
+          test -s phase299s-rpmh-audit/REPORT.md
+          test -s phase299s-rpmh-audit/phase13-rpmh-runtime-shims.json
+          (cd phase299s-rpmh-audit && sha256sum -c SHA256SUMS)
+          grep -Fq 'PROVEN_PHASE13_RUNTIME_SEMANTIC_ERASURE' \
+            phase299s-rpmh-audit/phase13-rpmh-runtime-shims.json
+
+      - name: Upload Phase299S evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase299S-PHASE13-RPMH-RUNTIME-SHIMS-${{ github.run_number }}-NON-FLASHABLE
+          path: phase299s-rpmh-audit/
+          if-no-files-found: warn
+          compression-level: 1
+          retention-days: 30

--- a/.github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
+++ b/.github/workflows/299s-a52-phase13-rpmh-runtime-shim-audit.yml
@@ -36,6 +36,8 @@ jobs:
     name: Reconstruct Phase296 and prove Phase13 RPMh shims
     runs-on: ubuntu-22.04
     timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Check out Phase299S branch
         uses: actions/checkout@v4

--- a/scripts/297_qemu_trace_lab.sh
+++ b/scripts/297_qemu_trace_lab.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+PHONE_OUT="$PWD/workspace/gki-phase199-out"
+QOUT="$PWD/workspace/gki-phase297-qemu-out"
+ART="$PWD/phase297-lab-out"
+PHONE="$ART/exact-phone"
+QART="$ART/qemu"
+ANALYSIS="$ART/analysis"
+ROOTFS="$PWD/workspace/phase297-rootfs"
+HDRS="$PWD/workspace/phase297-uapi"
+QIMAGE="$QOUT/arch/arm64/boot/Image"
+INITRAMFS="$QART/initramfs-phase297.cpio.gz"
+SERIAL="$QART/serial.log"
+STRICT_FLAGS='-Werror=declaration-after-statement -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=return-type'
+
+fail_report() {
+  local rc=$?
+  set +e
+  mkdir -p "$ART" "$ANALYSIS"
+  printf '%s\n' "$rc" > "$ART/exit-status.txt"
+  if [[ -f "$SERIAL" ]]; then
+    grep -nE 'Kernel panic|Oops:|BUG:|WARNING:|Call trace:|PHASE297_' "$SERIAL" \
+      > "$ANALYSIS/serial-key-events.txt" 2>/dev/null || true
+  fi
+  exit "$rc"
+}
+trap fail_report EXIT
+
+rm -rf "$ART" "$QOUT" "$ROOTFS" "$HDRS"
+mkdir -p "$PHONE" "$QART" "$ANALYSIS" "$ROOTFS" "$HDRS"
+
+cat > "$ART/README.txt" <<'TXT'
+Phase297 is a NON-FLASHABLE exact-source virtual diagnostics lab.
+
+The exact A52 Phase296 source/config is reconstructed and its real A52 display
+objects are compiled/audited. A second config from that exact same source tree
+is then booted on QEMU ARM64 virt with virtio-gpu so serial, initcall timing,
+DRM-core ioctls and function-graph tracing can be exercised automatically.
+
+QEMU does NOT emulate SM7125 SDE, Qualcomm DSI/PHY, the Samsung panel, A52 DTBO,
+or Samsung HWC. Therefore QEMU success is a preflight/debugging result, not
+proof that the physical A52 display path works. Never flash the QEMU Image.
+TXT
+
+# Reconstruct and compile the exact phone candidate first. This intentionally
+# reuses the same production script that produces the hardware Phase296 image.
+bash scripts/296_ci_build.sh
+
+test -s "$PHONE_OUT/arch/arm64/boot/Image"
+test -s phase296-out/package/boot.img
+cp phase296-out/config/final.config "$PHONE/phase296-final.config"
+cp phase296-out/BUILD-IDENTITY.json "$PHONE/BUILD-IDENTITY.json"
+cp phase296-out/package/repack-report.json "$PHONE/repack-report.json"
+sha256sum phase296-out/compile/Image phase296-out/package/boot.img \
+  > "$PHONE/phase296-phone-binaries.sha256"
+
+# Force a strict recompile of the exact objects carrying the new probes. This
+# catches C89 declaration ordering and ABI/prototype mistakes independently of
+# the full Image build, while using the exact phone config and generated tree.
+PHONE_OBJECTS=(
+  drivers/a52_display/msm/msm_drv.o
+  drivers/a52_display/msm/msm_atomic.o
+  drivers/a52_display/msm/sde/sde_kms.o
+)
+for rel in "${PHONE_OBJECTS[@]}"; do
+  rm -f "$PHONE_OUT/$rel"
+done
+set +e
+make -C "$ROOT" O="$PHONE_OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 \
+  KCFLAGS="$STRICT_FLAGS" -j"$(nproc)" "${PHONE_OBJECTS[@]}" \
+  2>&1 | tee "$PHONE/strict-object-build.log"
+strict_rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$strict_rc" > "$PHONE/strict-object-build.status"
+test "$strict_rc" -eq 0
+
+for rel in "${PHONE_OBJECTS[@]}"; do
+  test -s "$PHONE_OUT/$rel"
+  base="$(basename "$rel" .o)"
+  llvm-nm -n "$PHONE_OUT/$rel" > "$PHONE/${base}.nm.txt"
+  llvm-objdump -dr --no-show-raw-insn "$PHONE_OUT/$rel" > "$PHONE/${base}.objdump.txt"
+  strings -a "$PHONE_OUT/$rel" | grep -F 'P276 296' > "$PHONE/${base}.markers.txt" || true
+done
+
+python3 - <<'PY'
+from pathlib import Path
+root=Path('gki/common')
+out=Path('phase297-lab-out/analysis')
+files=[
+ root/'drivers/a52_display/msm/msm_drv.c',
+ root/'drivers/a52_display/msm/msm_atomic.c',
+ root/'drivers/a52_display/msm/sde/sde_kms.c',
+]
+markers=[
+ 'P276 296R r=%d','P276 296S o=%d/%d a=%d/%d',
+ 'P276 296O e','P276 296O x r=%d','P276 296A e','P276 296A x r=%d',
+ 'P276 296C e n=%d','P276 296C x r=%d q=1','P276 296C x r=0 q=0','P276 296C x r=%d q=2',
+ 'P276 296W e','P276 296K p','P276 296K c','P276 296K x',
+]
+all_text='\n'.join(p.read_text() for p in files)
+missing=[m for m in markers if m not in all_text]
+if missing:
+ raise SystemExit('missing Phase296 markers: '+repr(missing))
+lines=[]
+for p in files:
+ text=p.read_text()
+ src=text.splitlines()
+ lines.append(f'FILE {p}')
+ for marker in markers:
+  for idx,line in enumerate(src,1):
+   if marker in line:
+    lo=max(1,idx-4); hi=min(len(src),idx+4)
+    lines.append(f'  MARKER {marker!r} line={idx}')
+    for n in range(lo,hi+1):
+     lines.append(f'    {n:5d}: {src[n-1]}')
+(out/'phase296-marker-source-context.txt').write_text('\n'.join(lines)+'\n')
+PY
+
+# Build a generic ARM64 virt kernel from the already-patched exact Phase296
+# source tree. This config is deliberately separate from the phone config.
+make -C "$ROOT" O="$QOUT" ARCH=arm64 LLVM=1 LLVM_IAS=1 defconfig
+cfg="$ROOT/scripts/config"
+for s in \
+  PCI PCI_HOST_GENERIC VIRTIO VIRTIO_PCI VIRTIO_MMIO \
+  SERIAL_AMBA_PL011 SERIAL_AMBA_PL011_CONSOLE \
+  DEVTMPFS DEVTMPFS_MOUNT BLK_DEV_INITRD RD_GZIP TMPFS PROC_FS SYSFS \
+  DEBUG_FS TRACING FTRACE FUNCTION_TRACER FUNCTION_GRAPH_TRACER DYNAMIC_FTRACE \
+  SCHED_TRACER TRACEPOINTS KALLSYMS KALLSYMS_ALL PRINTK_TIME MAGIC_SYSRQ \
+  DEBUG_KERNEL DETECT_HUNG_TASK WQ_WATCHDOG DEBUG_ATOMIC_SLEEP DEBUG_LIST \
+  DEBUG_OBJECTS PROVE_LOCKING DEBUG_LOCK_ALLOC \
+  DRM DRM_KMS_HELPER DRM_VIRTIO_GPU; do
+  "$cfg" --file "$QOUT/.config" -e "$s"
+done
+for s in DRM_FBDEV_EMULATION FB; do
+  "$cfg" --file "$QOUT/.config" -d "$s"
+done
+"$cfg" --file "$QOUT/.config" --set-val DEFAULT_HUNG_TASK_TIMEOUT 30
+make -C "$ROOT" O="$QOUT" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig </dev/null
+cp "$QOUT/.config" "$QART/qemu-final.config"
+
+required=(
+  SERIAL_AMBA_PL011_CONSOLE DEVTMPFS BLK_DEV_INITRD RD_GZIP DEBUG_FS TRACING
+  FTRACE FUNCTION_GRAPH_TRACER DYNAMIC_FTRACE PROVE_LOCKING DRM DRM_VIRTIO_GPU
+  PCI_HOST_GENERIC VIRTIO_PCI
+)
+for s in "${required[@]}"; do
+  grep -Fxq "CONFIG_${s}=y" "$QOUT/.config" || {
+    echo "Phase297 missing required QEMU config: CONFIG_${s}=y" >&2
+    exit 1
+  }
+done
+grep -Fxq '# CONFIG_DRM_FBDEV_EMULATION is not set' "$QOUT/.config"
+grep -Fxq '# CONFIG_FB is not set' "$QOUT/.config"
+
+set +e
+make -C "$ROOT" O="$QOUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee "$QART/qemu-build.log"
+qbuild_rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$qbuild_rc" > "$QART/qemu-build.status"
+test "$qbuild_rc" -eq 0
+test -s "$QIMAGE"
+cp "$QIMAGE" "$QART/Image-qemu-virt-NOT-FOR-A52"
+sha256sum "$QART/Image-qemu-virt-NOT-FOR-A52" > "$QART/Image-qemu-virt-NOT-FOR-A52.sha256"
+
+# Install the exact source-tree UAPI and build a static ARM64 /init that opens
+# virtio DRM, sends core DRM ioctls (including an empty atomic request), and
+# exports a bounded function-graph trace to the serial console.
+make -C "$ROOT" O="$QOUT" ARCH=arm64 INSTALL_HDR_PATH="$HDRS" headers_install
+mkdir -p "$ROOTFS"/{dev,proc,sys,tmp,run}
+aarch64-linux-gnu-gcc -static -O2 -Wall -Wextra -Werror \
+  -idirafter "$HDRS/include" \
+  tests/qemu/phase297_trace_init.c -o "$ROOTFS/init"
+file "$ROOTFS/init" | tee "$QART/init-file.txt"
+file "$ROOTFS/init" | grep -Eq 'ARM aarch64|ARM64'
+sudo mknod -m 600 "$ROOTFS/dev/console" c 5 1
+sudo mknod -m 666 "$ROOTFS/dev/null" c 1 3
+(
+  cd "$ROOTFS"
+  find . -print0 | cpio --null -o --format=newc 2>"$QART/cpio.log"
+) | gzip -9n > "$INITRAMFS"
+test -s "$INITRAMFS"
+sha256sum "$INITRAMFS" > "$QART/initramfs-phase297.cpio.gz.sha256"
+
+# initcall_debug supplies boot-time function timing; panic/oops/lockup are fatal.
+# The guest then turns on function_graph tracing for DRM/workqueue functions.
+set +e
+timeout --foreground --signal=TERM 120 \
+  qemu-system-aarch64 \
+    -machine virt,gic-version=3 \
+    -cpu cortex-a72 \
+    -smp 4 \
+    -m 2048 \
+    -nographic \
+    -no-reboot \
+    -device virtio-gpu-pci \
+    -kernel "$QIMAGE" \
+    -initrd "$INITRAMFS" \
+    -append 'console=ttyAMA0 earlycon=pl011,0x09000000 rdinit=/init nokaslr loglevel=8 ignore_loglevel initcall_debug panic=1 oops=panic hung_task_panic=1 softlockup_panic=1 rcupdate.rcu_cpu_stall_timeout=21 drm.debug=0x1ff' \
+    2>&1 | tee "$SERIAL"
+qemu_rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$qemu_rc" > "$QART/qemu-run.status"
+
+# QEMU may return a non-zero code on a deliberate guest reboot; serial markers
+# are the authoritative success criterion.
+grep -Fq 'PHASE297_BOOT_OK' "$SERIAL"
+grep -Fq 'PHASE297_TRACE_READY' "$SERIAL"
+grep -Fq 'PHASE297_DRM card_open=0' "$SERIAL"
+grep -Fq 'PHASE297_DRM_COMPLETE' "$SERIAL"
+grep -Fq 'PHASE297_FTRACE_BEGIN' "$SERIAL"
+grep -Fq 'PHASE297_FTRACE_END' "$SERIAL"
+grep -Fq 'PHASE297_TRACE_COMPLETE trace_rc=0' "$SERIAL"
+if grep -Eq 'Kernel panic|Oops:|BUG: unable to handle|soft lockup|hung_task_panic' "$SERIAL"; then
+  echo 'Phase297 detected a fatal kernel diagnostic in QEMU serial output' >&2
+  exit 1
+fi
+
+grep -nE 'PHASE297_|drm:|\[drm\]|calling .*\+|initcall .* returned' "$SERIAL" \
+  > "$ANALYSIS/serial-key-events.txt" || true
+awk '/PHASE297_FTRACE_BEGIN/{p=1} p{print} /PHASE297_FTRACE_END/{p=0}' "$SERIAL" \
+  > "$ANALYSIS/function-graph-trace.txt"
+
+python3 - <<'PY'
+from pathlib import Path
+phone=Path('phase296-out/config/final.config').read_text().splitlines()
+qemu=Path('phase297-lab-out/qemu/qemu-final.config').read_text().splitlines()
+def asmap(lines):
+ d={}
+ for line in lines:
+  if line.startswith('CONFIG_'):
+   k=line.split('=',1)[0]; d[k]=line
+  elif line.startswith('# CONFIG_') and line.endswith(' is not set'):
+   k=line[2:].split(' ',1)[0]; d[k]=line
+ return d
+p=asmap(phone); q=asmap(qemu)
+keys=sorted(set(p)|set(q))
+out=[]
+for k in keys:
+ if p.get(k) != q.get(k):
+  out.append(f'{k}\n  phone: {p.get(k,"<absent>")}\n  qemu : {q.get(k,"<absent>")}')
+Path('phase297-lab-out/analysis/phone-vs-qemu-config.diff.txt').write_text('\n'.join(out)+'\n')
+PY
+
+cat > "$ANALYSIS/INTERPRETATION.txt" <<'TXT'
+What this lab proves:
+- The exact Phase296 A52 source/config reconstructs and produces the phone Image.
+- The exact A52 msm_drv/msm_atomic/sde_kms objects pass a forced strict compile.
+- Phase296 marker strings and call-site disassembly are archived from those objects.
+- The same patched 5.10 source can boot under ARM64 QEMU with panic/oops/lockup fatal.
+- With FB and DRM_FBDEV_EMULATION disabled, a real userspace process can open a DRM
+  card, negotiate DRM client caps, query resources, submit an atomic ioctl, and
+  produce function-graph traces of the generic DRM/workqueue path.
+
+What it cannot prove:
+- Whether Samsung's physical userspace opens /dev/dri/card* on the A52.
+- Any SM7125 SDE, DSI controller/PHY, panel, regulator, clock or DT behavior.
+- Whether the target F0 5A 5A panel transaction succeeds on hardware.
+
+Therefore Phase296 ramoops remains the decisive physical boundary test, but this
+lab removes compiler, binary-placement, generic-DRM and tracing uncertainty before
+we spend a hardware boot.
+TXT
+
+printf '0\n' > "$ART/exit-status.txt"
+trap - EXIT
+echo 'Phase297 exact-source QEMU trace lab: PASS'

--- a/scripts/298_qemu_trace_lab.sh
+++ b/scripts/298_qemu_trace_lab.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SRC="$PWD/scripts/297_qemu_trace_lab.sh"
+TMP="$PWD/workspace/phase298-qemu-trace-lab.generated.sh"
+
+test -s "$SRC"
+mkdir -p "$PWD/workspace"
+
+python3 - "$SRC" "$TMP" <<'PY'
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+out = Path(sys.argv[2])
+text = src.read_text()
+
+needle = '''# Build a generic ARM64 virt kernel from the already-patched exact Phase296
+# source tree. This config is deliberately separate from the phone config.
+'''
+
+if text.count(needle) != 1:
+    raise SystemExit('Phase298: Phase297 QEMU insertion point missing or ambiguous')
+if 'PHASE298_QEMU_KBUILD_ISOLATION_V1' in text:
+    raise SystemExit('Phase298: source Phase297 script already contains Phase298 isolation')
+
+block = r'''# PHASE298_QEMU_KBUILD_ISOLATION_V1
+# Phase296 reconstructs the real A52 phone tree by grafting hardware-only
+# vendor driver directories into drivers/Makefile.  That is correct for the
+# phone build, but ARM64 defconfig also traverses those grafts even though QEMU
+# virt can never instantiate them.  Phase297 therefore died while compiling
+# A52 DP/SCM/recorder code before qemu-system-aarch64 was ever launched.
+#
+# The exact phone Image and strict A52 display objects have already been built
+# and audited above.  From this point forward, isolate only the generic QEMU
+# Kbuild graph by removing active a52_* path tokens from drivers/Makefile.  The
+# source files themselves remain byte-for-byte present for the archived audit.
+A52_DRIVER_MAKEFILE="$ROOT/drivers/Makefile"
+test -s "$A52_DRIVER_MAKEFILE"
+cp "$A52_DRIVER_MAKEFILE" "$ANALYSIS/drivers-Makefile.phone.txt"
+
+python3 - "$A52_DRIVER_MAKEFILE" "$ANALYSIS/a52-kbuild-isolation.txt" <<'PYISO'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+audit = Path(sys.argv[2])
+original = path.read_text().splitlines()
+rewritten = []
+removed = []
+
+for lineno, line in enumerate(original, 1):
+    code, sep, comment = line.partition('#')
+    if 'a52_' not in code:
+        rewritten.append(line)
+        continue
+
+    indent = code[:len(code) - len(code.lstrip())]
+    tokens = code.split()
+    dropped = [tok for tok in tokens if 'a52_' in tok]
+    kept = [tok for tok in tokens if 'a52_' not in tok]
+
+    if not dropped:
+        rewritten.append(line)
+        continue
+
+    removed.append(f'{lineno}: {line}')
+
+    # Preserve unrelated Kbuild entries if an A52 path shared the line.
+    # If only the assignment and A52 paths remain, comment the original line.
+    if kept and kept[-1] not in {'=', '+=', ':='}:
+        rebuilt = indent + ' '.join(kept)
+        if sep and comment:
+            rebuilt += '  # ' + comment.strip()
+        rewritten.append(rebuilt.rstrip())
+    else:
+        rewritten.append(indent + '# PHASE298_QEMU_ISOLATED: ' + line.strip())
+
+if not removed:
+    raise SystemExit('Phase298: no active a52_* Kbuild entries found in drivers/Makefile')
+
+active = []
+for lineno, line in enumerate(rewritten, 1):
+    code = line.split('#', 1)[0]
+    if 'a52_' in code:
+        active.append(f'{lineno}: {line}')
+if active:
+    raise SystemExit('Phase298: active a52_* Kbuild entries remain: ' + repr(active))
+
+path.write_text('\n'.join(rewritten) + '\n')
+audit.write_text(
+    'PHASE298_QEMU_KBUILD_ISOLATION_V1\n'
+    'Removed active A52-only path tokens after exact phone object audit:\n' +
+    '\n'.join(removed) + '\n'
+)
+print('Phase298 isolated A52-only QEMU Kbuild entries:')
+for item in removed:
+    print('  ' + item)
+PYISO
+
+cp "$A52_DRIVER_MAKEFILE" "$ANALYSIS/drivers-Makefile.qemu.txt"
+for dir in a52_display a52_secure a52_pil; do
+  test -d "$ROOT/drivers/$dir"
+done
+for rel in \
+  drivers/a52_display/msm/msm_drv.c \
+  drivers/a52_display/msm/msm_atomic.c \
+  drivers/a52_display/msm/sde/sde_kms.c \
+  drivers/a52_secure/a52_ack_secure_flight_recorder.c; do
+  test -s "$ROOT/$rel"
+done
+
+'''
+
+out.write_text(text.replace(needle, block + needle, 1))
+print(f'Phase298 generated isolated QEMU driver: {out}')
+PY
+
+chmod +x "$TMP"
+bash "$TMP"

--- a/scripts/298r_qemu_smmu_isolation.sh
+++ b/scripts/298r_qemu_smmu_isolation.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SRC="$PWD/scripts/298_qemu_trace_lab.sh"
+OUT="$PWD/workspace/phase298r-qemu-smmu-isolation.generated.sh"
+
+test -s "$SRC"
+mkdir -p "$PWD/workspace"
+
+python3 - "$SRC" "$OUT" <<'PY'
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+out = Path(sys.argv[2])
+text = src.read_text()
+
+needle = '''chmod +x "$TMP"
+bash "$TMP"
+'''
+if text.count(needle) != 1:
+    raise SystemExit('Phase298R: Phase298 execution tail missing or ambiguous')
+if 'PHASE298R_QEMU_SMMU_ISOLATION_V1' in text:
+    raise SystemExit('Phase298R: source Phase298 script already contains Phase298R isolation')
+
+replacement = r'''# PHASE298R_QEMU_SMMU_ISOLATION_V1
+# Phase298 successfully removed the explicit a52_* driver Kbuild grafts, but
+# the reconstructed phone tree also carries ARM-SMMU work in the normal
+# drivers/iommu path. Generic QEMU virtio DRM does not need the A52/Qualcomm
+# SMMU path, so keep it out of this virtual-only build rather than changing
+# phone-side IOMMU source merely to satisfy QEMU.
+chmod +x "$TMP"
+python3 - "$TMP" <<'PY298R'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+anchor = '''"$cfg" --file "$QOUT/.config" --set-val DEFAULT_HUNG_TASK_TIMEOUT 30
+make -C "$ROOT" O="$QOUT" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig </dev/null
+cp "$QOUT/.config" "$QART/qemu-final.config"
+'''
+if text.count(anchor) != 1:
+    raise SystemExit('Phase298R: QEMU config finalization anchor missing or ambiguous')
+block = '''"$cfg" --file "$QOUT/.config" --set-val DEFAULT_HUNG_TASK_TIMEOUT 30
+
+# PHASE298R_QEMU_SMMU_CONFIG_ISOLATION_V1
+# arm-smmu v2/v3 is irrelevant to the virtio-gpu/ftrace lab and the Phase298
+# artifact proved ARM_SMMU=m was compiling a phone-modified arm-smmu.c against
+# the 5.10 core bus API. Disable both implementations only in the QEMU config.
+grep -nE '^CONFIG_(ARM_SMMU|ARM_SMMU_V3|ARM_SMMU_V3_PMU)=|^# CONFIG_(ARM_SMMU|ARM_SMMU_V3|ARM_SMMU_V3_PMU) is not set' \\
+  "$QOUT/.config" > "$ANALYSIS/qemu-smmu-before-disable.txt" || true
+for s in ARM_SMMU ARM_SMMU_V3 ARM_SMMU_V3_PMU; do
+  "$cfg" --file "$QOUT/.config" -d "$s"
+done
+make -C "$ROOT" O="$QOUT" ARCH=arm64 LLVM=1 LLVM_IAS=1 olddefconfig </dev/null
+
+grep -nE '^CONFIG_(ARM_SMMU|ARM_SMMU_V3|ARM_SMMU_V3_PMU)=|^# CONFIG_(ARM_SMMU|ARM_SMMU_V3|ARM_SMMU_V3_PMU) is not set' \\
+  "$QOUT/.config" > "$ANALYSIS/qemu-smmu-after-disable.txt" || true
+if grep -Eq '^CONFIG_(ARM_SMMU|ARM_SMMU_V3|ARM_SMMU_V3_PMU)=' "$QOUT/.config"; then
+  echo 'Phase298R: ARM SMMU unexpectedly remained enabled in generic QEMU config' >&2
+  grep -nE '^CONFIG_(ARM_SMMU|ARM_SMMU_V3|ARM_SMMU_V3_PMU)=' "$QOUT/.config" >&2 || true
+  exit 1
+fi
+printf '%s\\n' 'PHASE298R_QEMU_SMMU_ISOLATION_V1' > "$ANALYSIS/qemu-smmu-isolation.status"
+cp "$QOUT/.config" "$QART/qemu-final.config"
+'''
+path.write_text(text.replace(anchor, block, 1))
+print(f'Phase298R patched generated QEMU driver: {path}')
+PY298R
+bash "$TMP"
+'''
+
+out.write_text(text.replace(needle, replacement, 1))
+print(f'Phase298R generated driver: {out}')
+PY
+
+chmod +x "$OUT"
+bash "$OUT"

--- a/scripts/299_touchgrass_vs_gki_deep_audit.py
+++ b/scripts/299_touchgrass_vs_gki_deep_audit.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import difflib
+import hashlib
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+TEXT_EXT = {'.c','.h','.S','.s','.dts','.dtsi','.yaml','.yml','.txt','.md','.mk','.cfg','.defconfig'}
+TEXT_NAMES = {'Makefile','Kconfig'}
+
+CRITICAL_FILES = [
+    'dsi/dsi_ctrl.c',
+    'dsi/dsi_ctrl_hw_cmn.c',
+    'dsi/dsi_display.c',
+    'dsi/dsi_panel.c',
+    'msm_gem.c',
+    'msm_gem.h',
+    'msm_drv.c',
+    'msm_atomic.c',
+    'sde/sde_kms.c',
+    'sde/sde_encoder.c',
+    'sde/sde_connector.c',
+    'sde/sde_power_handle.c',
+]
+
+PATTERNS = {
+    'cmd-buffer-allocation': [r'MSM_BO_UNCACHED', r'msm_gem_new', r'msm_gem_get_iova', r'msm_gem_get_vaddr'],
+    'cmd-buffer-sync': [r'msm_gem_sync', r'dma_sync_sg_for_device', r'dma_sync_sg_for_cpu', r'DMA_BIDIRECTIONAL'],
+    'dsi-memory-fetch': [r'DSI_CTRL_CMD_FETCH_MEMORY', r'DSI_CTRL_CMD_FIFO_STORE', r'cmd_buffer_iova', r'tx_cmd_buf'],
+    'dsi-dma-kickoff': [r'trigger_command_dma', r'kickoff_command', r'DSI_CMD_MODE_DMA_CTRL', r'DSI_CMD_MODE_DMA_SW_TRIGGER'],
+    'dsi-completion': [r'DMA_DONE', r'wait_for_completion_timeout', r'reinit_completion', r'complete\('],
+    'iommu': [r'iommu_', r'arm_smmu', r'msm_smmu', r'iova_to_phys', r'MSM_SMMU_DOMAIN_UNSECURE'],
+    'dma-api': [r'dma_map', r'dma_unmap', r'dma_sync', r'dma_set_mask', r'dma_coherent'],
+    'interconnect': [r'msm_bus_', r'icc_', r'interconnect', r'ab_quota', r'ib_quota'],
+    'clock': [r'clk_prepare_enable', r'clk_disable_unprepare', r'clk_set_rate', r'clk_get_rate'],
+    'runtime-pm': [r'pm_runtime_', r'runtime_suspend', r'runtime_resume'],
+    'regulator': [r'regulator_enable', r'regulator_disable', r'regulator_set_voltage'],
+    'atomic': [r'atomic_check', r'atomic_commit', r'prepare_commit', r'complete_commit', r'drm_dev_register'],
+    'continuous-splash': [r'cont_splash', r'continuous_splash', r'splash_enabled'],
+    'irq': [r'request_irq', r'enable_irq', r'disable_irq', r'irq_status', r'clear.*irq', r'IRQ_HANDLED'],
+}
+
+LOWER_LAYER_PAIRS = [
+    ('ARM SMMU', 'drivers/iommu/arm-smmu.c', 'drivers/iommu/arm/arm-smmu/arm-smmu.c'),
+    ('DMA mapping core', 'kernel/dma/mapping.c', 'kernel/dma/mapping.c'),
+    ('DMA direct', 'kernel/dma/direct.c', 'kernel/dma/direct.c'),
+    ('QCOM SCM', 'drivers/firmware/qcom_scm.c', 'drivers/firmware/qcom_scm.c'),
+    ('RPMh', 'drivers/soc/qcom/rpmh.c', 'drivers/soc/qcom/rpmh.c'),
+    ('Command DB', 'drivers/soc/qcom/cmd-db.c', 'drivers/soc/qcom/cmd-db.c'),
+]
+
+CONFIG_PREFIXES = (
+    'CONFIG_IOMMU','CONFIG_ARM_SMMU','CONFIG_DMA','CONFIG_SWIOTLB','CONFIG_CMA',
+    'CONFIG_INTERCONNECT','CONFIG_QCOM','CONFIG_COMMON_CLK','CONFIG_CLK_',
+    'CONFIG_PM','CONFIG_REGULATOR','CONFIG_DRM','CONFIG_FB','CONFIG_IRQ',
+)
+
+
+def sha(path: Path) -> str:
+    h=hashlib.sha256()
+    with path.open('rb') as f:
+        for b in iter(lambda:f.read(1<<20), b''):
+            h.update(b)
+    return h.hexdigest()
+
+
+def is_text(path: Path) -> bool:
+    return path.name in TEXT_NAMES or path.suffix in TEXT_EXT
+
+
+def files(root: Path) -> dict[str,Path]:
+    out={}
+    if not root.exists(): return out
+    for p in root.rglob('*'):
+        if p.is_file() and '.git' not in p.parts:
+            out[p.relative_to(root).as_posix()]=p
+    return out
+
+
+def read(path: Path) -> str:
+    return path.read_text(errors='replace')
+
+
+def contexts(path: Path, regexes: list[str], radius: int=3) -> list[dict]:
+    if not path.exists() or not is_text(path): return []
+    lines=read(path).splitlines()
+    rx=[re.compile(x, re.I) for x in regexes]
+    hits=[]
+    for i,line in enumerate(lines):
+        if any(r.search(line) for r in rx):
+            lo=max(0,i-radius); hi=min(len(lines),i+radius+1)
+            hits.append({'line':i+1,'text':line.strip(),'context':'\n'.join(f'{n+1:5d}: {lines[n]}' for n in range(lo,hi))})
+    return hits
+
+
+def parse_config(path: Path) -> dict[str,str]:
+    d={}
+    if not path.exists(): return d
+    for raw in read(path).splitlines():
+        if raw.startswith('CONFIG_') and '=' in raw:
+            k,v=raw.split('=',1); d[k]=v
+        elif raw.startswith('# CONFIG_') and raw.endswith(' is not set'):
+            d[raw[2:].split(' ',1)[0]]='n'
+    return d
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--touchgrass',type=Path,required=True)
+    ap.add_argument('--gki',type=Path,required=True)
+    ap.add_argument('--gki-config',type=Path,required=True)
+    ap.add_argument('--output',type=Path,required=True)
+    a=ap.parse_args()
+    tg=a.touchgrass; gki=a.gki; out=a.output
+    tgdisp=tg/'techpack/display/msm'; gdisp=gki/'drivers/a52_display/msm'
+    for p in (tgdisp,gdisp,a.gki_config):
+        if not p.exists(): raise SystemExit(f'missing required input: {p}')
+    out.mkdir(parents=True,exist_ok=True)
+    (out/'diffs/display').mkdir(parents=True,exist_ok=True)
+    (out/'contexts').mkdir(parents=True,exist_ok=True)
+
+    T=files(tgdisp); G=files(gdisp); names=sorted(set(T)|set(G))
+    rows=[]; counts=Counter(); changed=[]
+    for rel in names:
+        tp=T.get(rel); gp=G.get(rel)
+        if tp and gp:
+            th,gh=sha(tp),sha(gp)
+            status='identical' if th==gh else 'modified'
+        elif tp:
+            th,gh,status=sha(tp),'','touchgrass-only'
+        else:
+            th,gh,status='',sha(gp),'gki-only'
+        counts[status]+=1
+        rows.append((rel,status,th,gh,tp.stat().st_size if tp else '',gp.stat().st_size if gp else ''))
+        if status=='modified': changed.append(rel)
+        if status=='modified' and is_text(tp) and is_text(gp) and tp.stat().st_size<2_000_000 and gp.stat().st_size<2_000_000:
+            diff=''.join(difflib.unified_diff(read(tp).splitlines(True),read(gp).splitlines(True),fromfile='touchgrass/'+rel,tofile='gki/'+rel,n=5))
+            target=out/'diffs/display'/(rel.replace('/','__')+'.diff')
+            target.write_text(diff)
+    with (out/'display-file-parity.tsv').open('w',newline='') as f:
+        w=csv.writer(f,delimiter='\t'); w.writerow(['relative_path','status','touchgrass_sha256','gki_sha256','touchgrass_bytes','gki_bytes']); w.writerows(rows)
+
+    critical=[]
+    for rel in CRITICAL_FILES:
+        tp=tgdisp/rel; gp=gdisp/rel
+        critical.append({'file':rel,'touchgrass':tp.exists(),'gki':gp.exists(),'identical':tp.exists() and gp.exists() and sha(tp)==sha(gp),'touchgrass_sha256':sha(tp) if tp.exists() else None,'gki_sha256':sha(gp) if gp.exists() else None})
+    (out/'critical-file-parity.json').write_text(json.dumps(critical,indent=2)+'\n')
+
+    # Extract critical semantic contexts from both display trees.
+    semantic={}
+    for category,regexes in PATTERNS.items():
+        semantic[category]={'touchgrass':[],'gki':[]}
+        for label,root,key in [('touchgrass',tgdisp,'touchgrass'),('gki',gdisp,'gki')]:
+            for rel,p in files(root).items():
+                if not is_text(p): continue
+                hs=contexts(p,regexes,2)
+                for h in hs[:40]:
+                    semantic[category][key].append({'file':rel,**h})
+        # bounded human-readable context file
+        lines=[f'# {category}']
+        for side in ('touchgrass','gki'):
+            lines += ['',f'## {side}']
+            for h in semantic[category][side][:120]:
+                lines += ['',f"### {h['file']}:{h['line']}",'```',h['context'],'```']
+        (out/'contexts'/f'{category}.md').write_text('\n'.join(lines)+'\n')
+    (out/'semantic-hit-counts.json').write_text(json.dumps({k:{s:len(v[s]) for s in ('touchgrass','gki')} for k,v in semantic.items()},indent=2)+'\n')
+
+    # Fingerprint lower layers where unchanged vendor display code meets a new kernel.
+    lower=[]
+    for label,tr,gr in LOWER_LAYER_PAIRS:
+        tp=tg/tr; gp=gki/gr
+        item={'label':label,'touchgrass_path':tr,'gki_path':gr,'touchgrass_exists':tp.exists(),'gki_exists':gp.exists()}
+        if tp.exists(): item['touchgrass_sha256']=sha(tp)
+        if gp.exists(): item['gki_sha256']=sha(gp)
+        if tp.exists() and gp.exists():
+            t=read(tp); g=read(gp)
+            item['identical']=sha(tp)==sha(gp)
+            probes=['dma_sync_sg_for_device','dma_map_sg','iommu_map','iommu_unmap','iova_to_phys','arm_smmu_map','arm_smmu_attach_dev','pm_runtime','of_dma_configure']
+            item['symbol_presence']={x:{'touchgrass':x in t,'gki':x in g} for x in probes}
+            if is_text(tp) and is_text(gp) and tp.stat().st_size<2_000_000 and gp.stat().st_size<2_000_000:
+                d=''.join(difflib.unified_diff(t.splitlines(True),g.splitlines(True),fromfile='touchgrass/'+tr,tofile='gki/'+gr,n=2))
+                (out/'diffs'/(label.lower().replace(' ','-')+'.diff')).write_text(d)
+        lower.append(item)
+    (out/'lower-layer-fingerprint.json').write_text(json.dumps(lower,indent=2)+'\n')
+
+    cfg=parse_config(a.gki_config)
+    selected={k:v for k,v in sorted(cfg.items()) if k.startswith(CONFIG_PREFIXES)}
+    (out/'phase296-critical-config.txt').write_text('\n'.join(f'{k}={v}' for k,v in selected.items())+'\n')
+
+    # Inventory all project instrumentation/compatibility markers still present in reconstructed display tree.
+    markers=[]
+    for rel,p in G.items():
+        if not is_text(p): continue
+        for i,line in enumerate(read(p).splitlines(),1):
+            if 'A52_PHASE' in line or 'P276 ' in line or 'GDM ' in line:
+                markers.append({'file':rel,'line':i,'text':line.strip()})
+    (out/'reconstructed-display-markers.json').write_text(json.dumps(markers,indent=2)+'\n')
+
+    crit_changed=[x['file'] for x in critical if x['touchgrass'] and x['gki'] and not x['identical']]
+    risks=[]
+    def risk(rank,title,evidence,next_test): risks.append({'rank':rank,'title':title,'evidence':evidence,'next_test':next_test})
+    risk(1,'DSI command-buffer DMA coherency / DMA-device semantic mismatch',
+         'TouchGrass memory-fetch uses GEM-backed uncached memory, an IOVA and dma_sync_sg_for_device. The vendor display code is running on a different 5.10 DMA/IOMMU implementation; a valid-looking IOVA can coexist with wrong cache ownership or DMA-device semantics.',
+         'At the target F0 5A 5A command record cmd_buffer_iova, translated PA, SG DMA address/length, aspace device name/coherent mask, first bytes before and after dma_sync, then compare device-visible memory if possible.')
+    risk(2,'DSI command DMA programming or completion IRQ semantic mismatch',
+         'The established boundary is memory-fetch kickoff followed by missing DMA_DONE. Register programming and IRQ acknowledge/order are therefore direct suspects even when probe/bind succeeds.',
+         'Compare Golden/GKI DMA_CTRL, OFFSET, LENGTH, SW_TRIGGER, raw interrupt status, mask, clear and completion state at identical points.')
+    risk(3,'Interconnect / bus vote mismatch during command fetch',
+         'Probe can succeed with register access while a memory DMA fetch stalls if the path between memory and DSI is not voted or clocked equivalently. 4.19 vendor msm-bus assumptions are not the same implementation as 5.10 interconnect.',
+         'Capture active bus/ICC votes and relevant clocks immediately before kickoff on Golden and GKI; test a minimally forced safe vote only if evidence shows a gap.')
+    risk(4,'Runtime PM / clock / power-domain ordering mismatch',
+         'A transplanted vendor driver may call the same functions while 5.10 provider/runtime-PM ordering differs. This can leave the controller register-visible but its DMA sub-block or bus path gated.',
+         'Capture runtime PM usage/status plus byte/pixel/esc/core clock enabled/rate state at pre-kickoff and timeout.')
+    risk(5,'Atomic handoff triggers a valid vendor path at the wrong lifecycle point',
+         'Phase296 exists because probe and DRM bind are proven. If userspace opens DRM and submits atomic state at a lifecycle point different from Golden, the first panel command can expose a lower-layer latent defect.',
+         'Use 296O/A/C/W/K markers to establish the caller/lifecycle boundary, then correlate it with the failing DSI transaction.')
+    risk(6,'SMMU translation/root fault',
+         'Still relevant structurally, but Phase279/280 were specifically designed to distinguish this and move downstream when IOVA/root/fault state are clean.',
+         'Re-read retained Phase280 evidence before spending another boot; only revive this as top suspect if mapping/root/fault snapshots are abnormal.')
+    (out/'risk-ranking.json').write_text(json.dumps(risks,indent=2)+'\n')
+
+    report=[
+        '# Phase299 TouchGrass vs reconstructed Phase296 GKI deep audit', '',
+        '## Scope','',
+        f'- TouchGrass display root: `{tgdisp}`',
+        f'- Reconstructed GKI display root: `{gdisp}`',
+        f'- Display files: identical={counts["identical"]}, modified={counts["modified"]}, TouchGrass-only={counts["touchgrass-only"]}, GKI-only={counts["gki-only"]}.','',
+        '## Critical-path file parity',''
+    ]
+    for x in critical:
+        state='IDENTICAL' if x['identical'] else ('MODIFIED' if x['touchgrass'] and x['gki'] else 'MISSING/EXTRA')
+        report.append(f"- `{x['file']}`: **{state}**")
+    report += ['', '## Highest-priority hypotheses','']
+    for r in risks:
+        report += [f"### {r['rank']}. {r['title']}",r['evidence'],'',f"Next discriminating test: {r['next_test']}",'']
+    report += ['## Modified critical files','']
+    report += [f'- `{x}`' for x in crit_changed] or ['- none']
+    report += ['', '## Important interpretation','',
+        'Identical vendor display source does not imply identical hardware behavior. The port changes the kernel services underneath it. A memory-fetch DSI command is a cross-subsystem event involving GEM memory, cache ownership, IOVA/SMMU translation, interconnect, clocks, controller DMA registers and IRQ completion. The audit therefore treats lower-layer semantic changes as first-class suspects.','']
+    (out/'REPORT.md').write_text('\n'.join(report)+'\n')
+
+    meta={'artifact_type':'phase299-source-audit-not-flashable','touchgrass_display_files':len(T),'gki_display_files':len(G),'counts':dict(counts),'critical_modified':crit_changed,'marker_count':len(markers)}
+    (out/'metadata.json').write_text(json.dumps(meta,indent=2)+'\n')
+    with (out/'SHA256SUMS').open('w') as f:
+        for p in sorted(x for x in out.rglob('*') if x.is_file() and x.name!='SHA256SUMS'):
+            f.write(f'{sha(p)}  {p.relative_to(out).as_posix()}\n')
+    print(json.dumps(meta,indent=2))
+    print((out/'REPORT.md').read_text())
+
+if __name__=='__main__':
+    main()

--- a/scripts/299r_rpmh_solver_contract_audit.py
+++ b/scripts/299r_rpmh_solver_contract_audit.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+TEXT_EXT = {'.c', '.h', '.S', '.s', '.dts', '.dtsi', '.mk', '.txt', '.cfg', '.defconfig'}
+TEXT_NAMES = {'Makefile', 'Kconfig'}
+
+SYMBOLS = [
+    'rpmh_mode_solver_set',
+    'rpmh_write_ctrl_data',
+    'rpmh_rsc_mode_solver_set',
+    'rpmh_rsc_write_ctrl_data',
+]
+TOKENS = SYMBOLS + [
+    'in_solver_mode',
+    'CONTROL_TCS',
+    'ACTIVE_TCS',
+]
+
+TOUCHGRASS_KEY_FILES = {
+    'display_rsc': 'techpack/display/msm/sde_rsc.c',
+    'rpmh_header': 'include/soc/qcom/rpmh.h',
+    'rpmh_core': 'drivers/soc/qcom/rpmh.c',
+    'rpmh_rsc': 'drivers/soc/qcom/rpmh-rsc.c',
+}
+GKI_KEY_FILES = {
+    'display_rsc': 'drivers/a52_display/msm/sde_rsc.c',
+    'rpmh_header': 'include/soc/qcom/rpmh.h',
+    'rpmh_core': 'drivers/soc/qcom/rpmh.c',
+    'rpmh_rsc': 'drivers/soc/qcom/rpmh-rsc.c',
+    'display_makefile': 'drivers/a52_display/msm/Makefile',
+}
+
+
+def sha(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for block in iter(lambda: f.read(1 << 20), b''):
+            h.update(block)
+    return h.hexdigest()
+
+
+def is_text(path: Path) -> bool:
+    return path.name in TEXT_NAMES or path.suffix in TEXT_EXT
+
+
+def read(path: Path) -> str:
+    return path.read_text(errors='replace')
+
+
+def config_value(path: Path, key: str) -> str | None:
+    if not path.exists():
+        return None
+    yes = f'{key}='
+    no = f'# {key} is not set'
+    for line in read(path).splitlines():
+        if line.startswith(yes):
+            return line.split('=', 1)[1]
+        if line == no:
+            return 'n'
+    return None
+
+
+def source_locations(root: Path, label: str) -> list[dict]:
+    rows: list[dict] = []
+    for path in root.rglob('*'):
+        if not path.is_file() or '.git' in path.parts or not is_text(path):
+            continue
+        try:
+            text = read(path)
+        except OSError:
+            continue
+        if not any(token in text for token in TOKENS):
+            continue
+        rel = path.relative_to(root).as_posix()
+        for lineno, line in enumerate(text.splitlines(), 1):
+            hits = [token for token in TOKENS if token in line]
+            if hits:
+                rows.append({
+                    'tree': label,
+                    'file': rel,
+                    'line': lineno,
+                    'tokens': ','.join(hits),
+                    'text': line.strip(),
+                })
+    return rows
+
+
+def key_file_snapshot(root: Path, mapping: dict[str, str]) -> dict:
+    out = {}
+    for name, rel in mapping.items():
+        p = root / rel
+        item = {'path': rel, 'exists': p.exists()}
+        if p.exists() and p.is_file():
+            text = read(p) if is_text(p) else ''
+            item['sha256'] = sha(p)
+            item['bytes'] = p.stat().st_size
+            item['token_counts'] = {token: text.count(token) for token in TOKENS}
+            item['solver_calls'] = {
+                symbol: len(re.findall(r'\b' + re.escape(symbol) + r'\s*\(', text))
+                for symbol in SYMBOLS
+            }
+        out[name] = item
+    return out
+
+
+def run_nm(tool: str, path: Path, extra: list[str] | None = None) -> dict:
+    if not path.exists():
+        return {'exists': False, 'path': str(path), 'matches': []}
+    cmd = [tool]
+    if extra:
+        cmd += extra
+    cmd.append(str(path))
+    try:
+        cp = subprocess.run(cmd, text=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, timeout=60, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {'exists': True, 'path': str(path), 'error': str(exc), 'matches': []}
+    matches = [line for line in cp.stdout.splitlines()
+               if any(symbol in line for symbol in SYMBOLS)]
+    return {
+        'exists': True,
+        'path': str(path),
+        'returncode': cp.returncode,
+        'matches': matches,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--touchgrass', type=Path, required=True)
+    ap.add_argument('--gki', type=Path, required=True)
+    ap.add_argument('--gki-config', type=Path, required=True)
+    ap.add_argument('--build-out', type=Path, required=True)
+    ap.add_argument('--output', type=Path, required=True)
+    a = ap.parse_args()
+
+    tg = a.touchgrass.resolve()
+    gki = a.gki.resolve()
+    bout = a.build_out.resolve()
+    out = a.output.resolve()
+    for p in (tg, gki, a.gki_config):
+        if not p.exists():
+            raise SystemExit(f'missing required input: {p}')
+    out.mkdir(parents=True, exist_ok=True)
+
+    tg_rows = source_locations(tg, 'touchgrass')
+    gki_rows = source_locations(gki, 'gki-reconstructed')
+    rows = tg_rows + gki_rows
+    with (out / 'symbol-locations.tsv').open('w', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=['tree', 'file', 'line', 'tokens', 'text'], delimiter='\t')
+        w.writeheader()
+        w.writerows(rows)
+
+    tg_key = key_file_snapshot(tg, TOUCHGRASS_KEY_FILES)
+    gki_key = key_file_snapshot(gki, GKI_KEY_FILES)
+    tg_sde = tg / TOUCHGRASS_KEY_FILES['display_rsc']
+    gki_sde = gki / GKI_KEY_FILES['display_rsc']
+
+    object_path = bout / 'drivers/a52_display/msm/sde_rsc.o'
+    vmlinux_path = bout / 'vmlinux'
+    object_nm = run_nm('llvm-nm', object_path, ['-u'])
+    vmlinux_nm = run_nm('llvm-nm', vmlinux_path, ['-n'])
+
+    module_symvers = bout / 'Module.symvers'
+    symvers_matches = []
+    if module_symvers.exists():
+        symvers_matches = [line for line in read(module_symvers).splitlines()
+                           if any(symbol in line for symbol in SYMBOLS)]
+
+    gki_symbol_files: dict[str, list[str]] = {}
+    tg_symbol_files: dict[str, list[str]] = {}
+    for symbol in SYMBOLS:
+        gki_symbol_files[symbol] = sorted({r['file'] for r in gki_rows if symbol in r['tokens'].split(',')})
+        tg_symbol_files[symbol] = sorted({r['file'] for r in tg_rows if symbol in r['tokens'].split(',')})
+
+    display_identical = bool(tg_sde.exists() and gki_sde.exists() and sha(tg_sde) == sha(gki_sde))
+    display_solver_counts = {}
+    if gki_sde.exists():
+        text = read(gki_sde)
+        display_solver_counts = {s: len(re.findall(r'\b' + re.escape(s) + r'\s*\(', text)) for s in SYMBOLS}
+
+    config = {
+        'CONFIG_DRM_SDE_RSC': config_value(a.gki_config, 'CONFIG_DRM_SDE_RSC'),
+        'CONFIG_QCOM_RPMH': config_value(a.gki_config, 'CONFIG_QCOM_RPMH'),
+    }
+
+    contract = {
+        'artifact_type': 'phase299r-rpmh-solver-contract-audit-not-flashable',
+        'touchgrass_root': str(tg),
+        'gki_root': str(gki),
+        'build_out': str(bout),
+        'config': config,
+        'display_sde_rsc_identical': display_identical,
+        'reconstructed_display_solver_call_counts': display_solver_counts,
+        'touchgrass_key_files': tg_key,
+        'gki_key_files': gki_key,
+        'touchgrass_symbol_files': tg_symbol_files,
+        'gki_symbol_files': gki_symbol_files,
+        'sde_rsc_object': object_nm,
+        'vmlinux': vmlinux_nm,
+        'module_symvers_matches': symvers_matches,
+    }
+
+    # Classification is deliberately evidence-only. No missing implementation is
+    # converted into a functional fix by this audit.
+    call_present = display_solver_counts.get('rpmh_mode_solver_set', 0) > 0
+    source_provider_present = any(
+        f != GKI_KEY_FILES['display_rsc']
+        for f in gki_symbol_files.get('rpmh_mode_solver_set', [])
+    )
+    object_built = object_nm.get('exists', False)
+    object_ref = any('rpmh_mode_solver_set' in x for x in object_nm.get('matches', []))
+    linked_symbol = any('rpmh_mode_solver_set' in x for x in vmlinux_nm.get('matches', []))
+
+    if not call_present:
+        classification = 'C_OR_D: reconstructed SDE RSC no longer calls rpmh_mode_solver_set; inspect its diff for removal or translation'
+    elif source_provider_present and linked_symbol:
+        classification = 'A_OR_E: call retained and a linked source implementation exists; compare its semantics with TouchGrass'
+    elif call_present and object_built and object_ref and not linked_symbol:
+        classification = 'LINK_CONTRADICTION: built SDE RSC object references solver API but final vmlinux has no matching symbol'
+    elif call_present and not source_provider_present:
+        classification = 'B_OR_BUILD_GATING: call retained but no second source occurrence provides the API; inspect object/config/preprocessor path'
+    else:
+        classification = 'UNRESOLVED: inspect emitted source/object evidence'
+    contract['classification'] = classification
+
+    (out / 'rpmh-solver-contract.json').write_text(json.dumps(contract, indent=2, sort_keys=True) + '\n')
+
+    lines = [
+        '# Phase299R SDE RSC to RPMh solver contract audit',
+        '',
+        'This is source/build evidence only. It makes no kernel or hardware behavior change.',
+        '',
+        f'- CONFIG_DRM_SDE_RSC: `{config["CONFIG_DRM_SDE_RSC"]}`',
+        f'- TouchGrass and reconstructed `sde_rsc.c` byte-identical: `{display_identical}`',
+        f'- Reconstructed `rpmh_mode_solver_set()` call count in sde_rsc.c: `{display_solver_counts.get("rpmh_mode_solver_set", 0)}`',
+        f'- Reconstructed `sde_rsc.o` exists: `{object_built}`',
+        f'- `sde_rsc.o` has an unresolved solver reference: `{object_ref}`',
+        f'- Final vmlinux exposes a solver symbol: `{linked_symbol}`',
+        '',
+        '## Classification',
+        '',
+        classification,
+        '',
+        '## Reconstructed source locations',
+        '',
+    ]
+    for symbol in SYMBOLS:
+        lines.append(f'### {symbol}')
+        files_here = gki_symbol_files.get(symbol, [])
+        if files_here:
+            lines.extend(f'- `{p}`' for p in files_here)
+        else:
+            lines.append('- none')
+        lines.append('')
+    lines += [
+        '## Interpretation rule',
+        '',
+        'If the downstream SDE RSC calls are preserved but the linked 5.10 implementation is absent or semantically different, the display can compile through compatibility work while still violating the original solver/TCS state contract. This audit only identifies that boundary. A later hardware phase must remain observation-only until the exact implementation is known.',
+        '',
+    ]
+    (out / 'REPORT.md').write_text('\n'.join(lines))
+
+    with (out / 'SHA256SUMS').open('w') as f:
+        for p in sorted(x for x in out.rglob('*') if x.is_file() and x.name != 'SHA256SUMS'):
+            f.write(f'{sha(p)}  {p.relative_to(out).as_posix()}\n')
+
+    print(json.dumps({
+        'classification': classification,
+        'display_identical': display_identical,
+        'solver_call_count': display_solver_counts.get('rpmh_mode_solver_set', 0),
+        'sde_rsc_object_exists': object_built,
+        'object_solver_reference': object_ref,
+        'linked_solver_symbol': linked_symbol,
+    }, indent=2))
+    print((out / 'REPORT.md').read_text())
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/299s_phase13_rpmh_runtime_shim_audit.py
+++ b/scripts/299s_phase13_rpmh_runtime_shim_audit.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+APIS = ('rpmh_mode_solver_set', 'rpmh_flush')
+
+
+def read(path: Path) -> str:
+    return path.read_text(errors='replace')
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for block in iter(lambda: f.read(1 << 20), b''):
+            h.update(block)
+    return h.hexdigest()
+
+
+def nm(path: Path, undefined: bool = False) -> dict:
+    if not path.exists():
+        return {'exists': False, 'path': str(path), 'matches': []}
+    cmd = ['llvm-nm'] + (['-u'] if undefined else ['-n']) + [str(path)]
+    cp = subprocess.run(cmd, text=True, stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT, check=False, timeout=60)
+    return {
+        'exists': True,
+        'path': str(path),
+        'returncode': cp.returncode,
+        'matches': [line for line in cp.stdout.splitlines()
+                    if any(api in line for api in APIS)],
+    }
+
+
+def function_signatures(text: str, name: str) -> list[str]:
+    pat = re.compile(
+        r'(?m)^\s*(?:static\s+)?(?:inline\s+)?(?:int|void|bool)\s+'
+        + re.escape(name) + r'\s*\([^;{]*\)'
+    )
+    return [' '.join(m.group(0).split()) for m in pat.finditer(text)]
+
+
+def macro_lines(text: str, name: str) -> list[str]:
+    pat = re.compile(r'(?m)^\s*#\s*define\s+' + re.escape(name) + r'\b.*$')
+    return [m.group(0).strip() for m in pat.finditer(text)]
+
+
+def call_count(text: str, name: str) -> int:
+    return len(re.findall(r'\b' + re.escape(name) + r'\s*\(', text))
+
+
+def source_context(text: str, needle: str, radius: int = 12) -> list[str]:
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if needle in line:
+            lo = max(0, idx - radius)
+            hi = min(len(lines), idx + radius + 1)
+            return [f'{i + 1}: {lines[i]}' for i in range(lo, hi)]
+    return []
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--touchgrass', type=Path, required=True)
+    ap.add_argument('--gki', type=Path, required=True)
+    ap.add_argument('--build-out', type=Path, required=True)
+    ap.add_argument('--output', type=Path, required=True)
+    a = ap.parse_args()
+
+    tg = a.touchgrass.resolve()
+    gki = a.gki.resolve()
+    bout = a.build_out.resolve()
+    out = a.output.resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    required = [
+        tg / 'techpack/display/msm/sde_rsc.c',
+        tg / 'drivers/soc/qcom/rpmh.c',
+        gki / 'drivers/a52_display/msm/sde_rsc.c',
+        gki / 'drivers/soc/qcom/rpmh.c',
+        gki / 'a52-port-compat.h',
+    ]
+    for p in required:
+        if not p.exists():
+            raise SystemExit(f'missing required input: {p}')
+
+    tg_sde = read(tg / 'techpack/display/msm/sde_rsc.c')
+    tg_rpmh = read(tg / 'drivers/soc/qcom/rpmh.c')
+    gki_sde = read(gki / 'drivers/a52_display/msm/sde_rsc.c')
+    gki_rpmh = read(gki / 'drivers/soc/qcom/rpmh.c')
+    compat = read(gki / 'a52-port-compat.h')
+
+    obj = nm(bout / 'drivers/a52_display/msm/sde_rsc.o', undefined=True)
+    vmlinux = nm(bout / 'vmlinux', undefined=False)
+
+    phase13_markers = {
+        'all_known': 'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS' in compat,
+        'diagnostic_non_flashable': 'diagnostic, non-flashable' in compat,
+        'secondary_compile_only': 'A52_PHASE13_SECONDARY_COMPAT: compile-only follow-up.' in compat,
+    }
+
+    apis = {}
+    for name in APIS:
+        tg_calls = call_count(tg_sde, name)
+        gki_calls = call_count(gki_sde, name)
+        macros = macro_lines(compat, name)
+        object_refs = [x for x in obj.get('matches', []) if name in x]
+        linked = [x for x in vmlinux.get('matches', []) if name in x]
+        tg_sigs = function_signatures(tg_rpmh, name)
+        gki_sigs = function_signatures(gki_rpmh, name)
+        if macros and gki_calls and not object_refs:
+            if name == 'rpmh_flush' and gki_sigs and tg_sigs and gki_sigs != tg_sigs:
+                classification = 'PROVEN_PHASE13_MACRO_ERASURE_WITH_API_DRIFT'
+            else:
+                classification = 'PROVEN_PHASE13_MACRO_ERASURE'
+        elif gki_calls and object_refs:
+            classification = 'CALL_SURVIVES_PREPROCESSING'
+        elif not gki_calls:
+            classification = 'CALL_NOT_PRESENT_IN_RECONSTRUCTED_SDE'
+        else:
+            classification = 'UNRESOLVED'
+        apis[name] = {
+            'classification': classification,
+            'touchgrass_sde_call_count': tg_calls,
+            'phase296_sde_call_count': gki_calls,
+            'compat_macro_lines': macros,
+            'touchgrass_rpmh_signatures': tg_sigs,
+            'phase296_rpmh_signatures': gki_sigs,
+            'sde_rsc_object_references': object_refs,
+            'vmlinux_symbols': linked,
+        }
+
+    flush_ctx = source_context(gki_sde, 'rpmh_flush(rsc->rpmh_dev)', 16)
+    solver_ctx = source_context(gki_sde, 'rpmh_mode_solver_set(rsc->rpmh_dev', 10)
+
+    result = {
+        'artifact_type': 'phase299s-phase13-rpmh-runtime-shim-audit-not-flashable',
+        'phase13_markers': phase13_markers,
+        'apis': apis,
+        'sde_rsc_object': obj,
+        'vmlinux': vmlinux,
+        'phase296_files': {
+            'a52-port-compat.h': sha256(gki / 'a52-port-compat.h'),
+            'drivers/a52_display/msm/sde_rsc.c': sha256(gki / 'drivers/a52_display/msm/sde_rsc.c'),
+            'drivers/soc/qcom/rpmh.c': sha256(gki / 'drivers/soc/qcom/rpmh.c'),
+            'drivers/soc/qcom/rpmh-rsc.c': sha256(gki / 'drivers/soc/qcom/rpmh-rsc.c'),
+        },
+        'touchgrass_files': {
+            'techpack/display/msm/sde_rsc.c': sha256(tg / 'techpack/display/msm/sde_rsc.c'),
+            'drivers/soc/qcom/rpmh.c': sha256(tg / 'drivers/soc/qcom/rpmh.c'),
+            'drivers/soc/qcom/rpmh-rsc.c': sha256(tg / 'drivers/soc/qcom/rpmh-rsc.c'),
+        },
+        'phase296_flush_call_context': flush_ctx,
+        'phase296_solver_call_context': solver_ctx,
+    }
+    result['combined_classification'] = (
+        'PROVEN_PHASE13_RUNTIME_SEMANTIC_ERASURE'
+        if all(apis[n]['classification'].startswith('PROVEN_PHASE13_MACRO_ERASURE') for n in APIS)
+        else 'PARTIAL_OR_UNRESOLVED'
+    )
+
+    (out / 'phase13-rpmh-runtime-shims.json').write_text(
+        json.dumps(result, indent=2, sort_keys=True) + '\n')
+
+    report = [
+        '# Phase299S Phase13 RPMh runtime-shim audit',
+        '',
+        'Source/build evidence only. This workflow does not create a boot image and does not change kernel behavior.',
+        '',
+        f'**Combined classification: `{result["combined_classification"]}`**',
+        '',
+        '## Phase13 provenance markers',
+        '',
+    ]
+    for key, value in phase13_markers.items():
+        report.append(f'- {key}: `{value}`')
+    report += ['', '## API results', '']
+    for name in APIS:
+        x = apis[name]
+        report += [
+            f'### `{name}()`',
+            '',
+            f'- classification: `{x["classification"]}`',
+            f'- TouchGrass SDE call count: `{x["touchgrass_sde_call_count"]}`',
+            f'- reconstructed Phase296 SDE call count: `{x["phase296_sde_call_count"]}`',
+            f'- compatibility macro: `{x["compat_macro_lines"]}`',
+            f'- TouchGrass provider signature(s): `{x["touchgrass_rpmh_signatures"]}`',
+            f'- Phase296 5.10 provider signature(s): `{x["phase296_rpmh_signatures"]}`',
+            f'- unresolved reference in compiled `sde_rsc.o`: `{x["sde_rsc_object_references"]}`',
+            f'- final `vmlinux` symbol(s): `{x["vmlinux_symbols"]}`',
+            '',
+        ]
+    report += [
+        '## Interpretation',
+        '',
+        'A downstream SDE source call that remains visible in reconstructed source but has no unresolved reference in the compiled SDE object is being removed before link time. When the exact compatibility header contains a no-op macro for that API, this is direct build evidence of semantic erasure rather than a missing linker provider.',
+        '',
+        'If both APIs classify as proven Phase13 macro erasure, the next hardware phase should instrument the call sites and the underlying RPMh write/cache/control-TCS path without restoring either behavior. That separates runtime consequence from repair.',
+        '',
+        '## Phase296 `rpmh_flush()` call context',
+        '',
+        '```c',
+        *flush_ctx,
+        '```',
+        '',
+    ]
+    (out / 'REPORT.md').write_text('\n'.join(report) + '\n')
+
+    with (out / 'SHA256SUMS').open('w') as f:
+        for p in sorted(x for x in out.iterdir() if x.is_file() and x.name != 'SHA256SUMS'):
+            f.write(f'{sha256(p)}  {p.name}\n')
+
+    print((out / 'REPORT.md').read_text())
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/qemu/phase297_trace_init.c
+++ b/tests/qemu/phase297_trace_init.c
@@ -1,0 +1,376 @@
+#define _GNU_SOURCE
+#include <drm/drm.h>
+#include <drm/drm_mode.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/reboot.h>
+#include <sched.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <sys/reboot.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <time.h>
+#include <unistd.h>
+
+static void say(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    fflush(stdout);
+}
+
+static void ensure_dir(const char *path)
+{
+    if (mkdir(path, 0755) && errno != EEXIST)
+        say("PHASE297_WARN mkdir path=%s errno=%d\n", path, errno);
+}
+
+static int write_text(const char *path, const char *text, int append)
+{
+    int flags = O_WRONLY | O_CLOEXEC | (append ? O_APPEND : O_TRUNC);
+    int fd = open(path, flags);
+    ssize_t len = (ssize_t)strlen(text);
+    ssize_t n;
+
+    if (fd < 0)
+        return -errno;
+    n = write(fd, text, (size_t)len);
+    if (n != len) {
+        int saved = errno ? errno : EIO;
+        close(fd);
+        return -saved;
+    }
+    close(fd);
+    return 0;
+}
+
+static char *read_all(const char *path, size_t limit, size_t *out_len)
+{
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    char *buf;
+    size_t used = 0;
+
+    if (fd < 0)
+        return NULL;
+    buf = calloc(1, limit + 1);
+    if (!buf) {
+        close(fd);
+        return NULL;
+    }
+    while (used < limit) {
+        ssize_t n = read(fd, buf + used, limit - used);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            free(buf);
+            close(fd);
+            return NULL;
+        }
+        if (n == 0)
+            break;
+        used += (size_t)n;
+    }
+    close(fd);
+    buf[used] = '\0';
+    if (out_len)
+        *out_len = used;
+    return buf;
+}
+
+static int has_function(const char *available, const char *name)
+{
+    const char *p = available;
+    size_t nlen = strlen(name);
+
+    if (!available)
+        return 0;
+    while (*p) {
+        const char *e = strchr(p, '\n');
+        size_t len = e ? (size_t)(e - p) : strlen(p);
+        if (len >= nlen && !strncmp(p, name, nlen) &&
+            (len == nlen || p[nlen] == ' ' || p[nlen] == '\t'))
+            return 1;
+        if (!e)
+            break;
+        p = e + 1;
+    }
+    return 0;
+}
+
+static const char *find_trace_dir(void)
+{
+    static const char *paths[] = {
+        "/sys/kernel/tracing",
+        "/sys/kernel/debug/tracing",
+    };
+    size_t i;
+    for (i = 0; i < sizeof(paths) / sizeof(paths[0]); ++i) {
+        char probe[256];
+        snprintf(probe, sizeof(probe), "%s/tracing_on", paths[i]);
+        if (access(probe, W_OK) == 0)
+            return paths[i];
+    }
+    return NULL;
+}
+
+static int setup_trace(const char *trace_dir)
+{
+    static const char *functions[] = {
+        "drm_open",
+        "drm_stub_open",
+        "drm_open_helper",
+        "drm_file_alloc",
+        "drm_ioctl",
+        "drm_ioctl_kernel",
+        "drm_setclientcap",
+        "drm_getcap",
+        "drm_mode_getresources",
+        "drm_mode_atomic_ioctl",
+        "drm_atomic_helper_check",
+        "drm_atomic_helper_commit",
+        "drm_release",
+        "virtio_gpu_probe",
+        "virtio_gpu_driver_open",
+        "virtio_gpu_driver_postclose",
+        "queue_delayed_work_on",
+        "__queue_delayed_work",
+        "process_one_work",
+        "worker_thread",
+    };
+    char path[256];
+    char *available;
+    size_t available_len = 0;
+    unsigned int enabled = 0;
+    size_t i;
+
+    snprintf(path, sizeof(path), "%s/tracing_on", trace_dir);
+    write_text(path, "0\n", 0);
+    snprintf(path, sizeof(path), "%s/current_tracer", trace_dir);
+    if (write_text(path, "function_graph\n", 0))
+        return -1;
+
+    snprintf(path, sizeof(path), "%s/set_ftrace_filter", trace_dir);
+    {
+        int fd = open(path, O_WRONLY | O_TRUNC | O_CLOEXEC);
+        if (fd >= 0)
+            close(fd);
+    }
+
+    snprintf(path, sizeof(path), "%s/available_filter_functions", trace_dir);
+    available = read_all(path, 4U * 1024U * 1024U, &available_len);
+    if (!available || !available_len) {
+        free(available);
+        return -2;
+    }
+
+    snprintf(path, sizeof(path), "%s/set_ftrace_filter", trace_dir);
+    for (i = 0; i < sizeof(functions) / sizeof(functions[0]); ++i) {
+        char line[128];
+        if (!has_function(available, functions[i]))
+            continue;
+        snprintf(line, sizeof(line), "%s\n", functions[i]);
+        if (!write_text(path, line, 1)) {
+            say("PHASE297_TRACE_FILTER fn=%s\n", functions[i]);
+            ++enabled;
+        }
+    }
+    free(available);
+
+    snprintf(path, sizeof(path), "%s/trace", trace_dir);
+    write_text(path, "", 0);
+    snprintf(path, sizeof(path), "%s/tracing_on", trace_dir);
+    if (write_text(path, "1\n", 0))
+        return -3;
+    say("PHASE297_TRACE_READY filters=%u\n", enabled);
+    return enabled ? 0 : -4;
+}
+
+static int wait_open_card0(int *saved_errno)
+{
+    int attempt;
+    for (attempt = 0; attempt < 100; ++attempt) {
+        int fd = open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+        if (fd >= 0)
+            return fd;
+        if (saved_errno)
+            *saved_errno = errno;
+        usleep(100000);
+    }
+    return -1;
+}
+
+static void run_drm_probe(void)
+{
+    int open_errno = 0;
+    int fd = wait_open_card0(&open_errno);
+    int version_rc = -1, version_errno = 0;
+    int cap_rc = -1, cap_errno = 0;
+    int universal_rc = -1, universal_errno = 0;
+    int atomic_cap_rc = -1, atomic_cap_errno = 0;
+    int resources_rc = -1, resources_errno = 0;
+    int atomic_rc = -1, atomic_errno = 0;
+    unsigned int crtcs = 0, conns = 0, encoders = 0, fbs = 0;
+    char name[128] = {0}, date[128] = {0}, desc[256] = {0};
+
+    if (fd < 0) {
+        say("PHASE297_DRM card_open=-1 errno=%d\n", open_errno);
+        return;
+    }
+    say("PHASE297_DRM card_open=0 fd=%d\n", fd);
+
+    {
+        struct drm_version v;
+        memset(&v, 0, sizeof(v));
+        v.name_len = sizeof(name) - 1;
+        v.name = name;
+        v.date_len = sizeof(date) - 1;
+        v.date = date;
+        v.desc_len = sizeof(desc) - 1;
+        v.desc = desc;
+        version_rc = ioctl(fd, DRM_IOCTL_VERSION, &v);
+        version_errno = version_rc ? errno : 0;
+        say("PHASE297_DRM version_rc=%d errno=%d driver=%s version=%d.%d.%d\n",
+            version_rc, version_errno, name,
+            v.version_major, v.version_minor, v.version_patchlevel);
+    }
+    {
+        struct drm_get_cap cap;
+        memset(&cap, 0, sizeof(cap));
+        cap.capability = DRM_CAP_DUMB_BUFFER;
+        cap_rc = ioctl(fd, DRM_IOCTL_GET_CAP, &cap);
+        cap_errno = cap_rc ? errno : 0;
+        say("PHASE297_DRM getcap_rc=%d errno=%d dumb=%llu\n",
+            cap_rc, cap_errno, (unsigned long long)cap.value);
+    }
+    {
+        struct drm_set_client_cap cap;
+        memset(&cap, 0, sizeof(cap));
+        cap.capability = DRM_CLIENT_CAP_UNIVERSAL_PLANES;
+        cap.value = 1;
+        universal_rc = ioctl(fd, DRM_IOCTL_SET_CLIENT_CAP, &cap);
+        universal_errno = universal_rc ? errno : 0;
+        cap.capability = DRM_CLIENT_CAP_ATOMIC;
+        cap.value = 1;
+        atomic_cap_rc = ioctl(fd, DRM_IOCTL_SET_CLIENT_CAP, &cap);
+        atomic_cap_errno = atomic_cap_rc ? errno : 0;
+        say("PHASE297_DRM client_caps universal=%d/%d atomic=%d/%d\n",
+            universal_rc, universal_errno, atomic_cap_rc, atomic_cap_errno);
+    }
+    {
+        struct drm_mode_card_res res;
+        memset(&res, 0, sizeof(res));
+        resources_rc = ioctl(fd, DRM_IOCTL_MODE_GETRESOURCES, &res);
+        resources_errno = resources_rc ? errno : 0;
+        crtcs = res.count_crtcs;
+        conns = res.count_connectors;
+        encoders = res.count_encoders;
+        fbs = res.count_fbs;
+        say("PHASE297_DRM resources_rc=%d errno=%d crtcs=%u connectors=%u encoders=%u fbs=%u\n",
+            resources_rc, resources_errno, crtcs, conns, encoders, fbs);
+    }
+    {
+        struct drm_mode_atomic req;
+        memset(&req, 0, sizeof(req));
+        req.flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
+        atomic_rc = ioctl(fd, DRM_IOCTL_MODE_ATOMIC, &req);
+        atomic_errno = atomic_rc ? errno : 0;
+        say("PHASE297_DRM empty_atomic_rc=%d errno=%d\n", atomic_rc, atomic_errno);
+    }
+
+    close(fd);
+    say("PHASE297_DRM_COMPLETE version=%d cap=%d universal=%d atomic_cap=%d resources=%d empty_atomic=%d\n",
+        version_rc, cap_rc, universal_rc, atomic_cap_rc, resources_rc, atomic_rc);
+}
+
+static void dump_trace(const char *trace_dir)
+{
+    char path[256];
+    char *trace;
+    size_t len = 0;
+
+    snprintf(path, sizeof(path), "%s/tracing_on", trace_dir);
+    write_text(path, "0\n", 0);
+    snprintf(path, sizeof(path), "%s/trace", trace_dir);
+    trace = read_all(path, 1024U * 1024U, &len);
+    say("PHASE297_FTRACE_BEGIN bytes=%zu\n", len);
+    if (trace && len)
+        fwrite(trace, 1, len, stdout);
+    say("\nPHASE297_FTRACE_END\n");
+    fflush(stdout);
+    free(trace);
+}
+
+static void dump_small_file(const char *tag, const char *path)
+{
+    size_t len = 0;
+    char *buf = read_all(path, 64U * 1024U, &len);
+    if (!buf)
+        return;
+    say("PHASE297_FILE_BEGIN tag=%s path=%s bytes=%zu\n", tag, path, len);
+    fwrite(buf, 1, len, stdout);
+    if (!len || buf[len - 1] != '\n')
+        putchar('\n');
+    say("PHASE297_FILE_END tag=%s\n", tag);
+    fflush(stdout);
+    free(buf);
+}
+
+int main(void)
+{
+    struct utsname uts;
+    const char *trace_dir;
+    int trace_rc;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+    ensure_dir("/dev");
+    ensure_dir("/proc");
+    ensure_dir("/sys");
+    ensure_dir("/sys/kernel");
+    ensure_dir("/sys/kernel/debug");
+    mount("devtmpfs", "/dev", "devtmpfs", MS_NOSUID, "mode=0755");
+    mount("proc", "/proc", "proc", 0, NULL);
+    mount("sysfs", "/sys", "sysfs", 0, NULL);
+    ensure_dir("/sys/kernel/debug");
+    mount("debugfs", "/sys/kernel/debug", "debugfs", 0, NULL);
+    ensure_dir("/sys/kernel/tracing");
+    mount("tracefs", "/sys/kernel/tracing", "tracefs", 0, NULL);
+
+    if (!uname(&uts))
+        say("PHASE297_BOOT_OK release=%s machine=%s\n", uts.release, uts.machine);
+    else
+        say("PHASE297_BOOT_OK uname_errno=%d\n", errno);
+    dump_small_file("cmdline", "/proc/cmdline");
+    dump_small_file("version", "/proc/version");
+
+    trace_dir = find_trace_dir();
+    if (!trace_dir) {
+        say("PHASE297_TRACE_UNAVAILABLE\n");
+        trace_rc = -1;
+    } else {
+        say("PHASE297_TRACE_DIR path=%s\n", trace_dir);
+        trace_rc = setup_trace(trace_dir);
+    }
+
+    run_drm_probe();
+    sleep(1);
+    if (trace_dir)
+        dump_trace(trace_dir);
+    dump_small_file("interrupts", "/proc/interrupts");
+    dump_small_file("modules", "/proc/modules");
+    say("PHASE297_TRACE_COMPLETE trace_rc=%d\n", trace_rc);
+    sync();
+    reboot(RB_AUTOBOOT);
+    for (;;)
+        pause();
+    return 0;
+}


### PR DESCRIPTION
Dedicated NON-FLASHABLE virtual diagnostics lane for the Phase296 userspace DRM frontier.

- Reconstructs the exact Phase296 phone source/config and production Image first.
- Force-recompiles the real A52 msm_drv/msm_atomic/sde_kms objects with strict declaration/prototype errors.
- Archives symbols, disassembly, marker strings and source context from the exact phone objects.
- Builds a separate ARM64 QEMU virt config from that same patched 5.10 source.
- Keeps FB and DRM_FBDEV_EMULATION disabled in the virtual lane.
- Boots virtio-gpu with panic/oops/lockup fatal, initcall_debug, DRM debug, and function_graph tracing.
- Static ARM64 /init opens /dev/dri/card0, negotiates client caps, queries resources, submits an empty atomic ioctl and prints a bounded trace to serial.

This does not emulate SM7125 SDE/DSI/panel or Samsung HWC and must never be treated as hardware validation or flashed to A52.