### PR TITLE
Phase303: expose exact F0 5A 5A command-DMA reference

### DIFF
--- a/.github/workflows/303-a52-gdm-visible-exact-f05a5a.yml
+++ b/.github/workflows/303-a52-gdm-visible-exact-f05a5a.yml
@@ -1,0 +1,115 @@
+name: 303 - A52 exact F0 5A 5A GDM visibility
+run-name: Phase 303 - expose retained command-DMA register/IRQ reference
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase303-gdm-visible-exact-f05a5a-v1
+    paths:
+      - .github/workflows/303-a52-gdm-visible-exact-f05a5a.yml
+      - scripts/303_apply_gdm_visible_exact_f05a5a.py
+      - scripts/303_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/303-a52-gdm-visible-exact-f05a5a.yml
+      - scripts/303_apply_gdm_visible_exact_f05a5a.py
+      - scripts/303_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase303-gdm-visible-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only exact F0 5A 5A GDM visibility
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase303 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/303_apply_gdm_visible_exact_f05a5a.py
+          bash -n scripts/303_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase303 candidate
+        run: bash scripts/303_ci_build.sh
+
+      - name: Upload complete Phase303 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase303-GDM-VISIBLE-F05A5A-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase303-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase303 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase303-GDM-VISIBLE-F05A5A-${{ github.run_number }}-BOOT-IMG
+          path: phase303-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase303-GDM-VISIBLE-F05A5A-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase303-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/303_apply_gdm_visible_exact_f05a5a.py
+++ b/scripts/303_apply_gdm_visible_exact_f05a5a.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+MARK = 'A52_PHASE303_GDM_VISIBLE_EXACT_F05A5A_V1'
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase303 {label}: expected exactly one match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' not in text:
+        raise SystemExit('Phase303 requires inherited Phase293 GDM controller trace')
+    if 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' not in text:
+        raise SystemExit('Phase303 requires inherited Phase280 timeout retention latch')
+
+    marker_anchor = '/* A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1\n'
+    marker_text = (
+        '/* ' + MARK + '\n'
+        ' * Phase302 hardware reached the first real compositor atomic commit and\n'
+        ' * reproduced the retained command-DMA timeout, but Phase293 GDM records\n'
+        ' * were silently rejected because they used a non-admitted "GDM" prefix.\n'
+        ' * Re-emit those passive MMIO/IRQ snapshots through the already-admitted\n'
+        ' * P276 namespace and arm them only for payload F0 5A 5A. No DSI write,\n'
+        ' * command flag, wait, timeout, recovery, clock, panel, SMMU or RPMh state\n'
+        ' * is changed.\n'
+        ' */\n'
+    )
+    text = replace_once(text, marker_anchor, marker_text + marker_anchor,
+                        'marker insertion')
+
+    old_scope = '''\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n\tp = msg->tx_buf;\n'''
+    new_scope = '''\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tp = msg->tx_buf;\n\tif (p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n'''
+    text = replace_once(text, old_scope, new_scope, 'exact payload scope')
+
+    # The recorder already admits P276 as critical persistent evidence. Phase293
+    # used "GDM ..." literals, which compile and execute but are rejected by that
+    # admission gate. Change formatting only; all trace call sites remain fixed.
+    text = text.replace('"GDM ', '"P276 303 ')
+    return text
+
+
+def patch_hw(text: str) -> str:
+    if 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' not in text:
+        raise SystemExit('Phase303 requires inherited Phase293 GDM HW trace')
+    text = text.replace('"GDM ', '"P276 303 ')
+    return text
+
+
+def validate(ctrl: str, hw: str) -> None:
+    combined = ctrl + hw
+    required = [
+        MARK,
+        'p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A',
+        'P276 303 S00 c=0 in=%x mf=%x t=%x l=%u',
+        'P276 303 S00p p=%02x%02x%02x',
+        'P276 303 S03 irq=%d in=%x st=%x',
+        'P276 303 S04 irq=%d in=%x st=%x',
+        'P276 303 S05 dc=%x off=%x len=%x fc=%x',
+        'P276 303 S06 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 S07 seen=1 st=%x in=%x irq0=%d',
+        'P276 303 S08 ret=%d irq=%d in=%x st=%x',
+        'P276 303 S09 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 DONE success=0 target=0/8/20/29/3',
+        'P276 280Z q=2',
+    ]
+    for token in required:
+        if token not in combined:
+            raise SystemExit('Phase303 required token missing: ' + token)
+    if 'a52_ackfr_record("GDM ' in combined:
+        raise SystemExit('Phase303 still contains recorder-rejected GDM runtime records')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    cp = args.root / CTRL
+    hp = args.root / HW
+    if not cp.is_file() or not hp.is_file():
+        raise SystemExit('Phase303 source files missing')
+
+    ctrl = cp.read_text()
+    hw = hp.read_text()
+    if not args.check_only:
+        ctrl = patch_ctrl(ctrl)
+        hw = patch_hw(hw)
+        cp.write_text(ctrl)
+        hp.write_text(hw)
+
+    validate(cp.read_text(), hp.read_text())
+    print('Phase303 exact F0 5A 5A persistent GDM visibility: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/303_ci_build.sh
+++ b/scripts/303_ci_build.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+OUT="$PWD/workspace/gki-phase199-out"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase303-failure
+  mkdir -p phase303-failure/{source,logs,audit}
+  cp phase303-compile.log phase303-failure/logs/ 2>/dev/null || true
+  for f in "$CTRL" "$HW" "$REC"; do [ -f "$f" ] && cp "$f" phase303-failure/source/ || true; done
+  cp scripts/303_apply_gdm_visible_exact_f05a5a.py phase303-failure/audit/ 2>/dev/null || true
+  cp /tmp/p303-base.config /tmp/p303-ctrl-before.c /tmp/p303-hw-before.c /tmp/p303-rec-before.c phase303-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact hardware-proven Phase296 lineage. Phase303 deliberately
+# drops the now-obsolete Phase302 odsign wait-channel observer: this boot proved
+# Android reaches composer and a real atomic commit. Keep the Phase280 timeout
+# retention latch and Phase293 passive command-DMA reference intact.
+bash scripts/296_ci_build.sh
+test -s phase296-out/package/boot.img
+test -s "$OUT/arch/arm64/boot/Image"
+for f in "$CTRL" "$HW" "$REC"; do test -s "$f"; done
+test "$(stat -c '%s' phase296-out/package/boot.img)" -eq 100663296
+
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' "$CTRL"
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' "$HW"
+grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$CTRL"
+grep -Fq 'P276 280Z q=2' "$CTRL"
+
+cp "$OUT/.config" /tmp/p303-base.config
+cp "$CTRL" /tmp/p303-ctrl-before.c
+cp "$HW" /tmp/p303-hw-before.c
+cp "$REC" /tmp/p303-rec-before.c
+
+python3 -m py_compile scripts/303_apply_gdm_visible_exact_f05a5a.py
+python3 scripts/303_apply_gdm_visible_exact_f05a5a.py --root "$ROOT"
+python3 scripts/303_apply_gdm_visible_exact_f05a5a.py --root "$ROOT" --check-only
+
+# Phase303 changes only diagnostic trace selection/formatting in the existing
+# Phase293 DSI reference. Recorder transport/admission and all other subsystems
+# stay byte-for-byte unchanged.
+cmp -s /tmp/p303-rec-before.c "$REC"
+! cmp -s /tmp/p303-ctrl-before.c "$CTRL"
+! cmp -s /tmp/p303-hw-before.c "$HW"
+
+# No behavior-changing DSI primitives may be added by the patch. Counts of the
+# relevant write/wait/clock/recovery primitives must be identical pre/post.
+python3 - <<'PY'
+from pathlib import Path
+pairs=[('/tmp/p303-ctrl-before.c', Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl.c')),
+       ('/tmp/p303-hw-before.c', Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c'))]
+tokens=['DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
+        'wait_for_completion_timeout(', 'msleep(', 'usleep_range(',
+        'DSI_CTRL_CMD_FIFO_STORE']
+for before, after in pairs:
+    b=Path(before).read_text(); a=after.read_text()
+    for t in tokens:
+        if b.count(t) != a.count(t):
+            raise SystemExit(f'Phase303 behavior primitive count changed: {after} {t} {b.count(t)}->{a.count(t)}')
+print('Phase303 behavior primitive count audit: PASS')
+PY
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig
+cmp -s /tmp/p303-base.config "$OUT/.config"
+
+make -C "$ROOT" O="$OUT" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase303-compile.log
+IMAGE="$OUT/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+for marker in \
+  'P276 303 S00 c=0 in=%x mf=%x t=%x l=%u' \
+  'P276 303 S00p p=%02x%02x%02x' \
+  'P276 303 S03 irq=%d in=%x st=%x' \
+  'P276 303 S04 irq=%d in=%x st=%x' \
+  'P276 303 S05 dc=%x off=%x len=%x fc=%x' \
+  'P276 303 S06 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 S07 seen=1 st=%x in=%x irq0=%d' \
+  'P276 303 S08 ret=%d irq=%d in=%x st=%x' \
+  'P276 303 S09 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 DONE success=0 target=0/8/20/29/3' \
+  'P276 280Z q=2'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+grep -Fq 'p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A' "$CTRL"
+! grep -Fq 'a52_ackfr_record("GDM ' "$CTRL"
+! grep -Fq 'a52_ackfr_record("GDM ' "$HW"
+
+rm -rf phase303-out
+mkdir -p phase303-out/{compile,config,package,audit,source}
+cp "$IMAGE" phase303-out/compile/Image
+cp "$OUT/.config" phase303-out/config/final.config
+cp /tmp/p303-base.config phase303-out/audit/phase296-final.config
+cp /tmp/p303-ctrl-before.c phase303-out/audit/dsi-ctrl-before.c
+cp /tmp/p303-hw-before.c phase303-out/audit/dsi-ctrl-hw-before.c
+cp /tmp/p303-rec-before.c phase303-out/audit/recorder-before.c
+cp phase303-compile.log phase303-out/audit/
+cp scripts/303_apply_gdm_visible_exact_f05a5a.py phase303-out/audit/
+cp "$CTRL" phase303-out/source/dsi_ctrl.c
+cp "$HW" phase303-out/source/dsi_ctrl_hw_cmn.c
+cp "$REC" phase303-out/source/a52_ack_secure_flight_recorder.c
+
+gzip -n -c "$IMAGE" > phase303-out/package/Image.gz
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase296-out/package/boot.img \
+  --kernel phase303-out/package/Image.gz \
+  --output phase303-out/package/boot.img \
+  --report phase303-out/package/repack-report.json
+
+test "$(stat -c '%s' phase303-out/package/boot.img)" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r=Path('phase303-out')
+idn={
+  'phase':'303',
+  'name':'GDM-VISIBLE-EXACT-F05A5A-V1',
+  'git_sha':os.getenv('GITHUB_SHA'),
+  'hardware_validated':False,
+  'base':'exact Phase296 reconstruction (Phase293 retained-timeout DSI lineage + userspace DRM frontier)',
+  'phase302_hardware_capture':'A52_RAW_RAMOOPS_20260823_004829.zip',
+  'phase302_hardware_result':[
+    'Android progressed through system_server/composer to DRM admission and a real atomic commit',
+    'TX_LEVEL1_KEY_ENABLE reached MIPI host transfer',
+    'memory-fetch command DMA waited about 200 ms and completion value remained zero',
+    'Phase280 q=2 retention latch froze the recorder immediately after the timeout snapshot',
+    'SMMU state remained unchanged from pre-kickoff through timeout and global fault registers stayed zero',
+    'Phase293 GDM strings were not persistent-visible because they used the non-admitted GDM prefix'
+  ],
+  'functional_change':'diagnostic-only: exact F0 5A 5A trace arm plus persistent-visible formatting',
+  'recorder_change':False,
+  'dsi_control_flow_change':False,
+  'wait_or_timeout_change':False,
+  'fifo_reroute':False,
+  'clock_recovery':False,
+  'rpmh_change':False,
+  'target':{'ctrl':0,'flags':0x20,'msg_flags':0x8,'type':0x29,'tx_len':3,'payload':'F05A5A'},
+  'markers':{
+    '303 S00/S00p':'target identity and payload',
+    '303 S03/S04':'pre/post DMA_DONE IRQ arm raw interrupt/controller state',
+    '303 S05':'programmed DMA registers immediately before production trigger',
+    '303 S06':'immediately after production SW trigger',
+    '303 S07':'DMA_DONE ISR only if hardware asserts completion',
+    '303 S08':'completion wait result plus raw interrupt/status',
+    '303 S09':'timeout-final FIFO/lane/clock/error/controller state before Phase280 retention latch'
+  },
+  'hardware_question':'For the exact Samsung F0 5A 5A level-1 key command, what raw DSI register/IRQ state first diverges between kickoff and the missing DMA_DONE completion?'
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(idn,indent=2,sort_keys=True)+'\n')
+files=['compile/Image','config/final.config','package/Image.gz','package/boot.img','package/repack-report.json',
+       'audit/phase296-final.config','audit/dsi-ctrl-before.c','audit/dsi-ctrl-hw-before.c','audit/recorder-before.c',
+       'audit/phase303-compile.log','audit/303_apply_gdm_visible_exact_f05a5a.py',
+       'source/dsi_ctrl.c','source/dsi_ctrl_hw_cmn.c','source/a52_ack_secure_flight_recorder.c','BUILD-IDENTITY.json']
+with (r/'SHA256SUMS').open('w') as f:
+    for n in files:
+        f.write(hashlib.sha256((r/n).read_bytes()).hexdigest()+'  ./'+n+'\n')
+PY
+(cd phase303-out && sha256sum -c SHA256SUMS)
+python3 scripts/303_apply_gdm_visible_exact_f05a5a.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase303 exact F0 5A 5A persistent GDM reference build/repack: PASS'


### PR DESCRIPTION
Phase302 hardware capture proved Android progresses through composer/DRM to a real atomic commit, then reproduces the retained DSI command-DMA timeout on the Samsung level-1 key path. The detailed Phase293 GDM MMIO/IRQ snapshots were not persistent-visible because their `GDM` prefix is outside the recorder's admitted namespace.

Phase303 is observation-only. It reconstructs exact Phase296, keeps the inherited Phase280 retention latch and Phase293 DMA reference, restricts the trace arm to payload `F0 5A 5A`, and re-emits the existing GDM snapshots through the admitted `P276 303` namespace. No DSI writes, command flags, waits/timeouts, FIFO routing, clock recovery, SMMU, RPMh, panel payload, or recorder transport are changed.

Hardware question: for the exact `F0 5A 5A` command, what raw DSI register/IRQ state first diverges between production kickoff and the missing DMA_DONE completion?