### PR TITLE
Phase306: restore display RPMh solver ownership

### DIFF
--- a/.github/workflows/306-a52-display-solver-compat.yml
+++ b/.github/workflows/306-a52-display-solver-compat.yml
@@ -1,0 +1,133 @@
+name: 306 - A52 display solver compatibility
+run-name: Phase 306 - causal test for erased display solver ownership
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase306-display-solver-compat-v1
+    paths:
+      - .github/workflows/306-a52-display-solver-compat.yml
+      - scripts/306_apply_display_solver_compat.py
+      - scripts/306_ci_build.sh
+      - scripts/305_apply_display_rpmh_flush_compat.py
+      - scripts/305_ci_build.sh
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase305-display-rpmh-flush-compat-v1
+    paths:
+      - .github/workflows/306-a52-display-solver-compat.yml
+      - scripts/306_apply_display_solver_compat.py
+      - scripts/306_ci_build.sh
+      - scripts/305_apply_display_rpmh_flush_compat.py
+      - scripts/305_ci_build.sh
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase306-display-solver-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build solver-semantics causal repair
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase306 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase305 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          python3 -m py_compile scripts/304_apply_exact_f05a5a_visibility.py
+          python3 -m py_compile scripts/305_apply_display_rpmh_flush_compat.py
+          python3 -m py_compile scripts/306_apply_display_solver_compat.py
+          bash -n scripts/301_ci_build.sh
+          bash -n scripts/304_ci_build.sh
+          bash -n scripts/305_ci_build.sh
+          bash -n scripts/306_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase306 solver repair
+        run: bash scripts/306_ci_build.sh
+
+      - name: Upload complete Phase306 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase306-DISPLAY-SOLVER-COMPAT-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase306-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase306 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase306-DISPLAY-SOLVER-COMPAT-${{ github.run_number }}-BOOT-IMG
+          path: phase306-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase306-DISPLAY-SOLVER-COMPAT-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase306-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/306_apply_display_solver_compat.py
+++ b/scripts/306_apply_display_solver_compat.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+RSC = Path('drivers/soc/qcom/rpmh-rsc.c')
+COMPAT = Path('a52-port-compat.h')
+MARK = 'A52_PHASE306_DISPLAY_SOLVER_COMPAT_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase306 {label}: expected exactly 1 anchor, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_rsc(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1' not in text:
+        raise SystemExit('Phase306 requires Phase305 flush repair')
+    if 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' not in text:
+        raise SystemExit('Phase306 requires inherited Phase301 observer')
+
+    helper = '''static bool a52_p301_disp_rsc(const struct rsc_drv *drv)\n{\n\treturn drv && drv->name && !strcmp(drv->name, "disp_rsc");\n}\n'''
+    helper_new = helper + '''\n/* A52_PHASE306_DISPLAY_SOLVER_COMPAT_V1: display-only solver ownership. */\nstatic bool a52_p306_disp_solver_owned;\n'''
+    text = one(text, helper, helper_new, 'solver state insertion')
+
+    flush_anchor = '''/*\n * A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1\n'''
+    solver_fn = '''/*\n * Restore the Samsung display-facing rpmh_mode_solver_set() contract without\n * replacing the pinned 5.10 RPMh core. Golden waits for the dedicated ACTIVE\n * TCS, or the borrowed WAKE TCS when ACTIVE is absent, to become idle before\n * changing ownership. Phase305 already provides exactly that busy predicate.\n *\n * The state is display-scoped and serialized by drv->lock. While owned, the\n * ACTIVE send path below returns -EBUSY, which msm_bus_disp_rsc explicitly\n * treats as the expected solver-mode result.\n */\nint a52_rpmh_mode_solver_set_compat(const struct device *dev, bool enable)\n{\n\tstruct rsc_drv *drv;\n\tunsigned long flags;\n\tbool old = false, waited = false;\n\tint ret = 0;\n\n\tif (!dev || !dev->parent) {\n\t\tret = -EINVAL;\n\t\tgoto out;\n\t}\n\n\tdrv = dev_get_drvdata(dev->parent);\n\tif (!drv) {\n\t\tret = -ENODEV;\n\t\tgoto out;\n\t}\n\n\t/* The compatibility contract is intentionally display-scoped. */\n\tif (!a52_p301_disp_rsc(drv))\n\t\tgoto out;\n\n\tfor (;;) {\n\t\tlocal_irq_save(flags);\n\t\tspin_lock(&drv->lock);\n\t\tif (!rpmh_rsc_ctrlr_is_busy(drv))\n\t\t\tbreak;\n\t\tspin_unlock(&drv->lock);\n\t\tlocal_irq_restore(flags);\n\t\twaited = true;\n\t\tcpu_relax();\n\t}\n\n\told = a52_p306_disp_solver_owned;\n\ta52_p306_disp_solver_owned = enable;\n\tspin_unlock(&drv->lock);\n\tlocal_irq_restore(flags);\n\nout:\n\ta52_ackfr_record("P276 306M e=%u o=%u w=%u r=%d",\n\t\tenable, old, waited, ret);\n\treturn ret;\n}\n\n'''
+    text = one(text, flush_anchor, solver_fn + flush_anchor, 'solver compatibility function insertion')
+
+    gate_anchor = '''\tspin_lock_irq(&drv->lock);\n\n\t/* Wait forever for a free tcs. It better be there eventually! */\n'''
+    gate_new = '''\tspin_lock_irq(&drv->lock);\n\n\t/*\n\t * Golden rejects ACTIVE/AMC traffic while disp_rsc is solver-owned.\n\t * Without this Phase13 semantic, pinned 5.10 borrows WAKE_TCS and\n\t * triggers it as an ACTIVE transaction.\n\t */\n\tif (a52_p301_disp_rsc(drv) &&\n\t    msg->state == RPMH_ACTIVE_ONLY_STATE &&\n\t    a52_p306_disp_solver_owned) {\n\t\tspin_unlock_irq(&drv->lock);\n\t\ta52_ackfr_record("P276 306G b st=%d ty=%d",\n\t\t\tmsg->state, tcs->type);\n\t\treturn -EBUSY;\n\t}\n\n\t/* Wait forever for a free tcs. It better be there eventually! */\n'''
+    return one(text, gate_anchor, gate_new, 'ACTIVE solver gate insertion')
+
+
+def patch_compat(text: str) -> str:
+    if MARK in text:
+        return text
+    old = '''#define rpmh_mode_solver_set(d,e) do{}while(0)\n/* A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1: flush-only causal repair. */\nint a52_rpmh_flush_compat(const struct device *dev);\n#define rpmh_flush(d) a52_rpmh_flush_compat((d))\n'''
+    new = '''/* A52_PHASE306_DISPLAY_SOLVER_COMPAT_V1: restore display solver ownership. */\nint a52_rpmh_mode_solver_set_compat(const struct device *dev, bool enable);\n#define rpmh_mode_solver_set(d,e) a52_rpmh_mode_solver_set_compat((d), (e))\n/* A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1: retained flush repair. */\nint a52_rpmh_flush_compat(const struct device *dev);\n#define rpmh_flush(d) a52_rpmh_flush_compat((d))\n'''
+    return one(text, old, new, 'Phase13 solver stub replacement')
+
+
+def validate(rsc: str, compat: str) -> None:
+    joined = rsc + compat
+    required = [
+        MARK,
+        'static bool a52_p306_disp_solver_owned;',
+        'int a52_rpmh_mode_solver_set_compat(const struct device *dev, bool enable)',
+        'rpmh_rsc_ctrlr_is_busy(drv)',
+        'cpu_relax();',
+        'a52_p306_disp_solver_owned = enable;',
+        'P276 306M e=%u o=%u w=%u r=%d',
+        'msg->state == RPMH_ACTIVE_ONLY_STATE',
+        'P276 306G b st=%d ty=%d',
+        'return -EBUSY;',
+        '#define rpmh_mode_solver_set(d,e) a52_rpmh_mode_solver_set_compat((d), (e))',
+        '#define rpmh_flush(d) a52_rpmh_flush_compat((d))',
+        'P276 305F e',
+        'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+    ]
+    for token in required:
+        if token not in joined:
+            raise SystemExit('Phase306 required token missing: ' + token)
+    if '#define rpmh_mode_solver_set(d,e) do{}while(0)' in compat:
+        raise SystemExit('Phase306 legacy solver erasure still present')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+    rp = args.root / RSC
+    cp = args.root / COMPAT
+    if not rp.is_file() or not cp.is_file():
+        raise SystemExit('Phase306 required source files missing')
+    if not args.check_only:
+        rp.write_text(patch_rsc(rp.read_text()))
+        cp.write_text(patch_compat(cp.read_text()))
+    validate(rp.read_text(), cp.read_text())
+    print('Phase306 display solver ownership compatibility repair: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/306_ci_build.sh
+++ b/scripts/306_ci_build.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase306-out"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+GOLD_RSC="$PWD/workspace/touchgrass-a52xq/drivers/soc/qcom/rpmh-rsc.c"
+GOLD_RPMH="$PWD/workspace/touchgrass-a52xq/drivers/soc/qcom/rpmh.c"
+
+fail_report() {
+  set +e
+  rm -rf phase306-failure
+  mkdir -p phase306-failure/{logs,audit,source}
+  cp phase306-compile.log phase306-olddefconfig.log phase306-failure/logs/ 2>/dev/null || true
+  for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase306-failure/source/ || true
+  done
+  cp /tmp/p306-* phase306-failure/audit/ 2>/dev/null || true
+  cp scripts/306_apply_display_solver_compat.py phase306-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact Phase305 candidate first. Hardware subsequently proved
+# its flush bridge executes successfully but does not restore DSI DMA_DONE.
+bash scripts/305_ci_build.sh
+
+test -s phase305-out/package/boot.img
+test -s phase305-out/compile/Image
+test -s phase305-out/config/final.config
+test "$(stat -c '%s' phase305-out/package/boot.img)" -eq 100663296
+for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC" "$GOLD_RSC" "$GOLD_RPMH"; do test -s "$f"; done
+
+# Lock the proven Phase305 repair and the still-erased solver contract.
+grep -Fq 'A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1' "$RSC"
+grep -Fq 'P276 305F e' "$RSC"
+grep -Fxq '#define rpmh_flush(d) a52_rpmh_flush_compat((d))' "$COMPAT"
+grep -Fxq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+
+# Lock exact Golden semantics used for this compatibility repair:
+# - wait for ACTIVE, or borrowed WAKE, TCS to be free before changing ownership
+# - reject ACTIVE requests with -EBUSY while solver-owned.
+grep -Fq 'void rpmh_rsc_mode_solver_set(struct rsc_drv *drv, bool enable)' "$GOLD_RSC"
+grep -Fq 'if (!tcs->num_tcs)' "$GOLD_RSC"
+grep -Fq 'tcs = get_tcs_of_type(drv, WAKE_TCS);' "$GOLD_RSC"
+grep -Fq 'drv->in_solver_mode = enable;' "$GOLD_RSC"
+grep -Fq 'if (ctrlr->in_solver_mode && state == RPMH_ACTIVE_ONLY_STATE)' "$GOLD_RPMH"
+grep -Fq 'ret = -EBUSY;' "$GOLD_RPMH"
+
+# The imported Samsung display bus explicitly accepts this solver-owned result.
+grep -Fq 'ret && ret != -EBUSY' "$BUS"
+grep -Fq 'the display RSC is in solver mode' "$BUS"
+
+cp phase305-out/config/final.config /tmp/p306-phase305.config
+cp "$CTRL" /tmp/p306-ctrl-before.c
+cp "$HW" /tmp/p306-hw-before.c
+cp "$SDE" /tmp/p306-sde-before.c
+cp "$BUS" /tmp/p306-bus-before.c
+cp "$RSC" /tmp/p306-rsc-before.c
+cp "$RPMH" /tmp/p306-rpmh-before.c
+cp "$COMPAT" /tmp/p306-compat-before.h
+cp "$REC" /tmp/p306-rec-before.c
+
+python3 -m py_compile scripts/306_apply_display_solver_compat.py
+python3 scripts/306_apply_display_solver_compat.py --root "$ROOT"
+python3 scripts/306_apply_display_solver_compat.py --root "$ROOT" --check-only
+
+# Solver-only delta on top of Phase305. Flush, DSI, SDE, bus, native rpmh.c,
+# recorder and config remain unchanged.
+cmp -s /tmp/p306-ctrl-before.c "$CTRL"
+cmp -s /tmp/p306-hw-before.c "$HW"
+cmp -s /tmp/p306-sde-before.c "$SDE"
+cmp -s /tmp/p306-bus-before.c "$BUS"
+cmp -s /tmp/p306-rpmh-before.c "$RPMH"
+cmp -s /tmp/p306-rec-before.c "$REC"
+! cmp -s /tmp/p306-rsc-before.c "$RSC"
+! cmp -s /tmp/p306-compat-before.h "$COMPAT"
+
+grep -Fxq '#define rpmh_mode_solver_set(d,e) a52_rpmh_mode_solver_set_compat((d), (e))' "$COMPAT"
+grep -Fxq '#define rpmh_flush(d) a52_rpmh_flush_compat((d))' "$COMPAT"
+! grep -Fq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+
+python3 - <<'PY'
+from pathlib import Path
+r0 = Path('/tmp/p306-rsc-before.c').read_text()
+r1 = Path('gki/common/drivers/soc/qcom/rpmh-rsc.c').read_text()
+c0 = Path('/tmp/p306-compat-before.h').read_text()
+c1 = Path('gki/common/a52-port-compat.h').read_text()
+
+expected = {
+    'rpmh_rsc_ctrlr_is_busy(drv)': 1,
+    'local_irq_save(': 1,
+    'local_irq_restore(': 2,
+    'cpu_relax();': 1,
+    'P276 306M e=%u o=%u w=%u r=%d': 1,
+    'P276 306G b st=%d ty=%d': 1,
+}
+for token, delta in expected.items():
+    got = r1.count(token) - r0.count(token)
+    if got != delta:
+        raise SystemExit(f'Phase306 intended RSC delta mismatch {token}: {got} != {delta}')
+
+for token in [
+    'write_tcs_reg(', 'write_tcs_reg_sync(', 'write_tcs_cmd(',
+    '__tcs_buffer_write(', '__tcs_set_trigger(', 'wait_event_lock_irq(',
+    'msleep(', 'usleep_range(', 'udelay(', 'rpmh_flush(&drv->client)',
+]:
+    if r1.count(token) != r0.count(token):
+        raise SystemExit(f'Phase306 unexpected low-level primitive drift: {token}')
+
+if c0.count('#define rpmh_mode_solver_set(d,e) do{}while(0)') != 1:
+    raise SystemExit('Phase306 baseline solver-erasure count changed')
+if c1.count('#define rpmh_mode_solver_set(d,e) a52_rpmh_mode_solver_set_compat((d), (e))') != 1:
+    raise SystemExit('Phase306 solver compatibility macro missing')
+if c0.count('#define rpmh_flush(d) a52_rpmh_flush_compat((d))') != 1 or c1.count('#define rpmh_flush(d) a52_rpmh_flush_compat((d))') != 1:
+    raise SystemExit('Phase306 Phase305 flush bridge drifted')
+print('Phase306 solver-only behavior delta audit: PASS')
+PY
+
+cp /tmp/p306-phase305.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase306-olddefconfig.log 2>&1
+cmp -s /tmp/p306-phase305.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase306-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase306-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+for marker in \
+  'P276 306M e=%u o=%u w=%u r=%d' \
+  'P276 306G b st=%d ty=%d' \
+  'P276 305F e' \
+  'P276 305F x r=%d l=%u b=%u' \
+  'P276 301S t=%d r=%d en=1 irq=%d' \
+  'P276 301B A r=%d st=%d mb=%s' \
+  'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d' \
+  'P276 301C e st=%d ty=%d n=%d slots=%u' \
+  'P276 303 S00p p=%02x%02x%02x' \
+  'P276 303 S06 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 S07 seen=1 st=%x in=%x irq0=%d' \
+  'P276 303 S08 ret=%d irq=%d in=%x st=%x' \
+  'P276 280Z q=2'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+if [ -f "$BUILD/vmlinux" ]; then
+  nm "$BUILD/vmlinux" | grep -Eq ' [Tt] a52_rpmh_mode_solver_set_compat$'
+  nm "$BUILD/vmlinux" | grep -Eq ' [Tt] a52_rpmh_flush_compat$'
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase306-compile.log phase306-olddefconfig.log "$OUT/audit/"
+cp scripts/306_apply_display_solver_compat.py "$OUT/audit/"
+for f in /tmp/p306-*; do [ -f "$f" ] && cp "$f" "$OUT/audit/"; done
+cp "$CTRL" "$OUT/source/dsi_ctrl.c"
+cp "$HW" "$OUT/source/dsi_ctrl_hw_cmn.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase305-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase306-out')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '306',
+    'name': 'DISPLAY-SOLVER-COMPAT-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'Phase305 flush-repair lineage plus hardware result A52_RAW_RAMOOPS_20260823_145905.zip',
+    'hardware_validated': False,
+    'functional_change': 'restore display-only rpmh_mode_solver_set ownership and block ACTIVE sends with -EBUSY while owned',
+    'phase305_hardware_result': [
+        '305F bridge executed with r=0 l=1 b=0',
+        '301I invalidate and WAKE/SLEEP 301C programming appeared',
+        'exact F0 5A 5A still produced CLK_STATUS=0x8037C3, LANE=0x1F1F and no DMA_DONE',
+        'flush defect is real but insufficient by itself',
+    ],
+    'phase305_flush_repair_retained': True,
+    'native_rpmh_core_changed': False,
+    'sde_source_changed': False,
+    'msm_bus_source_changed': False,
+    'dsi_control_flow_changed': False,
+    'smmu_or_gem_changed': False,
+    'wait_or_timeout_changed': False,
+    'hardware_question': 'Does restoring display solver ownership prevent borrowed WAKE_TCS ACTIVE triggers and restore DSI DMA_DONE for exact F0 5A 5A?',
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256((r/'compile/Image').read_bytes()).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase306 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase306 solver compatibility audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/306_apply_display_solver_compat.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase306 display solver compatibility build/repack: PASS'


### PR DESCRIPTION
## Hardware evidence entering Phase306

Phase305 hardware capture `A52_RAW_RAMOOPS_20260823_145905.zip` cleanly falsified the flush-only root-cause hypothesis:

- the Phase305 bridge entered and returned `P276 305F x r=0 l=1 b=0`
- low-level `301I` invalidation appeared
- both WAKE and SLEEP `301C` control-data programming completed successfully
- about 9.59 ms later the exact `F0 5A 5A` DSI command still reached STATUS=3 with `LANE=0x1F1F`, `CLK_STATUS=0x8037C3`, no S07 DMA_DONE ISR, and the same timeout

Therefore the missing flush contract is a real Phase13 defect, but it is not sufficient to explain the missing DSI DMA_DONE.

## Remaining Phase13 defect

The imported Samsung SDE still calls `rpmh_mode_solver_set(rsc->rpmh_dev, true/false)` at its RSC state transitions, but Phase13 currently erases every one of those calls with:

```c
#define rpmh_mode_solver_set(d,e) do{}while(0)
```

Golden 4.19 uses this as an ownership contract. It waits until the dedicated ACTIVE TCS, or borrowed WAKE TCS when no ACTIVE TCS exists, is idle before changing solver ownership. While solver-owned, ACTIVE_ONLY RPMh requests are rejected with `-EBUSY`.

The imported display msm_bus code explicitly treats `-EBUSY` as the expected result for Display RSC ACTIVE requests while the solver owns the RSC.

Phase304/305 instead proved the current GKI path sends those ACTIVE requests successfully by borrowing and triggering the single WAKE TCS.

## Phase306 repair

Restore only that missing display-facing solver ownership semantic on top of the proven Phase305 flush repair.

- add a display-only solver-owned state in `rpmh-rsc.c`
- serialize it with the existing `drv->lock`
- before changing ownership, wait for the ACTIVE TCS or borrowed WAKE TCS to become idle, mirroring Golden ordering
- while `disp_rsc` is solver-owned, return `-EBUSY` for `RPMH_ACTIVE_ONLY_STATE` before the WAKE TCS is claimed/programmed/triggered
- retain the Phase305 flush compatibility bridge unchanged

## New runtime markers

- `P276 306M e=%u o=%u w=%u r=%d` - solver ownership update: requested enable, old state, whether it had to wait for an in-flight TCS, result
- `P276 306G b st=%d ty=%d` - display ACTIVE request blocked before borrowed WAKE TCS trigger

Expected decisive sequence if the missing ownership semantic matters:

```text
301S ... en=1
306M e=1 ... r=0
301R e st=2 ty=1 ...
306G b st=2 ty=1
301B A r=-16 st=2 ...
(no 301R c/x borrowed-WAKE trigger)
305F / 301I / 301C flush path remains valid
F0 5A 5A
303 S06 ...
303 S07 seen=1   <-- causal success if DMA_DONE returns
```

## Explicitly unchanged

- Phase305 flush repair
- native pinned-5.10 `rpmh.c`
- SDE source and state machine
- msm_bus source
- DSI command/control flow and register writes
- DMA/GEM/SMMU
- clocks/regulators/GPIO/PHY/panel code
- waits/timeouts/recovery
- recorder transport
- kernel config

## Single hardware question

Does restoring the erased Samsung display solver-ownership contract prevent the borrowed-WAKE ACTIVE transactions and make the exact `F0 5A 5A` DSI command assert DMA_DONE?