### PR TITLE
Phase 301: trace Phase13 RPMh/RSC runtime contract

### DIFF
--- a/.github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+++ b/.github/workflows/301-a52-rpmh-rsc-contract-trace.yml
@@ -1,0 +1,115 @@
+name: 301 - A52 RPMh RSC contract trace
+run-name: Phase 301 - observe Phase13 solver/flush runtime consequences
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase301-rpmh-rsc-contract-trace-v1
+    paths:
+      - .github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase301-rpmh-rsc-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only RPMh/RSC contract trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase301 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          bash -n scripts/301_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase301 trace candidate
+        run: bash scripts/301_ci_build.sh
+
+      - name: Upload complete Phase301 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase301-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase301 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-BOOT-IMG
+          path: phase301-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase301-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/301_apply_rpmh_rsc_contract_trace.py
+++ b/scripts/301_apply_rpmh_rsc_contract_trace.py
@@ -232,9 +232,9 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 {
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301I s=%u w=%u use=%u",
-\t\t\tbitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
-\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
-\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
 \ttcs_invalidate(drv, SLEEP_TCS);
 \ttcs_invalidate(drv, WAKE_TCS);
 }
@@ -254,8 +254,8 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d",
 \t\t\tmsg->state, tcs->type, tcs->num_tcs, tcs->offset,
-\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
-\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
 \t\t\tirqs_disabled());
 
 \tspin_lock_irq(&drv->lock);
@@ -265,11 +265,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
     old_claim = '''\ttcs->req[tcs_id - tcs->offset] = msg;
 \tset_bit(tcs_id, drv->tcs_in_use);
 '''
-    new_claim = '''\tif (a52_p301_disp_rsc(drv))
-\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
-\ttcs->req[tcs_id - tcs->offset] = msg;
-\tset_bit(tcs_id, drv->tcs_in_use);
-'''
+    new_claim = old_claim
     text = one(text, old_claim, new_claim, 'rsc send claim')
 
     old_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
@@ -278,7 +274,9 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \treturn 0;
 }
 '''
-    new_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+    new_trigger = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
+\t__tcs_buffer_write(drv, tcs_id, 0, msg);
 \t__tcs_set_trigger(drv, tcs_id, true);
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301R x id=%d ty=%d", tcs_id, tcs->type);
@@ -299,7 +297,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
     new_ctrl = '''\tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301C e st=%d ty=%d n=%d slots=%u",
 \t\t\tmsg->state, tcs->type, msg->num_cmds,
-\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t\t\t(unsigned int)bitmap_weight(tcs->slots, MAX_TCS_SLOTS));
 \t/* find the TCS id and the command in the TCS to write to */
 \tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
 \tif (!ret)
@@ -307,7 +305,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301C x r=%d id=%d cmd=%d slots=%u",
 \t\t\tret, tcs_id, cmd_id,
-\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t\t\t(unsigned int)bitmap_weight(tcs->slots, MAX_TCS_SLOTS));
 
 \treturn ret;
 }

