### PR TITLE
Phase304: correlate RPMh/RSC contract with exact F0 5A 5A timeout

### DIFF
--- a/.github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+++ b/.github/workflows/301-a52-rpmh-rsc-contract-trace.yml
@@ -1,0 +1,115 @@
+name: 301 - A52 RPMh RSC contract trace
+run-name: Phase 301 - observe Phase13 solver/flush runtime consequences
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase301-rpmh-rsc-contract-trace-v1
+    paths:
+      - .github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase301-rpmh-rsc-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only RPMh/RSC contract trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase301 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          bash -n scripts/301_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase301 trace candidate
+        run: bash scripts/301_ci_build.sh
+
+      - name: Upload complete Phase301 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase301-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase301 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-BOOT-IMG
+          path: phase301-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase301-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
+++ b/.github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
@@ -1,0 +1,121 @@
+name: 304 - A52 RPMh/RSC and F0 5A 5A correlation
+run-name: Phase 304 - correlate display RPMh contract with exact DSI DMA timeout
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase304-rpmh-rsc-f05a5a-correlation-v1
+    paths:
+      - .github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase304-rpmh-rsc-f05a5a-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only RPMh/RSC plus exact F0 5A 5A correlation
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase304 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          python3 -m py_compile scripts/304_apply_exact_f05a5a_visibility.py
+          bash -n scripts/301_ci_build.sh
+          bash -n scripts/304_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase304 correlation candidate
+        run: bash scripts/304_ci_build.sh
+
+      - name: Upload complete Phase304 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase304-RPMH-RSC-F05A5A-CORRELATION-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase304-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase304 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase304-RPMH-RSC-F05A5A-CORRELATION-${{ github.run_number }}-BOOT-IMG
+          path: phase304-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase304-RPMH-RSC-F05A5A-CORRELATION-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase304-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/301_apply_rpmh_rsc_contract_trace.py
+++ b/scripts/301_apply_rpmh_rsc_contract_trace.py
@@ -232,9 +232,9 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 {
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301I s=%u w=%u use=%u",
-\t\t\tbitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
-\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
-\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
 \ttcs_invalidate(drv, SLEEP_TCS);
 \ttcs_invalidate(drv, WAKE_TCS);
 }
@@ -254,8 +254,8 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d",
 \t\t\tmsg->state, tcs->type, tcs->num_tcs, tcs->offset,
-\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
-\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
 \t\t\tirqs_disabled());
 
 \tspin_lock_irq(&drv->lock);
@@ -265,11 +265,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
     old_claim = '''\ttcs->req[tcs_id - tcs->offset] = msg;
 \tset_bit(tcs_id, drv->tcs_in_use);
 '''
-    new_claim = '''\tif (a52_p301_disp_rsc(drv))
-\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
-\ttcs->req[tcs_id - tcs->offset] = msg;
-\tset_bit(tcs_id, drv->tcs_in_use);
-'''
+    new_claim = old_claim
     text = one(text, old_claim, new_claim, 'rsc send claim')
 
     old_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
@@ -278,7 +274,9 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \treturn 0;
 }
 '''
-    new_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+    new_trigger = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
+\t__tcs_buffer_write(drv, tcs_id, 0, msg);
 \t__tcs_set_trigger(drv, tcs_id, true);
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301R x id=%d ty=%d", tcs_id, tcs->type);
@@ -299,7 +297,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
     new_ctrl = '''\tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301C e st=%d ty=%d n=%d slots=%u",
 \t\t\tmsg->state, tcs->type, msg->num_cmds,
-\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t\t\t(unsigned int)bitmap_weight(tcs->slots, MAX_TCS_SLOTS));
 \t/* find the TCS id and the command in the TCS to write to */
 \tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
 \tif (!ret)
@@ -307,7 +305,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301C x r=%d id=%d cmd=%d slots=%u",
 \t\t\tret, tcs_id, cmd_id,
-\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t\t\t(unsigned int)bitmap_weight(tcs->slots, MAX_TCS_SLOTS));
 
 \treturn ret;
 }

