### PR TITLE
Phase302: trace odsign/odrefresh wait channel

### DIFF
--- a/.github/workflows/302-a52-odsign-wait-channel-trace.yml
+++ b/.github/workflows/302-a52-odsign-wait-channel-trace.yml
@@ -1,0 +1,115 @@
+name: 302 - A52 odsign wait-channel trace
+run-name: Phase 302 - locate odsign/odrefresh userspace boot stall
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase302-odsign-wait-channel-trace-v1
+    paths:
+      - .github/workflows/302-a52-odsign-wait-channel-trace.yml
+      - scripts/302_apply_odsign_wait_channel_trace.py
+      - scripts/302_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/302-a52-odsign-wait-channel-trace.yml
+      - scripts/302_apply_odsign_wait_channel_trace.py
+      - scripts/302_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase302-odsign-wchan-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only odsign/odrefresh wait-channel trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase302 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/302_apply_odsign_wait_channel_trace.py
+          bash -n scripts/302_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase302 wait-channel candidate
+        run: bash scripts/302_ci_build.sh
+
+      - name: Upload complete Phase302 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase302-ODSIGN-WAIT-CHANNEL-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase302-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase302 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase302-ODSIGN-WAIT-CHANNEL-${{ github.run_number }}-BOOT-IMG
+          path: phase302-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase302-ODSIGN-WAIT-CHANNEL-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase302-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/302_apply_odsign_wait_channel_trace.py
+++ b/scripts/302_apply_odsign_wait_channel_trace.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE302_ODSIGN_WAIT_CHANNEL_TRACE_V1'
+
+
+def sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase302 {label}: expected exactly 1 anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+
+    old = '''static void a52_r226_task_snapshot(unsigned int tick)\n{\n\tstruct task_struct *group;\n\tstruct task_struct *task;\n\tunsigned int found = 0;\n\n\tif (!a52_r226_snapshot_tick(tick))\n\t\treturn;\n\trcu_read_lock();\n\tfor_each_process_thread(group, task) {\n\t\tif (!a52_r226_od_task(task->comm))\n\t\t\tcontinue;\n\t\tfound++;\n\t\ta52_ackfr_record("ODSPOST 226 ts t=%u p=%d c=%.10s s=%lx x=%x r=%d o=%d i=%d",\n\t\t\ttick, task_pid_nr(task), task->comm,\n\t\t\tREAD_ONCE(task->state), READ_ONCE(task->exit_state),\n\t\t\tREAD_ONCE(task->on_rq), READ_ONCE(task->on_cpu),\n\t\t\ttask->in_iowait);\n\t}\n\trcu_read_unlock();\n\tif (!found)\n\t\ta52_ackfr_record("ODSPOST 226 ts t=%u none", tick);\n}\n'''
+
+    new = '''/* A52_PHASE302_ODSIGN_WAIT_CHANNEL_TRACE_V1\n * Observation only: preserve the inherited Phase226 task-state snapshot and\n * add the scheduler wait channel for blocked odsign/odrefresh tasks.  %ps is\n * recorded first so KASLR does not prevent offline identification; the raw\n * address is emitted separately as a fallback.\n */\nstatic void a52_r226_task_snapshot(unsigned int tick)\n{\n\tstruct task_struct *group;\n\tstruct task_struct *task;\n\tunsigned int found = 0;\n\n\tif (!a52_r226_snapshot_tick(tick))\n\t\treturn;\n\trcu_read_lock();\n\tfor_each_process_thread(group, task) {\n\t\tunsigned long wchan;\n\n\t\tif (!a52_r226_od_task(task->comm))\n\t\t\tcontinue;\n\t\tfound++;\n\t\ta52_ackfr_record("ODSPOST 226 ts t=%u p=%d c=%.10s s=%lx x=%x r=%d o=%d i=%d",\n\t\t\ttick, task_pid_nr(task), task->comm,\n\t\t\tREAD_ONCE(task->state), READ_ONCE(task->exit_state),\n\t\t\tREAD_ONCE(task->on_rq), READ_ONCE(task->on_cpu),\n\t\t\ttask->in_iowait);\n\n\t\t/* get_wchan() returns zero when a usable blocked wait site is unavailable. */\n\t\twchan = get_wchan(task);\n\t\ta52_ackfr_record("P276 302W t=%u p=%d c=%.10s w=%ps",\n\t\t\ttick, task_pid_nr(task), task->comm, (void *)wchan);\n\t\ta52_ackfr_record("P276 302A t=%u p=%d a=%lx",\n\t\t\ttick, task_pid_nr(task), wchan);\n\t}\n\trcu_read_unlock();\n\tif (!found)\n\t\ta52_ackfr_record("ODSPOST 226 ts t=%u none", tick);\n}\n'''
+    return one(text, old, new, 'Phase226 snapshot')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, default=Path('.'))
+    ap.add_argument('--report', type=Path)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    path = args.root / REC
+    before_b = path.read_bytes()
+    before = before_b.decode()
+    after = patch(before)
+
+    required_before = [
+        'A52_PHASE226_ODSIGN_GATE_TRACE',
+        'ODSPOST 226 ts t=%u p=%d c=%.10s s=%lx x=%x r=%d o=%d i=%d',
+    ]
+    for token in required_before:
+        if token not in before:
+            raise SystemExit('Phase302 inherited recorder anchor missing: ' + token)
+
+    required_after = [
+        MARK,
+        'P276 302W t=%u p=%d c=%.10s w=%ps',
+        'P276 302A t=%u p=%d a=%lx',
+        'get_wchan(task)',
+    ]
+    for token in required_after:
+        if token not in after:
+            raise SystemExit('Phase302 marker missing after patch: ' + token)
+
+    # Preserve the inherited Phase226 snapshot and its schedule exactly.
+    for token in [
+        'return tick == 20 || tick == 30 || tick == 45 || tick == 60 ||',
+        'tick == 90 || tick == 120 || tick == 150 || tick == 180;',
+        'ODSPOST 226 ts t=%u p=%d c=%.10s s=%lx x=%x r=%d o=%d i=%d',
+        'ODSPOST 226 ts t=%u none',
+    ]:
+        if before.count(token) != after.count(token):
+            raise SystemExit('Phase302 changed inherited Phase226 contract: ' + token)
+
+    report = {
+        'phase': 302,
+        'name': 'ODSIGN-WAIT-CHANNEL-TRACE-V1',
+        'functional_change': 'instrumentation-only',
+        'target': REC.as_posix(),
+        'before_sha256': sha(before_b),
+        'after_sha256': sha(after.encode()),
+        'marker': MARK,
+        'markers': [
+            'P276 302W t=%u p=%d c=%.10s w=%ps',
+            'P276 302A t=%u p=%d a=%lx',
+        ],
+        'phase226_snapshot_preserved': True,
+    }
+
+    if args.check_only:
+        if after != before:
+            raise SystemExit('Phase302 check-only: patch not already applied')
+    else:
+        path.write_text(after)
+
+    if args.report:
+        args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+
+    print(json.dumps(report, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/302_ci_build.sh
+++ b/scripts/302_ci_build.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase302-out"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+EXPECTED_PHASE296_REC_SHA="0679e25f80d535bc16a05cd1ecaa4f9f2c78d0aa0d3f06f5b4813c7a4505156e"
+
+fail_report() {
+  set +e
+  rm -rf phase302-failure
+  mkdir -p phase302-failure/{logs,audit,source}
+  cp phase302-compile.log phase302-failure/logs/ 2>/dev/null || true
+  cp phase302-olddefconfig.log phase302-failure/logs/ 2>/dev/null || true
+  cp phase302-patch-report.json phase302-failure/audit/ 2>/dev/null || true
+  cp /tmp/p302-phase296.config phase302-failure/audit/ 2>/dev/null || true
+  cp /tmp/p302-rec-before.c phase302-failure/audit/ 2>/dev/null || true
+  [ -f "$REC" ] && cp "$REC" phase302-failure/source/ || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct and build the exact hardware-observed Phase296 baseline first.
+bash scripts/296_ci_build.sh
+test -s phase296-out/package/boot.img
+test -s phase296-out/compile/Image
+test -s phase296-out/config/final.config
+test -s "$BUILD/arch/arm64/boot/Image"
+test "$(stat -c '%s' phase296-out/package/boot.img)" -eq 100663296
+
+for f in "$REC" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT"; do test -s "$f"; done
+
+cp phase296-out/config/final.config /tmp/p302-phase296.config
+cp "$REC" /tmp/p302-rec-before.c
+cp "$SDE" /tmp/p302-sde-before.c
+cp "$BUS" /tmp/p302-bus-before.c
+cp "$RSC" /tmp/p302-rsc-before.c
+cp "$RPMH" /tmp/p302-rpmh-before.c
+cp "$COMPAT" /tmp/p302-compat-before.h
+
+actual_rec_sha="$(sha256sum "$REC" | awk '{print $1}')"
+if [ "$actual_rec_sha" != "$EXPECTED_PHASE296_REC_SHA" ]; then
+  echo "Phase302 exact Phase296 recorder hash mismatch: $actual_rec_sha" >&2
+  exit 1
+fi
+
+grep -Fq 'A52_PHASE226_ODSIGN_GATE_TRACE' "$REC"
+grep -Fq 'ODSPOST 226 ts t=%u p=%d c=%.10s s=%lx x=%x r=%d o=%d i=%d' "$REC"
+
+python3 -m py_compile scripts/302_apply_odsign_wait_channel_trace.py
+python3 scripts/302_apply_odsign_wait_channel_trace.py \
+  --root "$ROOT" --report phase302-patch-report.json
+python3 scripts/302_apply_odsign_wait_channel_trace.py \
+  --root "$ROOT" --check-only
+
+# Scope gate: Phase302 may modify only the recorder. Display/RPMh and the
+# compatibility semantics remain byte-identical to reconstructed Phase296.
+cmp -s /tmp/p302-sde-before.c "$SDE"
+cmp -s /tmp/p302-bus-before.c "$BUS"
+cmp -s /tmp/p302-rsc-before.c "$RSC"
+cmp -s /tmp/p302-rpmh-before.c "$RPMH"
+cmp -s /tmp/p302-compat-before.h "$COMPAT"
+python3 - <<'PY'
+from pathlib import Path
+root = Path('gki/common')
+marker = 'A52_PHASE302_ODSIGN_WAIT_CHANNEL_TRACE_V1'
+hits = []
+for p in root.rglob('*'):
+    if p.is_file() and '.git' not in p.parts:
+        try:
+            if marker in p.read_text(errors='ignore'):
+                hits.append(p.relative_to(root).as_posix())
+        except OSError:
+            pass
+expected = ['drivers/a52_secure/a52_ack_secure_flight_recorder.c']
+if hits != expected:
+    raise SystemExit(f'Phase302 marker scope mismatch: {hits}')
+print('Phase302 marker scope:', hits[0])
+PY
+
+# Preserve Phase296 configuration exactly.
+cp /tmp/p302-phase296.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase302-olddefconfig.log 2>&1
+cmp -s /tmp/p302-phase296.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase302-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$rc" > phase302-make-return-code.txt
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase302-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+VMLINUX="$BUILD/vmlinux"
+SYSTEM_MAP="$BUILD/System.map"
+test -s "$IMAGE"
+test -s "$VMLINUX"
+test -s "$SYSTEM_MAP"
+# Prove the pinned kernel actually provides the scheduler wait-channel API.
+grep -Eq ' [Tt] get_wchan$' "$SYSTEM_MAP"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$SYSTEM_MAP" "$OUT/compile/System.map"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase302-compile.log "$OUT/audit/"
+cp phase302-olddefconfig.log "$OUT/audit/"
+cp phase302-make-return-code.txt "$OUT/audit/"
+cp phase302-patch-report.json "$OUT/audit/"
+cp scripts/302_apply_odsign_wait_channel_trace.py "$OUT/audit/"
+cp /tmp/p302-rec-before.c "$OUT/audit/recorder-before.c"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase296-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase302-out')
+image = (r/'compile/Image').read_bytes()
+rec = (r/'source/a52_ack_secure_flight_recorder.c').read_text(errors='replace')
+markers = [
+    'P276 302W t=%u p=%d c=%.10s w=%ps',
+    'P276 302A t=%u p=%d a=%lx',
+]
+for marker in markers:
+    if marker not in rec:
+        raise SystemExit('Phase302 source marker missing: ' + marker)
+    if marker.encode() not in image:
+        raise SystemExit('Phase302 Image marker missing: ' + marker)
+if 'A52_PHASE226_ODSIGN_GATE_TRACE' not in rec:
+    raise SystemExit('Phase302 inherited Phase226 snapshot marker missing')
+if (r/'source/sde_rsc.c').read_bytes() != Path('/tmp/p302-sde-before.c').read_bytes():
+    raise SystemExit('Phase302 changed SDE unexpectedly')
+if (r/'source/msm_bus_fabric_rpmh.c').read_bytes() != Path('/tmp/p302-bus-before.c').read_bytes():
+    raise SystemExit('Phase302 changed msm_bus unexpectedly')
+if (r/'source/rpmh-rsc.c').read_bytes() != Path('/tmp/p302-rsc-before.c').read_bytes():
+    raise SystemExit('Phase302 changed rpmh-rsc unexpectedly')
+if (r/'source/rpmh.c').read_bytes() != Path('/tmp/p302-rpmh-before.c').read_bytes():
+    raise SystemExit('Phase302 changed rpmh core unexpectedly')
+if (r/'source/a52-port-compat.h').read_bytes() != Path('/tmp/p302-compat-before.h').read_bytes():
+    raise SystemExit('Phase302 changed compatibility header unexpectedly')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '302',
+    'name': 'ODSIGN-WAIT-CHANNEL-TRACE-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase296 userspace DRM atomic frontier',
+    'hardware_validated': False,
+    'functional_change': 'instrumentation-only',
+    'modified_runtime_source': 'drivers/a52_secure/a52_ack_secure_flight_recorder.c',
+    'display_stack_unchanged': True,
+    'rpmh_stack_unchanged': True,
+    'compat_header_unchanged': True,
+    'phase226_task_snapshot_preserved': True,
+    'markers': markers,
+    'hardware_questions': [
+        'At 30/45/60/90 seconds, where are the persistent odsign and odrefresh tasks sleeping?',
+        'Do repeated snapshots converge on one stable kernel wait channel?',
+        'Does odrefresh ever leave that wait channel or exit before zygote/surfaceflinger admission?',
+    ],
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256(image).hexdigest(),
+    'system_map_sha256': hashlib.sha256((r/'compile/System.map').read_bytes()).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase302 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase302 odsign/odrefresh wait-channel observation audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/302_apply_odsign_wait_channel_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase302 odsign/odrefresh wait-channel trace build/repack: PASS'


### PR DESCRIPTION
## Phase302 — odsign/odrefresh wait-channel trace

Phase301 hardware evidence changed the active frontier: KMS/DRM registration succeeds, but the captured boot never reaches `msm_open()`, `surfaceflinger`, `zygote64`, `system_server`, or `bootanimation`. The persistent task mask remains at init + service managers.

A full re-read of the fused trace also corrects an earlier interpretation: `odrefresh` is **not permanently asleep after ~21.45 s**. It is interruptibly asleep at the Phase226 snapshots, but wakes for another open burst around ~43.18 s and later performs repeated connection operations through ~73.6 s. `odsign` remains present while its child activity continues. The missing information is therefore the kernel wait site **between those bursts**, not proof of a permanent deadlock.

This phase is deliberately **parallel to Phase301** and is based directly on the exact hardware-observed Phase296 branch.

### Single hardware question
Where are the persistent `odsign` and `odrefresh` tasks sleeping between their userspace activity bursts while Android remains gated before zygote/SurfaceFlinger?

### Runtime change
Observation only. Preserve the inherited Phase226 task-state snapshot and add two recorder records at the existing 20/30/45/60/90/120/150/180-second snapshot points:

- `P276 302W ... w=%ps` — symbolized scheduler wait channel
- `P276 302A ... a=%lx` — raw address fallback

No ART/init behavior is modified. No DRM/SDE/DSI, RPMh/RSC, DMA/GEM/SMMU, DT, compatibility shim, or configuration behavior is changed.

### CI gates
- reconstruct exact Phase296 first
- verify exact inherited Phase296 recorder SHA-256
- preserve Phase296 config byte-for-byte
- require Phase302 marker scope to be recorder-only
- require SDE, msm_bus, rpmh-rsc, rpmh core, and compatibility header byte-identical to Phase296
- prove the pinned 5.10 build exports `get_wchan`
- require both Phase302 runtime marker strings in final Image
- preserve DTB, ramdisk, recovery DTBO, and 96 MiB boot image size
- upload `System.map` with evidence for fallback symbolization

### Interpretation
A repeated wait channel can identify the next userspace/kernel boundary to instrument. A changing/zero wait channel instead tells us the process is progressing intermittently and keeps us from prematurely modifying ART or the display stack.

Not hardware validated yet.