--- a/scripts/301_apply_rpmh_rsc_contract_trace.py
+++ b/scripts/301_apply_rpmh_rsc_contract_trace.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SDE = Path('drivers/a52_display/msm/sde_rsc.c')
+BUS = Path('drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c')
+RSC = Path('drivers/soc/qcom/rpmh-rsc.c')
+RPMH = Path('drivers/soc/qcom/rpmh.c')
+COMPAT = Path('a52-port-compat.h')
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1'
+REC_INCLUDE = '#include <linux/a52_ack_secure_flight_recorder.h>\n'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase301 {label}: expected exactly 1 anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def ensure_include(text: str, include: str, anchor: str, label: str) -> str:
+    if include in text:
+        return text
+    return one(text, anchor, anchor + include, f'{label} include')
+
+
+def behavior_counts(text: str) -> dict[str, int]:
+    tokens = (
+        'rpmh_mode_solver_set(', 'rpmh_flush(', 'rpmh_invalidate(',
+        'rpmh_write_batch(', 'rpmh_rsc_send_data(', 'rpmh_rsc_write_ctrl_data(',
+        'writel(', 'writel_relaxed(', 'write_tcs_reg(', 'write_tcs_reg_sync(',
+        '__tcs_buffer_write(', '__tcs_set_trigger(', 'msleep(', 'usleep_range(',
+        'udelay(', 'wait_event_lock_irq(',
+    )
+    return {t: text.count(t) for t in tokens}
+
+
+def patch_sde(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, REC_INCLUDE, '#include <linux/msm-bus.h>\n', 'sde recorder')
+    text = ensure_include(text, '#include <linux/irqflags.h>\n', REC_INCLUDE, 'sde irqflags')
+    text = one(
+        text,
+        REC_INCLUDE + '#include <linux/irqflags.h>\n',
+        REC_INCLUDE + '#include <linux/irqflags.h>\n\n'
+        '/* ' + MARK + '\n'
+        ' * Observation only: the inherited Phase13 macros still erase\n'
+        ' * rpmh_mode_solver_set and rpmh_flush. These markers record the\n'
+        ' * exact runtime points at which Golden would execute those contracts.\n'
+        ' */\n',
+        'sde marker',
+    )
+
+    transitions = [
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CMD_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CMD_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=1 irq=%d",\n'
+            '\t\t\tSDE_RSC_CMD_STATE, rc, irqs_disabled());\n',
+            'CMD state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CLK_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CLK_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=0 irq=%d",\n'
+            '\t\t\tSDE_RSC_CLK_STATE, rc, irqs_disabled());\n',
+            'CLK state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_VID_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_VID_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=%d irq=%d",\n'
+            '\t\t\tSDE_RSC_VID_STATE, rc,\n'
+            '\t\t\trsc->version == SDE_RSC_REV_3, irqs_disabled());\n',
+            'VID state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_IDLE_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_IDLE_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=1 irq=%d",\n'
+            '\t\t\tSDE_RSC_IDLE_STATE, rc, irqs_disabled());\n',
+            'IDLE state update',
+        ),
+    ]
+    for old, new, label in transitions:
+        text = one(text, old, new, label)
+
+    text = one(
+        text,
+        '\tif (delta_vote) {\n\t\tif (rsc->hw_ops.tcs_wait) {\n',
+        '\tif (delta_vote) {\n'
+        '\t\ta52_ackfr_record("P276 301V e cur=%d irq=%d",\n'
+        '\t\t\trsc->current_state, irqs_disabled());\n'
+        '\t\tif (rsc->hw_ops.tcs_wait) {\n',
+        'vote entry',
+    )
+    text = one(
+        text,
+        '\t\t\trc = rsc->hw_ops.tcs_wait(rsc);\n\t\t\tif (rc) {\n',
+        '\t\t\trc = rsc->hw_ops.tcs_wait(rsc);\n'
+        '\t\t\ta52_ackfr_record("P276 301V tw=%d", rc);\n'
+        '\t\t\tif (rc) {\n',
+        'tcs wait result',
+    )
+    text = one(
+        text,
+        '\t\trpmh_invalidate(rsc->rpmh_dev);\n',
+        '\t\ta52_ackfr_record("P276 301V inv dev=%s",\n'
+        '\t\t\tdev_name(rsc->rpmh_dev));\n'
+        '\t\trpmh_invalidate(rsc->rpmh_dev);\n',
+        'sde invalidate',
+    )
+    text = one(
+        text,
+        '\t\trpmh_flush(rsc->rpmh_dev);\n',
+        '\t\ta52_ackfr_record("P276 301F would dev=%s irq=%d",\n'
+        '\t\t\tdev_name(rsc->rpmh_dev), irqs_disabled());\n'
+        '\t\trpmh_flush(rsc->rpmh_dev);\n',
+        'sde flush call',
+    )
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 sde behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def patch_bus(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, REC_INCLUDE, '#include <soc/qcom/tcs.h>\n', 'bus recorder')
+    text = one(
+        text,
+        REC_INCLUDE,
+        REC_INCLUDE + '\n/* ' + MARK + ': Display-RSC bus votes, observation only. */\n',
+        'bus marker',
+    )
+
+    text = one(
+        text,
+        '\tif (!cnt_active)\n\t\tgoto exit_msm_bus_commit_data;\n',
+        '\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)\n'
+        '\t\ta52_ackfr_record("P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d",\n'
+        '\t\t\tcnt_active, cnt_wake, cnt_sleep, cnt_vcd,\n'
+        '\t\t\tcur_rsc->rscdev->req_state);\n\n'
+        '\tif (!cnt_active)\n\t\tgoto exit_msm_bus_commit_data;\n',
+        'bus entry counts',
+    )
+
+    text = one(
+        text,
+        '\t/* rpmh_invalidate() is void in the pinned GKI 5.10 RPMh API. */\n\trpmh_invalidate(cur_mbox);\n',
+        '\t/* rpmh_invalidate() is void in the pinned GKI 5.10 RPMh API. */\n'
+        '\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)\n'
+        '\t\ta52_ackfr_record("P276 301B inv mb=%s", dev_name(cur_mbox));\n'
+        '\trpmh_invalidate(cur_mbox);\n',
+        'bus invalidate',
+    )
+
+    active = '''\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP) {
+\t\tret = rpmh_write_batch(cur_mbox, cur_rsc->rscdev->req_state,
+\t\t\t\t\t\tcmdlist_active, n_active);
+'''
+    active_new = '''\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP) {
+\t\tret = rpmh_write_batch(cur_mbox, cur_rsc->rscdev->req_state,
+\t\t\t\t\t\tcmdlist_active, n_active);
+\t\ta52_ackfr_record("P276 301B A r=%d st=%d mb=%s",
+\t\t\tret, cur_rsc->rscdev->req_state, dev_name(cur_mbox));
+'''
+    text = one(text, active, active_new, 'display active batch')
+
+    wake = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_WAKE_ONLY_STATE,
+\t\t\t\t\t\t\tcmdlist_wake, n_wake);
+\t\tif (ret)
+'''
+    wake_new = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_WAKE_ONLY_STATE,
+\t\t\t\t\t\t\tcmdlist_wake, n_wake);
+\t\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)
+\t\t\ta52_ackfr_record("P276 301B W r=%d", ret);
+\t\tif (ret)
+'''
+    text = one(text, wake, wake_new, 'wake batch')
+
+    sleep = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_SLEEP_STATE,
+\t\t\t\t\t\t\tcmdlist_sleep, n_sleep);
+\t\tif (ret)
+'''
+    sleep_new = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_SLEEP_STATE,
+\t\t\t\t\t\t\tcmdlist_sleep, n_sleep);
+\t\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)
+\t\t\ta52_ackfr_record("P276 301B S r=%d", ret);
+\t\tif (ret)
+'''
+    text = one(text, sleep, sleep_new, 'sleep batch')
+
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 bus behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def patch_rsc(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, '#include <linux/string.h>\n', '#include <linux/spinlock.h>\n', 'rsc string')
+    text = ensure_include(text, REC_INCLUDE, '#include <dt-bindings/soc/qcom,rpmh-rsc.h>\n', 'rsc recorder')
+    anchor = '#include "trace-rpmh.h"\n'
+    helper = '''#include "trace-rpmh.h"
+
+/* A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1: observation only. */
+static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
+{
+\treturn drv && drv->name && !strcmp(drv->name, "disp_rsc");
+}
+'''
+    text = one(text, anchor, helper, 'rsc helper')
+
+    old_inv = '''void rpmh_rsc_invalidate(struct rsc_drv *drv)
+{
+\ttcs_invalidate(drv, SLEEP_TCS);
+\ttcs_invalidate(drv, WAKE_TCS);
+}
+'''
+    new_inv = '''void rpmh_rsc_invalidate(struct rsc_drv *drv)
+{
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301I s=%u w=%u use=%u",
+\t\t\tbitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
+\ttcs_invalidate(drv, SLEEP_TCS);
+\ttcs_invalidate(drv, WAKE_TCS);
+}
+'''
+    text = one(text, old_inv, new_inv, 'rsc invalidate trace')
+
+    old_send = '''\ttcs = get_tcs_for_msg(drv, msg);
+\tif (IS_ERR(tcs))
+\t\treturn PTR_ERR(tcs);
+
+\tspin_lock_irq(&drv->lock);
+'''
+    new_send = '''\ttcs = get_tcs_for_msg(drv, msg);
+\tif (IS_ERR(tcs))
+\t\treturn PTR_ERR(tcs);
+
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d",
+\t\t\tmsg->state, tcs->type, tcs->num_tcs, tcs->offset,
+\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
+\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tirqs_disabled());
+
+\tspin_lock_irq(&drv->lock);
+'''
+    text = one(text, old_send, new_send, 'rsc send entry')
+
+    old_claim = '''\ttcs->req[tcs_id - tcs->offset] = msg;
+\tset_bit(tcs_id, drv->tcs_in_use);
+'''
+    new_claim = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
+\ttcs->req[tcs_id - tcs->offset] = msg;
+\tset_bit(tcs_id, drv->tcs_in_use);
+'''
+    text = one(text, old_claim, new_claim, 'rsc send claim')
+
+    old_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+\t__tcs_set_trigger(drv, tcs_id, true);
+
+\treturn 0;
+}
+'''
+    new_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+\t__tcs_set_trigger(drv, tcs_id, true);
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R x id=%d ty=%d", tcs_id, tcs->type);
+
+\treturn 0;
+}
+'''
+    text = one(text, old_trigger, new_trigger, 'rsc send exit')
+
+    old_ctrl = '''\t/* find the TCS id and the command in the TCS to write to */
+\tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
+\tif (!ret)
+\t\t__tcs_buffer_write(drv, tcs_id, cmd_id, msg);
+
+\treturn ret;
+}
+'''
+    new_ctrl = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301C e st=%d ty=%d n=%d slots=%u",
+\t\t\tmsg->state, tcs->type, msg->num_cmds,
+\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t/* find the TCS id and the command in the TCS to write to */
+\tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
+\tif (!ret)
+\t\t__tcs_buffer_write(drv, tcs_id, cmd_id, msg);
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301C x r=%d id=%d cmd=%d slots=%u",
+\t\t\tret, tcs_id, cmd_id,
+\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+
+\treturn ret;
+}
+'''
+    text = one(text, old_ctrl, new_ctrl, 'rsc ctrl trace')
+
+    old_solver = '''\tsolver_config = readl_relaxed(base + DRV_SOLVER_CONFIG);
+\tsolver_config &= DRV_HW_SOLVER_MASK << DRV_HW_SOLVER_SHIFT;
+\tsolver_config = solver_config >> DRV_HW_SOLVER_SHIFT;
+\tif (!solver_config) {
+'''
+    new_solver = '''\tsolver_config = readl_relaxed(base + DRV_SOLVER_CONFIG);
+\tsolver_config &= DRV_HW_SOLVER_MASK << DRV_HW_SOLVER_SHIFT;
+\tsolver_config = solver_config >> DRV_HW_SOLVER_SHIFT;
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301P hw=%u a=%d sl=%d w=%d c=%d",
+\t\t\tsolver_config, drv->tcs[ACTIVE_TCS].num_tcs,
+\t\t\tdrv->tcs[SLEEP_TCS].num_tcs, drv->tcs[WAKE_TCS].num_tcs,
+\t\t\tdrv->tcs[CONTROL_TCS].num_tcs);
+\tif (!solver_config) {
+'''
+    text = one(text, old_solver, new_solver, 'rsc solver config')
+
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 rsc behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def check(root: Path) -> dict:
+    for rel in (SDE, BUS, RSC, RPMH, COMPAT, REC):
+        if not (root / rel).is_file():
+            raise SystemExit(f'Phase301 missing {rel}')
+    sde = (root / SDE).read_text(errors='replace')
+    bus = (root / BUS).read_text(errors='replace')
+    rsc = (root / RSC).read_text(errors='replace')
+    compat = (root / COMPAT).read_text(errors='replace')
+    markers = [
+        'P276 301S t=%d r=%d en=1 irq=%d',
+        'P276 301V e cur=%d irq=%d',
+        'P276 301V tw=%d',
+        'P276 301F would dev=%s irq=%d',
+        'P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d',
+        'P276 301B A r=%d st=%d mb=%s',
+        'P276 301B W r=%d',
+        'P276 301B S r=%d',
+        'P276 301P hw=%u a=%d sl=%d w=%d c=%d',
+        'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+        'P276 301R c id=%d ty=%d',
+        'P276 301C e st=%d ty=%d n=%d slots=%u',
+        'P276 301I s=%u w=%u use=%u',
+    ]
+    joined = sde + bus + rsc
+    missing = [m for m in markers if m not in joined]
+    if missing:
+        raise SystemExit('Phase301 missing markers: ' + repr(missing))
+    required_compat = [
+        '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+        '#define rpmh_flush(d) do{}while(0)',
+        'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.',
+    ]
+    for token in required_compat:
+        if token not in compat:
+            raise SystemExit('Phase301 inherited Phase13 invariant missing: ' + token)
+    if '#undef rpmh_mode_solver_set' in joined or '#undef rpmh_flush' in joined:
+        raise SystemExit('Phase301 must not restore Phase13 RPMh behavior')
+    return {
+        'status': 'phase301-rpmh-rsc-contract-trace-v1-staged',
+        'functional_change': 'instrumentation-only',
+        'targets': [str(SDE), str(BUS), str(RSC)],
+        'protected_unchanged': [str(RPMH), str(COMPAT), str(REC)],
+        'phase13_solver_stub_preserved': True,
+        'phase13_flush_stub_preserved': True,
+        'marker_count': len(markers),
+        'hardware_question': (
+            'When SDE reaches its Golden solver/flush boundaries, does Phase296 send '
+            'Display-RSC ACTIVE votes through the borrowed WAKE TCS and leave WAKE/SLEEP '
+            'batches cached without the expected immediate flush?'
+        ),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--report', type=Path)
+    ap.add_argument('--check-only', action='store_true')
+    a = ap.parse_args()
+    root = a.root.resolve()
+    if not a.check_only:
+        for rel, fn in ((SDE, patch_sde), (BUS, patch_bus), (RSC, patch_rsc)):
+            p = root / rel
+            if not p.is_file():
+                raise SystemExit(f'Phase301 missing target {rel}')
+            p.write_text(fn(p.read_text(errors='replace')))
+    report = check(root)
+    if a.report:
+        a.report.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/301_ci_build.sh
+++ b/scripts/301_ci_build.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase301-out"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase301-failure
+  mkdir -p phase301-failure/{logs,audit,source}
+  cp phase301-compile.log phase301-failure/logs/ 2>/dev/null || true
+  cp phase301-patch-report.json phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-phase296.config phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-before.diff phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-after.diff phase301-failure/audit/ 2>/dev/null || true
+  for f in "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase301-failure/source/ || true
+  done
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Exact hardware-observed Phase296 baseline. Phase301 is deliberately parallel
+# to Phase300 and inherits no DMA/GEM/SMMU experiment.
+bash scripts/296_ci_build.sh
+test -s phase296-out/package/boot.img
+test -s phase296-out/compile/Image
+test -s phase296-out/config/final.config
+test -s "$BUILD/arch/arm64/boot/Image"
+test "$(stat -c '%s' phase296-out/package/boot.img)" -eq 100663296
+
+for f in "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do test -s "$f"; done
+
+cp phase296-out/config/final.config /tmp/p301-phase296.config
+cp "$RPMH" /tmp/p301-rpmh-before.c
+cp "$COMPAT" /tmp/p301-compat-before.h
+cp "$REC" /tmp/p301-rec-before.c
+cp "$SDE" /tmp/p301-sde-before.c
+cp "$BUS" /tmp/p301-bus-before.c
+cp "$RSC" /tmp/p301-rsc-before.c
+
+git -C "$ROOT" diff --binary --no-ext-diff > /tmp/p301-before.diff
+
+# Prove the exact inherited Phase13 compile-only runtime shims are still active.
+grep -Fq 'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.' "$COMPAT"
+grep -Fq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py \
+  --root "$ROOT" --report phase301-patch-report.json
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py \
+  --root "$ROOT" --check-only
+
+# Protected runtime implementation and recorder transport must be byte-identical.
+cmp -s /tmp/p301-rpmh-before.c "$RPMH"
+cmp -s /tmp/p301-compat-before.h "$COMPAT"
+cmp -s /tmp/p301-rec-before.c "$REC"
+
+# Scope gate: relative to the reconstructed Phase296 tree, this phase may only
+# touch the three observation targets.
+git -C "$ROOT" diff --binary --no-ext-diff > /tmp/p301-after.diff
+python3 - <<'PY'
+import subprocess
+from pathlib import Path
+root = Path('gki/common')
+allowed = {
+    'drivers/a52_display/msm/sde_rsc.c',
+    'drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c',
+    'drivers/soc/qcom/rpmh-rsc.c',
+}
+cp = subprocess.run(['git', '-C', str(root), 'diff', '--name-only'],
+                    text=True, stdout=subprocess.PIPE, check=True)
+changed = {x.strip() for x in cp.stdout.splitlines() if x.strip()}
+# The reconstructed Phase296 tree is itself generated and may already differ
+# from pristine common. Determine only the new files changed by comparing
+# before/after content snapshots of all candidate paths through explicit hashes.
+for rel in allowed:
+    if not (root / rel).is_file():
+        raise SystemExit('Phase301 missing allowed target: ' + rel)
+# Protected files are checked bytewise in shell. Here reject obvious Phase301
+# writes outside the three target paths by looking for our marker globally.
+marker = 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1'
+hits = []
+for p in root.rglob('*'):
+    if p.is_file() and '.git' not in p.parts:
+        try:
+            t = p.read_text(errors='ignore')
+        except OSError:
+            continue
+        if marker in t:
+            hits.append(p.relative_to(root).as_posix())
+if sorted(hits) != sorted(allowed):
+    raise SystemExit(f'Phase301 marker scope mismatch: {hits}')
+print('Phase301 marker scope:', ', '.join(sorted(hits)))
+PY
+
+# Preserve Phase296 configuration exactly.
+cp /tmp/p301-phase296.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase301-olddefconfig.log 2>&1
+cmp -s /tmp/p301-phase296.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase301-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$rc" > phase301-make-return-code.txt
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase301-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase301-compile.log "$OUT/audit/"
+cp phase301-olddefconfig.log "$OUT/audit/"
+cp phase301-make-return-code.txt "$OUT/audit/"
+cp phase301-patch-report.json "$OUT/audit/"
+cp scripts/301_apply_rpmh_rsc_contract_trace.py "$OUT/audit/"
+cp /tmp/p301-sde-before.c "$OUT/audit/sde_rsc-before.c"
+cp /tmp/p301-bus-before.c "$OUT/audit/msm_bus_fabric_rpmh-before.c"
+cp /tmp/p301-rsc-before.c "$OUT/audit/rpmh-rsc-before.c"
+cp /tmp/p301-rpmh-before.c "$OUT/audit/rpmh-before.c"
+cp /tmp/p301-compat-before.h "$OUT/audit/a52-port-compat-before.h"
+cp /tmp/p301-rec-before.c "$OUT/audit/recorder-before.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase296-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase301-out')
+image = (r/'compile/Image').read_bytes()
+source = ''.join((r/'source'/n).read_text(errors='replace') for n in (
+    'sde_rsc.c','msm_bus_fabric_rpmh.c','rpmh-rsc.c'))
+markers = [
+    'P276 301S t=%d r=%d en=1 irq=%d',
+    'P276 301V e cur=%d irq=%d',
+    'P276 301V tw=%d',
+    'P276 301V inv dev=%s',
+    'P276 301F would dev=%s irq=%d',
+    'P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d',
+    'P276 301B inv mb=%s',
+    'P276 301B A r=%d st=%d mb=%s',
+    'P276 301B W r=%d',
+    'P276 301B S r=%d',
+    'P276 301P hw=%u a=%d sl=%d w=%d c=%d',
+    'P276 301I s=%u w=%u use=%u',
+    'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+    'P276 301R c id=%d ty=%d',
+    'P276 301R x id=%d ty=%d',
+    'P276 301C e st=%d ty=%d n=%d slots=%u',
+    'P276 301C x r=%d id=%d cmd=%d slots=%u',
+]
+for m in markers:
+    if m not in source:
+        raise SystemExit('Phase301 source marker missing: ' + m)
+    if m.encode() not in image:
+        raise SystemExit('Phase301 runtime marker missing from Image: ' + m)
+compat = (r/'source/a52-port-compat.h').read_text(errors='replace')
+for token in [
+    'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.',
+    '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+    '#define rpmh_flush(d) do{}while(0)',
+]:
+    if token not in compat:
+        raise SystemExit('Phase301 Phase13 invariant missing: ' + token)
+if (r/'source/rpmh.c').read_bytes() != (r/'audit/rpmh-before.c').read_bytes():
+    raise SystemExit('Phase301 rpmh.c changed unexpectedly')
+if (r/'source/a52-port-compat.h').read_bytes() != (r/'audit/a52-port-compat-before.h').read_bytes():
+    raise SystemExit('Phase301 compatibility header changed unexpectedly')
+if (r/'source/a52_ack_secure_flight_recorder.c').read_bytes() != (r/'audit/recorder-before.c').read_bytes():
+    raise SystemExit('Phase301 recorder changed unexpectedly')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '301',
+    'name': 'RPMH-RSC-CONTRACT-TRACE-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase296 userspace DRM atomic frontier',
+    'hardware_validated': False,
+    'functional_change': 'instrumentation-only',
+    'solver_behavior_restored': False,
+    'flush_behavior_restored': False,
+    'phase13_solver_stub_preserved': True,
+    'phase13_flush_stub_preserved': True,
+    'protected_rpmh_core_unchanged': True,
+    'protected_compat_header_unchanged': True,
+    'protected_recorder_unchanged': True,
+    'display_rsc_expected_dt_tcs': {'active':0,'sleep':1,'wake':1,'control':0},
+    'markers': markers,
+    'hardware_questions': [
+        'Does disp_rsc report HW solver support?',
+        'When SDE would enable solver mode, does an ACTIVE display bus vote still succeed?',
+        'Does that ACTIVE_ONLY transfer select and claim the borrowed WAKE TCS?',
+        'After WAKE/SLEEP batches are cached and SDE reaches would-flush, is control-data programming absent at that boundary?',
+    ],
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256(image).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase301 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase301 RPMh/RSC observation audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase301 RPMh/RSC contract trace build/repack: PASS'


### PR DESCRIPTION
## Evidence basis

Phase299R first proved the solver call erasure. Phase299S now reconstructs exact Phase296 and formally classifies the complete Phase13 RPMh runtime-shim boundary as `PROVEN_PHASE13_RUNTIME_SEMANTIC_ERASURE`:

- `rpmh_mode_solver_set()` -> `PROVEN_PHASE13_MACRO_ERASURE`
- `rpmh_flush()` -> `PROVEN_PHASE13_MACRO_ERASURE_WITH_API_DRIFT`

The reconstructed Samsung SDE source still contains four solver calls and one flush call, but compiled `sde_rsc.o` has no unresolved reference to either API. The compatibility header contains the exact no-op macros and the original Phase13 `diagnostic, non-flashable` provenance. Final `vmlinux` still exposes pinned 5.10's internal `rpmh_flush(struct rpmh_ctrlr *)`, which is a different API and confirms that the Samsung device-facing SDE call was erased rather than linked to the 5.10 implementation.

The exact Lagoon DT makes the solver mismatch especially important: `disp_rsc` has zero ACTIVE TCSes and one WAKE TCS. Pinned Android 5.10 therefore routes every Display-RSC `RPMH_ACTIVE_ONLY_STATE` transfer through the borrowed WAKE TCS. Golden downstream RPMh blocks those active transfers while display solver mode is active; Phase296 has no such solver state or guard.

The pinned 5.10 core also changed `rpmh_flush()` into an internal `struct rpmh_ctrlr *` API with IRQ-disabled/cache-lock assumptions, so simply un-stubbing the call would not be a safe compatibility fix.

The invalidate/flush part is one coupled semantic break rather than a third independent defect. Golden `rpmh_invalidate(dev)` performs software batch invalidation and immediately invalidates hardware sleep/wake TCS state. Pinned 5.10 intentionally changed `rpmh_invalidate(dev)` to software-cache invalidation only and moved low-level TCS invalidation into `rpmh_flush()`. Phase252 adapted the return/signature difference, which is coherent only if the matching 5.10 flush still occurs. Phase13 erases SDE's explicit flush, leaving the new 5.10 invalidate half of the transaction without the operation that completes it.

Pinned 5.10 additionally documents the required lock order as `drv->lock -> cache_lock`. A literal transplant of Golden's solver implementation would risk the opposite order and is therefore not an acceptable repair strategy.

## Phase301

This phase is observation-only and remains independent of the Phase300 GEM/DMA/SMMU diagnostic.

It reconstructs the exact Phase296 baseline and adds bounded persistent records at three boundaries:

- SDE RSC state transitions and the exact points where Golden would set solver mode or flush cached votes
- legacy Display-RSC msm_bus ACTIVE/WAKE/SLEEP batch submissions and return codes
- pinned 5.10 `disp_rsc` TCS selection, WAKE-TCS borrowing, slot/in-use state, hardware solver-config bit, low-level hardware invalidation and sleep/wake control-data programming

The low-level RPMh trace is filtered to `drv->name == "disp_rsc"` to avoid recorder flooding. The latest refinement emits the claimed-TCS persistent marker only after the native RSC spinlock is released, reducing observer perturbation without changing the recorded state or any hardware behavior. Runtime interpretation will rely primarily on the pre-claim `301R e` selection marker and the post-trigger `301R x` marker.

## Hardware questions

The next boot should determine whether:

1. `disp_rsc` reports hardware solver support.
2. SDE successfully reaches a state where Golden would enable solver mode.
3. a Display-RSC ACTIVE vote nevertheless returns success.
4. that ACTIVE vote selects and successfully triggers the borrowed WAKE TCS.
5. WAKE/SLEEP batches are cached successfully.
6. SDE reaches its Golden invalidate/flush transaction boundary without corresponding immediate low-level hardware invalidation and sleep/wake TCS programming.

Together, those observations would directly demonstrate the runtime consequences of the incomplete 4.19->5.10 RPMh transaction-model port before any repair is attempted.

## Phase302 design constraints, only if Phase301 hardware supports the hypothesis

- do not replace the 5.10 RPMh core wholesale
- keep one display solver-ownership state in `struct rsc_drv`, protected by native `drv->lock`
- reject Display-RSC ACTIVE batch traffic while solver-owned before it can use the borrowed WAKE TCS; preserve the legacy msm_bus expectation that `-EBUSY` is normal in this state
- restore a display-scoped flush using the existing 5.10 low-level invalidate/cache/TCS machinery and the documented `drv->lock -> cache_lock` order
- do not globally change apps/system RPMh semantics unless hardware evidence independently requires it

## Scope and safety

- no solver behavior restored
- no flush behavior restored
- no invalidate behavior changed
- Phase13 no-op macros preserved exactly
- `drivers/soc/qcom/rpmh.c` byte-for-byte unchanged
- recorder implementation byte-for-byte unchanged
- Phase296 config preserved exactly
- no DTB, ramdisk or recovery-DTBO change
- no clock, regulator, GPIO, DSI, DMA/GEM, SMMU, timeout or recovery behavior change

CI rejects missing runtime markers, protected-file changes, config drift and boot-container drift. The resulting boot image remains not hardware validated until a fresh RAMOOPS capture is collected.