--- a/scripts/301_apply_rpmh_rsc_contract_trace.py
+++ b/scripts/301_apply_rpmh_rsc_contract_trace.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SDE = Path('drivers/a52_display/msm/sde_rsc.c')
+BUS = Path('drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c')
+RSC = Path('drivers/soc/qcom/rpmh-rsc.c')
+RPMH = Path('drivers/soc/qcom/rpmh.c')
+COMPAT = Path('a52-port-compat.h')
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1'
+REC_INCLUDE = '#include <linux/a52_ack_secure_flight_recorder.h>\n'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase301 {label}: expected exactly 1 anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def ensure_include(text: str, include: str, anchor: str, label: str) -> str:
+    if include in text:
+        return text
+    return one(text, anchor, anchor + include, f'{label} include')
+
+
+def behavior_counts(text: str) -> dict[str, int]:
+    tokens = (
+        'rpmh_mode_solver_set(', 'rpmh_flush(', 'rpmh_invalidate(',
+        'rpmh_write_batch(', 'rpmh_rsc_send_data(', 'rpmh_rsc_write_ctrl_data(',
+        'writel(', 'writel_relaxed(', 'write_tcs_reg(', 'write_tcs_reg_sync(',
+        '__tcs_buffer_write(', '__tcs_set_trigger(', 'msleep(', 'usleep_range(',
+        'udelay(', 'wait_event_lock_irq(',
+    )
+    return {t: text.count(t) for t in tokens}
+
+
+def patch_sde(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, REC_INCLUDE, '#include <linux/msm-bus.h>\n', 'sde recorder')
+    text = ensure_include(text, '#include <linux/irqflags.h>\n', REC_INCLUDE, 'sde irqflags')
+    text = one(
+        text,
+        REC_INCLUDE + '#include <linux/irqflags.h>\n',
+        REC_INCLUDE + '#include <linux/irqflags.h>\n\n'
+        '/* ' + MARK + '\n'
+        ' * Observation only: the inherited Phase13 macros still erase\n'
+        ' * rpmh_mode_solver_set and rpmh_flush. These markers record the\n'
+        ' * exact runtime points at which Golden would execute those contracts.\n'
+        ' */\n',
+        'sde marker',
+    )
+
+    transitions = [
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CMD_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CMD_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=1 irq=%d",\n'
+            '\t\t\tSDE_RSC_CMD_STATE, rc, irqs_disabled());\n',
+            'CMD state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CLK_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CLK_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=0 irq=%d",\n'
+            '\t\t\tSDE_RSC_CLK_STATE, rc, irqs_disabled());\n',
+            'CLK state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_VID_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_VID_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=%d irq=%d",\n'
+            '\t\t\tSDE_RSC_VID_STATE, rc,\n'
+            '\t\t\trsc->version == SDE_RSC_REV_3, irqs_disabled());\n',
+            'VID state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_IDLE_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_IDLE_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=1 irq=%d",\n'
+            '\t\t\tSDE_RSC_IDLE_STATE, rc, irqs_disabled());\n',
+            'IDLE state update',
+        ),
+    ]
+    for old, new, label in transitions:
+        text = one(text, old, new, label)
+
+    text = one(
+        text,
+        '\tif (delta_vote) {\n\t\tif (rsc->hw_ops.tcs_wait) {\n',
+        '\tif (delta_vote) {\n'
+        '\t\ta52_ackfr_record("P276 301V e cur=%d irq=%d",\n'
+        '\t\t\trsc->current_state, irqs_disabled());\n'
+        '\t\tif (rsc->hw_ops.tcs_wait) {\n',
+        'vote entry',
+    )
+    text = one(
+        text,
+        '\t\t\trc = rsc->hw_ops.tcs_wait(rsc);\n\t\t\tif (rc) {\n',
+        '\t\t\trc = rsc->hw_ops.tcs_wait(rsc);\n'
+        '\t\t\ta52_ackfr_record("P276 301V tw=%d", rc);\n'
+        '\t\t\tif (rc) {\n',
+        'tcs wait result',
+    )
+    text = one(
+        text,
+        '\t\trpmh_invalidate(rsc->rpmh_dev);\n',
+        '\t\ta52_ackfr_record("P276 301V inv dev=%s",\n'
+        '\t\t\tdev_name(rsc->rpmh_dev));\n'
+        '\t\trpmh_invalidate(rsc->rpmh_dev);\n',
+        'sde invalidate',
+    )
+    text = one(
+        text,
+        '\t\trpmh_flush(rsc->rpmh_dev);\n',
+        '\t\ta52_ackfr_record("P276 301F would dev=%s irq=%d",\n'
+        '\t\t\tdev_name(rsc->rpmh_dev), irqs_disabled());\n'
+        '\t\trpmh_flush(rsc->rpmh_dev);\n',
+        'sde flush call',
+    )
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 sde behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def patch_bus(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, REC_INCLUDE, '#include <soc/qcom/tcs.h>\n', 'bus recorder')
+    text = one(
+        text,
+        REC_INCLUDE,
+        REC_INCLUDE + '\n/* ' + MARK + ': Display-RSC bus votes, observation only. */\n',
+        'bus marker',
+    )
+
+    text = one(
+        text,
+        '\tif (!cnt_active)\n\t\tgoto exit_msm_bus_commit_data;\n',
+        '\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)\n'
+        '\t\ta52_ackfr_record("P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d",\n'
+        '\t\t\tcnt_active, cnt_wake, cnt_sleep, cnt_vcd,\n'
+        '\t\t\tcur_rsc->rscdev->req_state);\n\n'
+        '\tif (!cnt_active)\n\t\tgoto exit_msm_bus_commit_data;\n',
+        'bus entry counts',
+    )
+
+    text = one(
+        text,
+        '\t/* rpmh_invalidate() is void in the pinned GKI 5.10 RPMh API. */\n\trpmh_invalidate(cur_mbox);\n',
+        '\t/* rpmh_invalidate() is void in the pinned GKI 5.10 RPMh API. */\n'
+        '\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)\n'
+        '\t\ta52_ackfr_record("P276 301B inv mb=%s", dev_name(cur_mbox));\n'
+        '\trpmh_invalidate(cur_mbox);\n',
+        'bus invalidate',
+    )
+
+    active = '''\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP) {
+\t\tret = rpmh_write_batch(cur_mbox, cur_rsc->rscdev->req_state,
+\t\t\t\t\t\tcmdlist_active, n_active);
+'''
+    active_new = '''\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP) {
+\t\tret = rpmh_write_batch(cur_mbox, cur_rsc->rscdev->req_state,
+\t\t\t\t\t\tcmdlist_active, n_active);
+\t\ta52_ackfr_record("P276 301B A r=%d st=%d mb=%s",
+\t\t\tret, cur_rsc->rscdev->req_state, dev_name(cur_mbox));
+'''
+    text = one(text, active, active_new, 'display active batch')
+
+    wake = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_WAKE_ONLY_STATE,
+\t\t\t\t\t\t\tcmdlist_wake, n_wake);
+\t\tif (ret)
+'''
+    wake_new = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_WAKE_ONLY_STATE,
+\t\t\t\t\t\t\tcmdlist_wake, n_wake);
+\t\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)
+\t\t\ta52_ackfr_record("P276 301B W r=%d", ret);
+\t\tif (ret)
+'''
+    text = one(text, wake, wake_new, 'wake batch')
+
+    sleep = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_SLEEP_STATE,
+\t\t\t\t\t\t\tcmdlist_sleep, n_sleep);
+\t\tif (ret)
+'''
+    sleep_new = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_SLEEP_STATE,
+\t\t\t\t\t\t\tcmdlist_sleep, n_sleep);
+\t\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)
+\t\t\ta52_ackfr_record("P276 301B S r=%d", ret);
+\t\tif (ret)
+'''
+    text = one(text, sleep, sleep_new, 'sleep batch')
+
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 bus behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def patch_rsc(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, '#include <linux/string.h>\n', '#include <linux/spinlock.h>\n', 'rsc string')
+    text = ensure_include(text, REC_INCLUDE, '#include <dt-bindings/soc/qcom,rpmh-rsc.h>\n', 'rsc recorder')
+    anchor = '#include "trace-rpmh.h"\n'
+    helper = '''#include "trace-rpmh.h"
+
+/* A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1: observation only. */
+static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
+{
+\treturn drv && drv->name && !strcmp(drv->name, "disp_rsc");
+}
+'''
+    text = one(text, anchor, helper, 'rsc helper')
+
+    old_inv = '''void rpmh_rsc_invalidate(struct rsc_drv *drv)
+{
+\ttcs_invalidate(drv, SLEEP_TCS);
+\ttcs_invalidate(drv, WAKE_TCS);
+}
+'''
+    new_inv = '''void rpmh_rsc_invalidate(struct rsc_drv *drv)
+{
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301I s=%u w=%u use=%u",
+\t\t\tbitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
+\ttcs_invalidate(drv, SLEEP_TCS);
+\ttcs_invalidate(drv, WAKE_TCS);
+}
+'''
+    text = one(text, old_inv, new_inv, 'rsc invalidate trace')
+
+    old_send = '''\ttcs = get_tcs_for_msg(drv, msg);
+\tif (IS_ERR(tcs))
+\t\treturn PTR_ERR(tcs);
+
+\tspin_lock_irq(&drv->lock);
+'''
+    new_send = '''\ttcs = get_tcs_for_msg(drv, msg);
+\tif (IS_ERR(tcs))
+\t\treturn PTR_ERR(tcs);
+
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d",
+\t\t\tmsg->state, tcs->type, tcs->num_tcs, tcs->offset,
+\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
+\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tirqs_disabled());
+
+\tspin_lock_irq(&drv->lock);
+'''
+    text = one(text, old_send, new_send, 'rsc send entry')
+
+    old_claim = '''\ttcs->req[tcs_id - tcs->offset] = msg;
+\tset_bit(tcs_id, drv->tcs_in_use);
+'''
+    new_claim = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
+\ttcs->req[tcs_id - tcs->offset] = msg;
+\tset_bit(tcs_id, drv->tcs_in_use);
+'''
+    text = one(text, old_claim, new_claim, 'rsc send claim')
+
+    old_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+\t__tcs_set_trigger(drv, tcs_id, true);
+
+\treturn 0;
+}
+'''
+    new_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+\t__tcs_set_trigger(drv, tcs_id, true);
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R x id=%d ty=%d", tcs_id, tcs->type);
+
+\treturn 0;
+}
+'''
+    text = one(text, old_trigger, new_trigger, 'rsc send exit')
+
+    old_ctrl = '''\t/* find the TCS id and the command in the TCS to write to */
+\tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
+\tif (!ret)
+\t\t__tcs_buffer_write(drv, tcs_id, cmd_id, msg);
+
+\treturn ret;
+}
+'''
+    new_ctrl = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301C e st=%d ty=%d n=%d slots=%u",
+\t\t\tmsg->state, tcs->type, msg->num_cmds,
+\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t/* find the TCS id and the command in the TCS to write to */
+\tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
+\tif (!ret)
+\t\t__tcs_buffer_write(drv, tcs_id, cmd_id, msg);
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301C x r=%d id=%d cmd=%d slots=%u",
+\t\t\tret, tcs_id, cmd_id,
+\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+
+\treturn ret;
+}
+'''
+    text = one(text, old_ctrl, new_ctrl, 'rsc ctrl trace')
+
+    old_solver = '''\tsolver_config = readl_relaxed(base + DRV_SOLVER_CONFIG);
+\tsolver_config &= DRV_HW_SOLVER_MASK << DRV_HW_SOLVER_SHIFT;
+\tsolver_config = solver_config >> DRV_HW_SOLVER_SHIFT;
+\tif (!solver_config) {
+'''
+    new_solver = '''\tsolver_config = readl_relaxed(base + DRV_SOLVER_CONFIG);
+\tsolver_config &= DRV_HW_SOLVER_MASK << DRV_HW_SOLVER_SHIFT;
+\tsolver_config = solver_config >> DRV_HW_SOLVER_SHIFT;
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301P hw=%u a=%d sl=%d w=%d c=%d",
+\t\t\tsolver_config, drv->tcs[ACTIVE_TCS].num_tcs,
+\t\t\tdrv->tcs[SLEEP_TCS].num_tcs, drv->tcs[WAKE_TCS].num_tcs,
+\t\t\tdrv->tcs[CONTROL_TCS].num_tcs);
+\tif (!solver_config) {
+'''
+    text = one(text, old_solver, new_solver, 'rsc solver config')
+
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 rsc behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def check(root: Path) -> dict:
+    for rel in (SDE, BUS, RSC, RPMH, COMPAT, REC):
+        if not (root / rel).is_file():
+            raise SystemExit(f'Phase301 missing {rel}')
+    sde = (root / SDE).read_text(errors='replace')
+    bus = (root / BUS).read_text(errors='replace')
+    rsc = (root / RSC).read_text(errors='replace')
+    compat = (root / COMPAT).read_text(errors='replace')
+    markers = [
+        'P276 301S t=%d r=%d en=1 irq=%d',
+        'P276 301V e cur=%d irq=%d',
+        'P276 301V tw=%d',
+        'P276 301F would dev=%s irq=%d',
+        'P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d',
+        'P276 301B A r=%d st=%d mb=%s',
+        'P276 301B W r=%d',
+        'P276 301B S r=%d',
+        'P276 301P hw=%u a=%d sl=%d w=%d c=%d',
+        'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+        'P276 301R c id=%d ty=%d',
+        'P276 301C e st=%d ty=%d n=%d slots=%u',
+        'P276 301I s=%u w=%u use=%u',
+    ]
+    joined = sde + bus + rsc
+    missing = [m for m in markers if m not in joined]
+    if missing:
+        raise SystemExit('Phase301 missing markers: ' + repr(missing))
+    required_compat = [
+        '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+        '#define rpmh_flush(d) do{}while(0)',
+        'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.',
+    ]
+    for token in required_compat:
+        if token not in compat:
+            raise SystemExit('Phase301 inherited Phase13 invariant missing: ' + token)
+    if '#undef rpmh_mode_solver_set' in joined or '#undef rpmh_flush' in joined:
+        raise SystemExit('Phase301 must not restore Phase13 RPMh behavior')
+    return {
+        'status': 'phase301-rpmh-rsc-contract-trace-v1-staged',
+        'functional_change': 'instrumentation-only',
+        'targets': [str(SDE), str(BUS), str(RSC)],
+        'protected_unchanged': [str(RPMH), str(COMPAT), str(REC)],
+        'phase13_solver_stub_preserved': True,
+        'phase13_flush_stub_preserved': True,
+        'marker_count': len(markers),
+        'hardware_question': (
+            'When SDE reaches its Golden solver/flush boundaries, does Phase296 send '
+            'Display-RSC ACTIVE votes through the borrowed WAKE TCS and leave WAKE/SLEEP '
+            'batches cached without the expected immediate flush?'
+        ),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--report', type=Path)
+    ap.add_argument('--check-only', action='store_true')
+    a = ap.parse_args()
+    root = a.root.resolve()
+    if not a.check_only:
+        for rel, fn in ((SDE, patch_sde), (BUS, patch_bus), (RSC, patch_rsc)):
+            p = root / rel
+            if not p.is_file():
+                raise SystemExit(f'Phase301 missing target {rel}')
+            p.write_text(fn(p.read_text(errors='replace')))
+    report = check(root)
+    if a.report:
+        a.report.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/301_ci_build.sh
+++ b/scripts/301_ci_build.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase301-out"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase301-failure
+  mkdir -p phase301-failure/{logs,audit,source}
+  cp phase301-compile.log phase301-failure/logs/ 2>/dev/null || true
+  cp phase301-patch-report.json phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-phase296.config phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-before.diff phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-after.diff phase301-failure/audit/ 2>/dev/null || true
+  for f in "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase301-failure/source/ || true
+  done
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Exact hardware-observed Phase296 baseline. Phase301 is deliberately parallel
+# to Phase300 and inherits no DMA/GEM/SMMU experiment.
+bash scripts/296_ci_build.sh
+test -s phase296-out/package/boot.img
+test -s phase296-out/compile/Image
+test -s phase296-out/config/final.config
+test -s "$BUILD/arch/arm64/boot/Image"
+test "$(stat -c '%s' phase296-out/package/boot.img)" -eq 100663296
+
+for f in "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do test -s "$f"; done
+
+cp phase296-out/config/final.config /tmp/p301-phase296.config
+cp "$RPMH" /tmp/p301-rpmh-before.c
+cp "$COMPAT" /tmp/p301-compat-before.h
+cp "$REC" /tmp/p301-rec-before.c
+cp "$SDE" /tmp/p301-sde-before.c
+cp "$BUS" /tmp/p301-bus-before.c
+cp "$RSC" /tmp/p301-rsc-before.c
+
+git -C "$ROOT" diff --binary --no-ext-diff > /tmp/p301-before.diff
+
+# Prove the exact inherited Phase13 compile-only runtime shims are still active.
+grep -Fq 'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.' "$COMPAT"
+grep -Fq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py \
+  --root "$ROOT" --report phase301-patch-report.json
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py \
+  --root "$ROOT" --check-only
+
+# Protected runtime implementation and recorder transport must be byte-identical.
+cmp -s /tmp/p301-rpmh-before.c "$RPMH"
+cmp -s /tmp/p301-compat-before.h "$COMPAT"
+cmp -s /tmp/p301-rec-before.c "$REC"
+
+# Scope gate: relative to the reconstructed Phase296 tree, this phase may only
+# touch the three observation targets.
+git -C "$ROOT" diff --binary --no-ext-diff > /tmp/p301-after.diff
+python3 - <<'PY'
+import subprocess
+from pathlib import Path
+root = Path('gki/common')
+allowed = {
+    'drivers/a52_display/msm/sde_rsc.c',
+    'drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c',
+    'drivers/soc/qcom/rpmh-rsc.c',
+}
+cp = subprocess.run(['git', '-C', str(root), 'diff', '--name-only'],
+                    text=True, stdout=subprocess.PIPE, check=True)
+changed = {x.strip() for x in cp.stdout.splitlines() if x.strip()}
+# The reconstructed Phase296 tree is itself generated and may already differ
+# from pristine common. Determine only the new files changed by comparing
+# before/after content snapshots of all candidate paths through explicit hashes.
+for rel in allowed:
+    if not (root / rel).is_file():
+        raise SystemExit('Phase301 missing allowed target: ' + rel)
+# Protected files are checked bytewise in shell. Here reject obvious Phase301
+# writes outside the three target paths by looking for our marker globally.
+marker = 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1'
+hits = []
+for p in root.rglob('*'):
+    if p.is_file() and '.git' not in p.parts:
+        try:
+            t = p.read_text(errors='ignore')
+        except OSError:
+            continue
+        if marker in t:
+            hits.append(p.relative_to(root).as_posix())
+if sorted(hits) != sorted(allowed):
+    raise SystemExit(f'Phase301 marker scope mismatch: {hits}')
+print('Phase301 marker scope:', ', '.join(sorted(hits)))
+PY
+
+# Preserve Phase296 configuration exactly.
+cp /tmp/p301-phase296.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase301-olddefconfig.log 2>&1
+cmp -s /tmp/p301-phase296.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase301-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$rc" > phase301-make-return-code.txt
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase301-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase301-compile.log "$OUT/audit/"
+cp phase301-olddefconfig.log "$OUT/audit/"
+cp phase301-make-return-code.txt "$OUT/audit/"
+cp phase301-patch-report.json "$OUT/audit/"
+cp scripts/301_apply_rpmh_rsc_contract_trace.py "$OUT/audit/"
+cp /tmp/p301-sde-before.c "$OUT/audit/sde_rsc-before.c"
+cp /tmp/p301-bus-before.c "$OUT/audit/msm_bus_fabric_rpmh-before.c"
+cp /tmp/p301-rsc-before.c "$OUT/audit/rpmh-rsc-before.c"
+cp /tmp/p301-rpmh-before.c "$OUT/audit/rpmh-before.c"
+cp /tmp/p301-compat-before.h "$OUT/audit/a52-port-compat-before.h"
+cp /tmp/p301-rec-before.c "$OUT/audit/recorder-before.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase296-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase301-out')
+image = (r/'compile/Image').read_bytes()
+source = ''.join((r/'source'/n).read_text(errors='replace') for n in (
+    'sde_rsc.c','msm_bus_fabric_rpmh.c','rpmh-rsc.c'))
+markers = [
+    'P276 301S t=%d r=%d en=1 irq=%d',
+    'P276 301V e cur=%d irq=%d',
+    'P276 301V tw=%d',
+    'P276 301V inv dev=%s',
+    'P276 301F would dev=%s irq=%d',
+    'P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d',
+    'P276 301B inv mb=%s',
+    'P276 301B A r=%d st=%d mb=%s',
+    'P276 301B W r=%d',
+    'P276 301B S r=%d',
+    'P276 301P hw=%u a=%d sl=%d w=%d c=%d',
+    'P276 301I s=%u w=%u use=%u',
+    'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+    'P276 301R c id=%d ty=%d',
+    'P276 301R x id=%d ty=%d',
+    'P276 301C e st=%d ty=%d n=%d slots=%u',
+    'P276 301C x r=%d id=%d cmd=%d slots=%u',
+]
+for m in markers:
+    if m not in source:
+        raise SystemExit('Phase301 source marker missing: ' + m)
+    if m.encode() not in image:
+        raise SystemExit('Phase301 runtime marker missing from Image: ' + m)
+compat = (r/'source/a52-port-compat.h').read_text(errors='replace')
+for token in [
+    'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.',
+    '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+    '#define rpmh_flush(d) do{}while(0)',
+]:
+    if token not in compat:
+        raise SystemExit('Phase301 Phase13 invariant missing: ' + token)
+if (r/'source/rpmh.c').read_bytes() != (r/'audit/rpmh-before.c').read_bytes():
+    raise SystemExit('Phase301 rpmh.c changed unexpectedly')
+if (r/'source/a52-port-compat.h').read_bytes() != (r/'audit/a52-port-compat-before.h').read_bytes():
+    raise SystemExit('Phase301 compatibility header changed unexpectedly')
+if (r/'source/a52_ack_secure_flight_recorder.c').read_bytes() != (r/'audit/recorder-before.c').read_bytes():
+    raise SystemExit('Phase301 recorder changed unexpectedly')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '301',
+    'name': 'RPMH-RSC-CONTRACT-TRACE-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase296 userspace DRM atomic frontier',
+    'hardware_validated': False,
+    'functional_change': 'instrumentation-only',
+    'solver_behavior_restored': False,
+    'flush_behavior_restored': False,
+    'phase13_solver_stub_preserved': True,
+    'phase13_flush_stub_preserved': True,
+    'protected_rpmh_core_unchanged': True,
+    'protected_compat_header_unchanged': True,
+    'protected_recorder_unchanged': True,
+    'display_rsc_expected_dt_tcs': {'active':0,'sleep':1,'wake':1,'control':0},
+    'markers': markers,
+    'hardware_questions': [
+        'Does disp_rsc report HW solver support?',
+        'When SDE would enable solver mode, does an ACTIVE display bus vote still succeed?',
+        'Does that ACTIVE_ONLY transfer select and claim the borrowed WAKE TCS?',
+        'After WAKE/SLEEP batches are cached and SDE reaches would-flush, is control-data programming absent at that boundary?',
+    ],
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256(image).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase301 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase301 RPMh/RSC observation audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase301 RPMh/RSC contract trace build/repack: PASS'

--- a/scripts/304_apply_exact_f05a5a_visibility.py
+++ b/scripts/304_apply_exact_f05a5a_visibility.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+MARK = 'A52_PHASE304_EXACT_F05A5A_VISIBILITY_V1'
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase304 {label}: expected exactly one match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' not in text:
+        raise SystemExit('Phase304 requires inherited Phase293 GDM controller trace')
+    if 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' not in text:
+        raise SystemExit('Phase304 requires inherited Phase280 timeout retention latch')
+
+    marker_anchor = '/* A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1\n'
+    marker_text = (
+        '/* ' + MARK + '\n'
+        ' * Correlation-only continuation of the hardware-validated Phase303\n'
+        ' * visibility fix. Re-emit the inherited passive GDM snapshots through\n'
+        ' * the admitted P276 namespace and arm only for payload F0 5A 5A.\n'
+        ' * No DSI write, command flag, wait, timeout, recovery, clock, panel,\n'
+        ' * DMA/GEM/SMMU or RPMh behavior is changed.\n'
+        ' */\n'
+    )
+    text = replace_once(text, marker_anchor, marker_text + marker_anchor,
+                        'marker insertion')
+
+    old_scope = '''\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n\tp = msg->tx_buf;\n'''
+    new_scope = '''\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tp = msg->tx_buf;\n\tif (p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n'''
+    text = replace_once(text, old_scope, new_scope, 'exact payload scope')
+
+    text = text.replace('"GDM ', '"P276 303 ')
+    return text
+
+
+def patch_hw(text: str) -> str:
+    if 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' not in text:
+        raise SystemExit('Phase304 requires inherited Phase293 GDM HW trace')
+    return text.replace('"GDM ', '"P276 303 ')
+
+
+def validate(ctrl: str, hw: str) -> None:
+    combined = ctrl + hw
+    required = [
+        MARK,
+        'p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A',
+        'P276 303 S00 c=0 in=%x mf=%x t=%x l=%u',
+        'P276 303 S00p p=%02x%02x%02x',
+        'P276 303 S03 irq=%d in=%x st=%x',
+        'P276 303 S04 irq=%d in=%x st=%x',
+        'P276 303 S05 dc=%x off=%x len=%x fc=%x',
+        'P276 303 S06 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 S07 seen=1 st=%x in=%x irq0=%d',
+        'P276 303 S08 ret=%d irq=%d in=%x st=%x',
+        'P276 303 S09 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 DONE success=0 target=0/8/20/29/3',
+        'P276 280Z q=2',
+    ]
+    for token in required:
+        if token not in combined:
+            raise SystemExit('Phase304 required DSI token missing: ' + token)
+    if 'a52_ackfr_record("GDM ' in combined:
+        raise SystemExit('Phase304 still contains recorder-rejected GDM runtime records')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    cp = args.root / CTRL
+    hp = args.root / HW
+    if not cp.is_file() or not hp.is_file():
+        raise SystemExit('Phase304 DSI source files missing')
+
+    ctrl = cp.read_text()
+    hw = hp.read_text()
+    if not args.check_only:
+        cp.write_text(patch_ctrl(ctrl))
+        hp.write_text(patch_hw(hw))
+
+    validate(cp.read_text(), hp.read_text())
+    print('Phase304 exact F0 5A 5A visibility: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/304_ci_build.sh
+++ b/scripts/304_ci_build.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase304-out"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase304-failure
+  mkdir -p phase304-failure/{logs,audit,source}
+  cp phase304-compile.log phase304-olddefconfig.log phase304-failure/logs/ 2>/dev/null || true
+  for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase304-failure/source/ || true
+  done
+  cp /tmp/p304-* phase304-failure/audit/ 2>/dev/null || true
+  cp scripts/304_apply_exact_f05a5a_visibility.py phase304-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Build the already-audited Phase301 observer first. Phase301 itself reconstructs
+# the exact Phase296 physical-phone lineage and changes only SDE RSC, display
+# msm_bus and disp_rsc observation sites. Phase304 then adds only the exact
+# Phase303 F0 5A 5A persistent-visibility formatting to the inherited DSI trace.
+bash scripts/301_ci_build.sh
+
+test -s phase301-out/package/boot.img
+test -s phase301-out/compile/Image
+test -s phase301-out/config/final.config
+test "$(stat -c '%s' phase301-out/package/boot.img)" -eq 100663296
+for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do test -s "$f"; done
+
+# Confirm Phase301 is really present and the Phase13 behavior erasures remain.
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$SDE"
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$BUS"
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$RSC"
+grep -Fq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+# Confirm the clean inherited DSI reference and retention path are present.
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' "$CTRL"
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' "$HW"
+grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$CTRL"
+grep -Fq 'P276 280Z q=2' "$CTRL"
+
+cp phase301-out/config/final.config /tmp/p304-phase301.config
+cp "$CTRL" /tmp/p304-ctrl-before.c
+cp "$HW" /tmp/p304-hw-before.c
+cp "$SDE" /tmp/p304-sde-before.c
+cp "$BUS" /tmp/p304-bus-before.c
+cp "$RSC" /tmp/p304-rsc-before.c
+cp "$RPMH" /tmp/p304-rpmh-before.c
+cp "$COMPAT" /tmp/p304-compat-before.h
+cp "$REC" /tmp/p304-rec-before.c
+
+python3 -m py_compile scripts/304_apply_exact_f05a5a_visibility.py
+python3 scripts/304_apply_exact_f05a5a_visibility.py --root "$ROOT"
+python3 scripts/304_apply_exact_f05a5a_visibility.py --root "$ROOT" --check-only
+
+# Phase304 must not touch the Phase301 observer, RPMh core, compatibility ABI or
+# recorder transport. Only the inherited Phase293 DSI recorder formatting/scope
+# is changed in this second step.
+cmp -s /tmp/p304-sde-before.c "$SDE"
+cmp -s /tmp/p304-bus-before.c "$BUS"
+cmp -s /tmp/p304-rsc-before.c "$RSC"
+cmp -s /tmp/p304-rpmh-before.c "$RPMH"
+cmp -s /tmp/p304-compat-before.h "$COMPAT"
+cmp -s /tmp/p304-rec-before.c "$REC"
+! cmp -s /tmp/p304-ctrl-before.c "$CTRL"
+! cmp -s /tmp/p304-hw-before.c "$HW"
+
+# Prove the DSI visibility patch adds no behavior-changing primitive.
+python3 - <<'PY'
+from pathlib import Path
+pairs = [
+    (Path('/tmp/p304-ctrl-before.c'), Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl.c')),
+    (Path('/tmp/p304-hw-before.c'), Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')),
+]
+tokens = [
+    'DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
+    'wait_for_completion_timeout(', 'msleep(', 'usleep_range(',
+    'DSI_CTRL_CMD_FIFO_STORE', 'rpmh_mode_solver_set(', 'rpmh_flush(',
+]
+for before, after in pairs:
+    b = before.read_text()
+    a = after.read_text()
+    for token in tokens:
+        if b.count(token) != a.count(token):
+            raise SystemExit(
+                f'Phase304 behavior primitive count changed: {after} {token} '
+                f'{b.count(token)}->{a.count(token)}')
+print('Phase304 DSI behavior primitive audit: PASS')
+PY
+
+# Preserve Phase301/Phase296 configuration byte-for-byte.
+cp /tmp/p304-phase301.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase304-olddefconfig.log 2>&1
+cmp -s /tmp/p304-phase301.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase304-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase304-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+# Require both observer families in the final kernel image.
+for marker in \
+  'P276 301S t=%d r=%d en=1 irq=%d' \
+  'P276 301V e cur=%d irq=%d' \
+  'P276 301F would dev=%s irq=%d' \
+  'P276 301B A r=%d st=%d mb=%s' \
+  'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d' \
+  'P276 301R x id=%d ty=%d' \
+  'P276 301I s=%u w=%u use=%u' \
+  'P276 303 S00 c=0 in=%x mf=%x t=%x l=%u' \
+  'P276 303 S00p p=%02x%02x%02x' \
+  'P276 303 S03 irq=%d in=%x st=%x' \
+  'P276 303 S04 irq=%d in=%x st=%x' \
+  'P276 303 S05 dc=%x off=%x len=%x fc=%x' \
+  'P276 303 S06 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 S07 seen=1 st=%x in=%x irq0=%d' \
+  'P276 303 S08 ret=%d irq=%d in=%x st=%x' \
+  'P276 303 S09 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 DONE success=0 target=0/8/20/29/3' \
+  'P276 280Z q=2'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase304-compile.log phase304-olddefconfig.log "$OUT/audit/"
+cp scripts/301_apply_rpmh_rsc_contract_trace.py "$OUT/audit/"
+cp scripts/304_apply_exact_f05a5a_visibility.py "$OUT/audit/"
+for f in /tmp/p304-*; do [ -f "$f" ] && cp "$f" "$OUT/audit/"; done
+cp "$CTRL" "$OUT/source/dsi_ctrl.c"
+cp "$HW" "$OUT/source/dsi_ctrl_hw_cmn.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase301-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase304-out')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '304',
+    'name': 'RPMH-RSC-F05A5A-CORRELATION-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase296 reconstruction plus Phase301 observation-only RPMh/RSC trace',
+    'hardware_validated': False,
+    'functional_change': 'instrumentation-only',
+    'phase13_solver_stub_preserved': True,
+    'phase13_flush_stub_preserved': True,
+    'solver_behavior_restored': False,
+    'flush_behavior_restored': False,
+    'dsi_control_flow_change': False,
+    'wait_or_timeout_change': False,
+    'fifo_reroute': False,
+    'clock_recovery': False,
+    'recorder_transport_change': False,
+    'phase303_hardware_capture': 'A52_RAW_RAMOOPS_20260823_123924.zip',
+    'phase303_hardware_result': [
+        'exact F0 5A 5A normal FETCH_MEMORY transaction reached',
+        'Golden-compatible IRQ arm state observed before kickoff',
+        'after trigger STATUS became 3 but raw DMA_DONE remained zero',
+        'no Phase303 S07 DMA_DONE ISR record was emitted',
+        'completion timed out after about 200 ms with irq=0',
+        'IOVA translation/root and SMMU global fault state remained stable through timeout',
+    ],
+    'hardware_question': (
+        'During the same real F0 5A 5A transaction that fails to assert DMA_DONE, '
+        'does the Phase13-erased display RPMh solver/flush contract produce an '
+        'observable ACTIVE-vote / borrowed-WAKE-TCS / missing-flush runtime divergence?'
+    ),
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256((r/'compile/Image').read_bytes()).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase304 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase304 combined observation audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py --root "$ROOT" --check-only
+python3 scripts/304_apply_exact_f05a5a_visibility.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase304 RPMh/RSC + exact F0 5A 5A correlation build/repack: PASS'


### PR DESCRIPTION
## Hardware evidence entering Phase304

Phase303 hardware capture `A52_RAW_RAMOOPS_20260823_123924.zip` finally provides the persistent apples-to-apples DSI command-DMA trace for the exact Samsung level-1 key command:

- ctrl0
- incoming `FETCH_MEMORY = 0x20`
- MIPI flags `0x8`
- type `0x29`
- tx_len `3`
- payload `F0 5A 5A`

The retained sequence matches Golden through DMA_DONE interrupt arming. Immediately after the production SW trigger, GKI reaches `STATUS=3` but raw `DMA_DONE` remains zero, no `S07` ISR record occurs, the completion wait expires after about 200 ms with `irq=0`, and Phase280 retains the timeout. The inherited Phase280 SMMU evidence remains stable across q0/q1/q2 with valid contiguous IOVA translation, matching live/cached TTBR0/TCR and no new global SMMU fault.

Golden, by contrast, asserts raw DMA_DONE immediately after the same target kickoff, enters the ISR, wakes the completion and returns idle.

Historical Phase282 also showed the supported FIFO/TPG transport timing out without DMA_DONE, weakening an external command-memory-fetch-only explanation and keeping the shared DSI resource path important.

## Why combine Phase301 and Phase303

Phase301 already contains the bounded observation-only trace for the known Phase13 RPMh semantic erasure:

- SDE RSC state transitions and points where Golden would enter/leave solver mode or flush
- Display-RSC msm_bus ACTIVE/WAKE/SLEEP submissions
- `disp_rsc` TCS selection, including borrowed WAKE TCS use for ACTIVE traffic
- low-level invalidate and control-data programming

But the Phase301 hardware capture ended before Android reached the real graphics commit. Phase303 now proves the phone can reach that exact failing transaction.

Phase304 therefore runs both already-audited observers on the same exact Phase296 reconstruction so one retained hardware capture can correlate the RPMh/RSC transaction model with the exact missing DMA_DONE event.

## Scope

Observation only.

Phase304 does **not**:

- restore `rpmh_mode_solver_set()` behavior
- restore `rpmh_flush()` behavior
- change `rpmh_invalidate()`
- change DSI writes or command flags
- reroute memory fetch to FIFO
- change clocks, regulators, GPIOs, PHY state or panel commands
- change DMA/GEM/SMMU behavior
- change waits, timeouts or recovery
- change recorder transport/admission

The inherited Phase13 no-op macros remain exactly:

```c
#define rpmh_mode_solver_set(d,e) do{}while(0)
#define rpmh_flush(d) do{}while(0)
```

## Hardware question

During the same real `F0 5A 5A` transaction that fails to assert raw DMA_DONE, do we observe the runtime consequences predicted by the Phase13 RPMh contract erasure, especially an ACTIVE display vote using the borrowed WAKE TCS and/or an SDE invalidate/would-flush boundary without the corresponding low-level hardware flush/control-data transaction?

If yes, that provides the missing runtime basis for a narrowly scoped display RPMh compatibility repair. If no, keep the semantic erasure as technical debt and move to the remaining shared DSI power/interconnect dependency.