### PR TITLE
Phase307: compare Golden vs GKI v3 PHY clock-lane transition

### DIFF
--- a/.github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+++ b/.github/workflows/301-a52-rpmh-rsc-contract-trace.yml
@@ -1,0 +1,115 @@
+name: 301 - A52 RPMh RSC contract trace
+run-name: Phase 301 - observe Phase13 solver/flush runtime consequences
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase301-rpmh-rsc-contract-trace-v1
+    paths:
+      - .github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/301-a52-rpmh-rsc-contract-trace.yml
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase301-rpmh-rsc-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only RPMh/RSC contract trace
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase301 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          bash -n scripts/301_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase301 trace candidate
+        run: bash scripts/301_ci_build.sh
+
+      - name: Upload complete Phase301 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase301-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase301 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-BOOT-IMG
+          path: phase301-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase301-RPMH-RSC-CONTRACT-TRACE-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase301-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
+++ b/.github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
@@ -1,0 +1,121 @@
+name: 304 - A52 RPMh/RSC and F0 5A 5A correlation
+run-name: Phase 304 - correlate display RPMh contract with exact DSI DMA timeout
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase304-rpmh-rsc-f05a5a-correlation-v1
+    paths:
+      - .github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/304-a52-rpmh-rsc-f05a5a-correlation.yml
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase304-rpmh-rsc-f05a5a-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build observation-only RPMh/RSC plus exact F0 5A 5A correlation
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase304 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase296 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          python3 -m py_compile scripts/304_apply_exact_f05a5a_visibility.py
+          bash -n scripts/301_ci_build.sh
+          bash -n scripts/304_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase304 correlation candidate
+        run: bash scripts/304_ci_build.sh
+
+      - name: Upload complete Phase304 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase304-RPMH-RSC-F05A5A-CORRELATION-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase304-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase304 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase304-RPMH-RSC-F05A5A-CORRELATION-${{ github.run_number }}-BOOT-IMG
+          path: phase304-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase304-RPMH-RSC-F05A5A-CORRELATION-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase304-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/305-a52-display-rpmh-flush-compat.yml
+++ b/.github/workflows/305-a52-display-rpmh-flush-compat.yml
@@ -1,0 +1,127 @@
+name: 305 - A52 display RPMh flush compatibility
+run-name: Phase 305 - causal test for missing display RPMh flush
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase305-display-rpmh-flush-compat-v1
+    paths:
+      - .github/workflows/305-a52-display-rpmh-flush-compat.yml
+      - scripts/305_apply_display_rpmh_flush_compat.py
+      - scripts/305_ci_build.sh
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+    paths:
+      - .github/workflows/305-a52-display-rpmh-flush-compat.yml
+      - scripts/305_apply_display_rpmh_flush_compat.py
+      - scripts/305_ci_build.sh
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+      - scripts/296_ci_build.sh
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase305-display-rpmh-flush-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build flush-only causal repair
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase305 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare exact Phase304 environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+          python3 -m py_compile scripts/304_apply_exact_f05a5a_visibility.py
+          python3 -m py_compile scripts/305_apply_display_rpmh_flush_compat.py
+          bash -n scripts/301_ci_build.sh
+          bash -n scripts/304_ci_build.sh
+          bash -n scripts/305_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase305 flush-only repair
+        run: bash scripts/305_ci_build.sh
+
+      - name: Upload complete Phase305 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase305-DISPLAY-RPMH-FLUSH-COMPAT-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase305-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase305 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase305-DISPLAY-RPMH-FLUSH-COMPAT-${{ github.run_number }}-BOOT-IMG
+          path: phase305-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase305-DISPLAY-RPMH-FLUSH-COMPAT-${{ github.run_number }}-FAILED-DIAGNOSTICS
+          path: phase305-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/307-a52-gki-v3-phy-clocklane-correlation.yml
+++ b/.github/workflows/307-a52-gki-v3-phy-clocklane-correlation.yml
@@ -1,0 +1,115 @@
+name: 307 - A52 GKI v3 PHY clock-lane correlation
+run-name: Phase 307 - GKI exact F05A5A v3 PHY clock-lane observer
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase307-golden-gki-v3-phy-clocklane-correlation-v1
+    paths:
+      - .github/workflows/307-a52-gki-v3-phy-clocklane-correlation.yml
+      - scripts/307_apply_v3_phy_clocklane_correlation.py
+      - scripts/307_ci_build.sh
+      - scripts/305_apply_display_rpmh_flush_compat.py
+      - scripts/305_ci_build.sh
+      - scripts/304_apply_exact_f05a5a_visibility.py
+      - scripts/304_ci_build.sh
+      - scripts/301_apply_rpmh_rsc_contract_trace.py
+      - scripts/301_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase307-gki-v3-phy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build Phase305-based read-only v3 PHY observer
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase307 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/307_apply_v3_phy_clocklane_correlation.py
+          bash -n scripts/307_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase307 GKI observer
+        run: bash scripts/307_ci_build.sh
+
+      - name: Upload complete GKI evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase307-GKI-V3-PHY-CLOCKLANE-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase307-gki-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload GKI boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase307-GKI-V3-PHY-CLOCKLANE-${{ github.run_number }}-BOOT-IMG
+          path: phase307-gki-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase307-GKI-V3-PHY-CLOCKLANE-${{ github.run_number }}-FAILED
+          path: phase307-gki-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/307g-a52-golden-v3-phy-clocklane-reference.yml
+++ b/.github/workflows/307g-a52-golden-v3-phy-clocklane-reference.yml
@@ -25,6 +25,10 @@ concurrency:
 env:
   BOOT_SOURCE_ASSET_ID: '478920392'
   BOOT_SOURCE_SHA256: '41ae3b24771c70747c26aa17a18d254ffcb1c0d742b96f4f1f1fff20a6638554'
+  GOLDEN_CONTROL_REF: agent/a52-golden-touchgrass-clock-reference-v1
+  JOBS: '4'
+  CCACHE_DIR: ${{ github.workspace }}/golden-work/.ccache
+  CCACHE_MAXSIZE: 5G
 
 jobs:
   build:
@@ -45,33 +49,54 @@ jobs:
           python3 -m py_compile scripts/307g_apply_golden_v3_phy_clocklane_reference.py
           bash -n scripts/307g_ci_build.sh
 
+      - name: Create exact proven Golden-control workspace
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          rm -rf golden-work
+          gh repo clone "$GITHUB_REPOSITORY" golden-work -- \
+            --depth=1 --branch "$GOLDEN_CONTROL_REF" --single-branch
+          test -s golden-work/scripts/golden_touchgrass_clock_reference_build.sh
+          test -s golden-work/scripts/04_apply_linux_4.19.154.sh
+          test -s golden-work/scripts/checkpoint_resolve_linux_4.19.200.sh
+          cp scripts/307g_apply_golden_v3_phy_clocklane_reference.py golden-work/scripts/
+          cp scripts/307g_ci_build.sh golden-work/scripts/
+          python3 -m py_compile golden-work/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+          bash -n golden-work/scripts/307g_ci_build.sh
+
       - name: Hydrate known-good Golden FDR repack helpers
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -Eeuo pipefail
-          mkdir -p scripts projects/a52-p1-boot-image
+          mkdir -p golden-work/scripts golden-work/projects/a52-p1-boot-image
           fetch_file() {
-            local ref="$1" path="$2"
-            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${ref}" --jq '.content' | tr -d '\n' | base64 --decode > "$path"
-            test -s "$path"
+            local ref="$1" path="$2" out="golden-work/$2"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${ref}" \
+              --jq '.content' | tr -d '\n' | base64 --decode > "$out"
+            test -s "$out"
           }
           fetch_file main scripts/37_validate_a52_p1_boot_source.py
           fetch_file main scripts/38_repack_a52_p1_boot.py
           fetch_file main projects/a52-p1-boot-image/boot-source.lock
-          chmod +x scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
+          chmod +x golden-work/scripts/37_validate_a52_p1_boot_source.py \
+            golden-work/scripts/38_repack_a52_p1_boot.py
 
       - name: Restore compiler cache
         uses: actions/cache@v4
         with:
-          path: .ccache
+          path: golden-work/.ccache
           key: a52xq-phase307-golden-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
             a52xq-linux-4.19.200-ccache-${{ runner.os }}-
             a52xq-linux-4.19.180-ccache-${{ runner.os }}-
 
       - name: Reconstruct and build Golden observer
-        run: bash scripts/307g_ci_build.sh
+        run: |
+          set -Eeuo pipefail
+          cd golden-work
+          bash scripts/307g_ci_build.sh
 
       - name: Repack with known-good Golden FDR boot container
         if: success()
@@ -79,6 +104,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -Eeuo pipefail
+          cd golden-work
           OUT=phase307-golden-out
           mkdir -p intake "$OUT/package"
           gzip -n -9 -c "$OUT/Image" > "$OUT/package/Image.gz"
@@ -95,15 +121,17 @@ jobs:
             --source intake/boot.img --kernel "$OUT/package/Image.gz" \
             --output "$OUT/package/boot.img" --report "$OUT/package/repack-report.json"
           test "$(stat -c %s "$OUT/package/boot.img")" = 100663296
-          sed -i 's/^flashable=.*/flashable=yes-known-good-96MiB-container-repacked/' "$OUT/BUILD-IDENTITY.txt"
-          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          sed -i 's/^flashable=.*/flashable=yes-known-good-96MiB-container-repacked/' \
+            "$OUT/BUILD-IDENTITY.txt"
+          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | \
+            xargs -0 sha256sum > SHA256SUMS)
 
       - name: Upload Golden evidence
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: A52XQ-Phase307-GOLDEN-TOUCHGRASS-V3-PHY-CLOCKLANE-${{ github.run_number }}-BOOT-IMG
-          path: phase307-golden-out/
+          path: golden-work/phase307-golden-out/
           if-no-files-found: error
           compression-level: 1
           retention-days: 30
@@ -113,6 +141,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: A52XQ-Phase307-GOLDEN-V3-PHY-CLOCKLANE-${{ github.run_number }}-FAILED
-          path: phase307-golden-failure/
+          path: golden-work/phase307-golden-failure/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/307g-a52-golden-v3-phy-clocklane-reference.yml
+++ b/.github/workflows/307g-a52-golden-v3-phy-clocklane-reference.yml
@@ -1,0 +1,118 @@
+name: 307G - A52 Golden TouchGrass v3 PHY clock-lane reference
+run-name: Phase 307G - known-good TouchGrass exact F05A5A v3 PHY observer
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase307-golden-gki-v3-phy-clocklane-correlation-v1
+    paths:
+      - .github/workflows/307g-a52-golden-v3-phy-clocklane-reference.yml
+      - scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+      - scripts/307g_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase296-userspace-drm-atomic-frontier-v1
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase307-golden-v3-phy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BOOT_SOURCE_ASSET_ID: '478920392'
+  BOOT_SOURCE_SHA256: '41ae3b24771c70747c26aa17a18d254ffcb1c0d742b96f4f1f1fff20a6638554'
+
+jobs:
+  build:
+    name: Build and repack known-good TouchGrass observer
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    steps:
+      - name: Check out Phase307 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare runner
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl xz-utils gzip zip unzip make gcc g++ bc bison flex ccache patch \
+            libssl-dev libelf-dev python3 rsync cpio lz4 binutils file tar
+          python3 -m py_compile scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+          bash -n scripts/307g_ci_build.sh
+
+      - name: Hydrate known-good Golden FDR repack helpers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p scripts projects/a52-p1-boot-image
+          fetch_file() {
+            local ref="$1" path="$2"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${ref}" --jq '.content' | tr -d '\n' | base64 --decode > "$path"
+            test -s "$path"
+          }
+          fetch_file main scripts/37_validate_a52_p1_boot_source.py
+          fetch_file main scripts/38_repack_a52_p1_boot.py
+          fetch_file main projects/a52-p1-boot-image/boot-source.lock
+          chmod +x scripts/37_validate_a52_p1_boot_source.py scripts/38_repack_a52_p1_boot.py
+
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: a52xq-phase307-golden-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            a52xq-linux-4.19.200-ccache-${{ runner.os }}-
+            a52xq-linux-4.19.180-ccache-${{ runner.os }}-
+
+      - name: Reconstruct and build Golden observer
+        run: bash scripts/307g_ci_build.sh
+
+      - name: Repack with known-good Golden FDR boot container
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          OUT=phase307-golden-out
+          mkdir -p intake "$OUT/package"
+          gzip -n -9 -c "$OUT/Image" > "$OUT/package/Image.gz"
+          curl --fail --location --retry 3 --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" -H 'Accept: application/octet-stream' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${BOOT_SOURCE_ASSET_ID}" \
+            --output intake/boot.img
+          test "$(stat -c %s intake/boot.img)" = 100663296
+          printf '%s  %s\n' "$BOOT_SOURCE_SHA256" intake/boot.img | sha256sum -c -
+          python3 scripts/37_validate_a52_p1_boot_source.py intake/boot.img \
+            --lock projects/a52-p1-boot-image/boot-source.lock \
+            --output "$OUT/package/source-validation.json"
+          python3 scripts/38_repack_a52_p1_boot.py \
+            --source intake/boot.img --kernel "$OUT/package/Image.gz" \
+            --output "$OUT/package/boot.img" --report "$OUT/package/repack-report.json"
+          test "$(stat -c %s "$OUT/package/boot.img")" = 100663296
+          sed -i 's/^flashable=.*/flashable=yes-known-good-96MiB-container-repacked/' "$OUT/BUILD-IDENTITY.txt"
+          (cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+
+      - name: Upload Golden evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase307-GOLDEN-TOUCHGRASS-V3-PHY-CLOCKLANE-${{ github.run_number }}-BOOT-IMG
+          path: phase307-golden-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase307-GOLDEN-V3-PHY-CLOCKLANE-${{ github.run_number }}-FAILED
+          path: phase307-golden-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/301_apply_rpmh_rsc_contract_trace.py
+++ b/scripts/301_apply_rpmh_rsc_contract_trace.py
@@ -232,9 +232,9 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 {
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301I s=%u w=%u use=%u",
-\t\t\tbitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
-\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
-\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
 \ttcs_invalidate(drv, SLEEP_TCS);
 \ttcs_invalidate(drv, WAKE_TCS);
 }
@@ -254,8 +254,8 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d",
 \t\t\tmsg->state, tcs->type, tcs->num_tcs, tcs->offset,
-\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
-\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
+\t\t\t(unsigned int)bitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
 \t\t\tirqs_disabled());
 
 \tspin_lock_irq(&drv->lock);
@@ -265,11 +265,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
     old_claim = '''\ttcs->req[tcs_id - tcs->offset] = msg;
 \tset_bit(tcs_id, drv->tcs_in_use);
 '''
-    new_claim = '''\tif (a52_p301_disp_rsc(drv))
-\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
-\ttcs->req[tcs_id - tcs->offset] = msg;
-\tset_bit(tcs_id, drv->tcs_in_use);
-'''
+    new_claim = old_claim
     text = one(text, old_claim, new_claim, 'rsc send claim')
 
     old_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
@@ -278,7 +274,9 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \treturn 0;
 }
 '''
-    new_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+    new_trigger = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
+\t__tcs_buffer_write(drv, tcs_id, 0, msg);
 \t__tcs_set_trigger(drv, tcs_id, true);
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301R x id=%d ty=%d", tcs_id, tcs->type);
@@ -299,7 +297,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
     new_ctrl = '''\tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301C e st=%d ty=%d n=%d slots=%u",
 \t\t\tmsg->state, tcs->type, msg->num_cmds,
-\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t\t\t(unsigned int)bitmap_weight(tcs->slots, MAX_TCS_SLOTS));
 \t/* find the TCS id and the command in the TCS to write to */
 \tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
 \tif (!ret)
@@ -307,7 +305,7 @@ static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
 \tif (a52_p301_disp_rsc(drv))
 \t\ta52_ackfr_record("P276 301C x r=%d id=%d cmd=%d slots=%u",
 \t\t\tret, tcs_id, cmd_id,
-\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t\t\t(unsigned int)bitmap_weight(tcs->slots, MAX_TCS_SLOTS));
 
 \treturn ret;
 }

--- a/scripts/301_apply_rpmh_rsc_contract_trace.py
+++ b/scripts/301_apply_rpmh_rsc_contract_trace.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SDE = Path('drivers/a52_display/msm/sde_rsc.c')
+BUS = Path('drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c')
+RSC = Path('drivers/soc/qcom/rpmh-rsc.c')
+RPMH = Path('drivers/soc/qcom/rpmh.c')
+COMPAT = Path('a52-port-compat.h')
+REC = Path('drivers/a52_secure/a52_ack_secure_flight_recorder.c')
+MARK = 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1'
+REC_INCLUDE = '#include <linux/a52_ack_secure_flight_recorder.h>\n'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase301 {label}: expected exactly 1 anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def ensure_include(text: str, include: str, anchor: str, label: str) -> str:
+    if include in text:
+        return text
+    return one(text, anchor, anchor + include, f'{label} include')
+
+
+def behavior_counts(text: str) -> dict[str, int]:
+    tokens = (
+        'rpmh_mode_solver_set(', 'rpmh_flush(', 'rpmh_invalidate(',
+        'rpmh_write_batch(', 'rpmh_rsc_send_data(', 'rpmh_rsc_write_ctrl_data(',
+        'writel(', 'writel_relaxed(', 'write_tcs_reg(', 'write_tcs_reg_sync(',
+        '__tcs_buffer_write(', '__tcs_set_trigger(', 'msleep(', 'usleep_range(',
+        'udelay(', 'wait_event_lock_irq(',
+    )
+    return {t: text.count(t) for t in tokens}
+
+
+def patch_sde(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, REC_INCLUDE, '#include <linux/msm-bus.h>\n', 'sde recorder')
+    text = ensure_include(text, '#include <linux/irqflags.h>\n', REC_INCLUDE, 'sde irqflags')
+    text = one(
+        text,
+        REC_INCLUDE + '#include <linux/irqflags.h>\n',
+        REC_INCLUDE + '#include <linux/irqflags.h>\n\n'
+        '/* ' + MARK + '\n'
+        ' * Observation only: the inherited Phase13 macros still erase\n'
+        ' * rpmh_mode_solver_set and rpmh_flush. These markers record the\n'
+        ' * exact runtime points at which Golden would execute those contracts.\n'
+        ' */\n',
+        'sde marker',
+    )
+
+    transitions = [
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CMD_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CMD_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=1 irq=%d",\n'
+            '\t\t\tSDE_RSC_CMD_STATE, rc, irqs_disabled());\n',
+            'CMD state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CLK_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_CLK_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=0 irq=%d",\n'
+            '\t\t\tSDE_RSC_CLK_STATE, rc, irqs_disabled());\n',
+            'CLK state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_VID_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_VID_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=%d irq=%d",\n'
+            '\t\t\tSDE_RSC_VID_STATE, rc,\n'
+            '\t\t\trsc->version == SDE_RSC_REV_3, irqs_disabled());\n',
+            'VID state update',
+        ),
+        (
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_IDLE_STATE);\n',
+            '\t\trc = rsc->hw_ops.state_update(rsc, SDE_RSC_IDLE_STATE);\n'
+            '\t\ta52_ackfr_record("P276 301S t=%d r=%d en=1 irq=%d",\n'
+            '\t\t\tSDE_RSC_IDLE_STATE, rc, irqs_disabled());\n',
+            'IDLE state update',
+        ),
+    ]
+    for old, new, label in transitions:
+        text = one(text, old, new, label)
+
+    text = one(
+        text,
+        '\tif (delta_vote) {\n\t\tif (rsc->hw_ops.tcs_wait) {\n',
+        '\tif (delta_vote) {\n'
+        '\t\ta52_ackfr_record("P276 301V e cur=%d irq=%d",\n'
+        '\t\t\trsc->current_state, irqs_disabled());\n'
+        '\t\tif (rsc->hw_ops.tcs_wait) {\n',
+        'vote entry',
+    )
+    text = one(
+        text,
+        '\t\t\trc = rsc->hw_ops.tcs_wait(rsc);\n\t\t\tif (rc) {\n',
+        '\t\t\trc = rsc->hw_ops.tcs_wait(rsc);\n'
+        '\t\t\ta52_ackfr_record("P276 301V tw=%d", rc);\n'
+        '\t\t\tif (rc) {\n',
+        'tcs wait result',
+    )
+    text = one(
+        text,
+        '\t\trpmh_invalidate(rsc->rpmh_dev);\n',
+        '\t\ta52_ackfr_record("P276 301V inv dev=%s",\n'
+        '\t\t\tdev_name(rsc->rpmh_dev));\n'
+        '\t\trpmh_invalidate(rsc->rpmh_dev);\n',
+        'sde invalidate',
+    )
+    text = one(
+        text,
+        '\t\trpmh_flush(rsc->rpmh_dev);\n',
+        '\t\ta52_ackfr_record("P276 301F would dev=%s irq=%d",\n'
+        '\t\t\tdev_name(rsc->rpmh_dev), irqs_disabled());\n'
+        '\t\trpmh_flush(rsc->rpmh_dev);\n',
+        'sde flush call',
+    )
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 sde behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def patch_bus(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, REC_INCLUDE, '#include <soc/qcom/tcs.h>\n', 'bus recorder')
+    text = one(
+        text,
+        REC_INCLUDE,
+        REC_INCLUDE + '\n/* ' + MARK + ': Display-RSC bus votes, observation only. */\n',
+        'bus marker',
+    )
+
+    text = one(
+        text,
+        '\tif (!cnt_active)\n\t\tgoto exit_msm_bus_commit_data;\n',
+        '\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)\n'
+        '\t\ta52_ackfr_record("P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d",\n'
+        '\t\t\tcnt_active, cnt_wake, cnt_sleep, cnt_vcd,\n'
+        '\t\t\tcur_rsc->rscdev->req_state);\n\n'
+        '\tif (!cnt_active)\n\t\tgoto exit_msm_bus_commit_data;\n',
+        'bus entry counts',
+    )
+
+    text = one(
+        text,
+        '\t/* rpmh_invalidate() is void in the pinned GKI 5.10 RPMh API. */\n\trpmh_invalidate(cur_mbox);\n',
+        '\t/* rpmh_invalidate() is void in the pinned GKI 5.10 RPMh API. */\n'
+        '\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)\n'
+        '\t\ta52_ackfr_record("P276 301B inv mb=%s", dev_name(cur_mbox));\n'
+        '\trpmh_invalidate(cur_mbox);\n',
+        'bus invalidate',
+    )
+
+    active = '''\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP) {
+\t\tret = rpmh_write_batch(cur_mbox, cur_rsc->rscdev->req_state,
+\t\t\t\t\t\tcmdlist_active, n_active);
+'''
+    active_new = '''\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP) {
+\t\tret = rpmh_write_batch(cur_mbox, cur_rsc->rscdev->req_state,
+\t\t\t\t\t\tcmdlist_active, n_active);
+\t\ta52_ackfr_record("P276 301B A r=%d st=%d mb=%s",
+\t\t\tret, cur_rsc->rscdev->req_state, dev_name(cur_mbox));
+'''
+    text = one(text, active, active_new, 'display active batch')
+
+    wake = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_WAKE_ONLY_STATE,
+\t\t\t\t\t\t\tcmdlist_wake, n_wake);
+\t\tif (ret)
+'''
+    wake_new = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_WAKE_ONLY_STATE,
+\t\t\t\t\t\t\tcmdlist_wake, n_wake);
+\t\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)
+\t\t\ta52_ackfr_record("P276 301B W r=%d", ret);
+\t\tif (ret)
+'''
+    text = one(text, wake, wake_new, 'wake batch')
+
+    sleep = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_SLEEP_STATE,
+\t\t\t\t\t\t\tcmdlist_sleep, n_sleep);
+\t\tif (ret)
+'''
+    sleep_new = '''\t\tret = rpmh_write_batch(cur_mbox, RPMH_SLEEP_STATE,
+\t\t\t\t\t\t\tcmdlist_sleep, n_sleep);
+\t\tif (cur_rsc->node_info->id == MSM_BUS_RSC_DISP)
+\t\t\ta52_ackfr_record("P276 301B S r=%d", ret);
+\t\tif (ret)
+'''
+    text = one(text, sleep, sleep_new, 'sleep batch')
+
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 bus behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def patch_rsc(text: str) -> str:
+    if MARK in text:
+        return text
+    before = behavior_counts(text)
+    text = ensure_include(text, '#include <linux/string.h>\n', '#include <linux/spinlock.h>\n', 'rsc string')
+    text = ensure_include(text, REC_INCLUDE, '#include <dt-bindings/soc/qcom,rpmh-rsc.h>\n', 'rsc recorder')
+    anchor = '#include "trace-rpmh.h"\n'
+    helper = '''#include "trace-rpmh.h"
+
+/* A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1: observation only. */
+static bool a52_p301_disp_rsc(const struct rsc_drv *drv)
+{
+\treturn drv && drv->name && !strcmp(drv->name, "disp_rsc");
+}
+'''
+    text = one(text, anchor, helper, 'rsc helper')
+
+    old_inv = '''void rpmh_rsc_invalidate(struct rsc_drv *drv)
+{
+\ttcs_invalidate(drv, SLEEP_TCS);
+\ttcs_invalidate(drv, WAKE_TCS);
+}
+'''
+    new_inv = '''void rpmh_rsc_invalidate(struct rsc_drv *drv)
+{
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301I s=%u w=%u use=%u",
+\t\t\tbitmap_weight(drv->tcs[SLEEP_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR));
+\ttcs_invalidate(drv, SLEEP_TCS);
+\ttcs_invalidate(drv, WAKE_TCS);
+}
+'''
+    text = one(text, old_inv, new_inv, 'rsc invalidate trace')
+
+    old_send = '''\ttcs = get_tcs_for_msg(drv, msg);
+\tif (IS_ERR(tcs))
+\t\treturn PTR_ERR(tcs);
+
+\tspin_lock_irq(&drv->lock);
+'''
+    new_send = '''\ttcs = get_tcs_for_msg(drv, msg);
+\tif (IS_ERR(tcs))
+\t\treturn PTR_ERR(tcs);
+
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d",
+\t\t\tmsg->state, tcs->type, tcs->num_tcs, tcs->offset,
+\t\t\tbitmap_weight(drv->tcs_in_use, MAX_TCS_NR),
+\t\t\tbitmap_weight(drv->tcs[WAKE_TCS].slots, MAX_TCS_SLOTS),
+\t\t\tirqs_disabled());
+
+\tspin_lock_irq(&drv->lock);
+'''
+    text = one(text, old_send, new_send, 'rsc send entry')
+
+    old_claim = '''\ttcs->req[tcs_id - tcs->offset] = msg;
+\tset_bit(tcs_id, drv->tcs_in_use);
+'''
+    new_claim = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R c id=%d ty=%d", tcs_id, tcs->type);
+\ttcs->req[tcs_id - tcs->offset] = msg;
+\tset_bit(tcs_id, drv->tcs_in_use);
+'''
+    text = one(text, old_claim, new_claim, 'rsc send claim')
+
+    old_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+\t__tcs_set_trigger(drv, tcs_id, true);
+
+\treturn 0;
+}
+'''
+    new_trigger = '''\t__tcs_buffer_write(drv, tcs_id, 0, msg);
+\t__tcs_set_trigger(drv, tcs_id, true);
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301R x id=%d ty=%d", tcs_id, tcs->type);
+
+\treturn 0;
+}
+'''
+    text = one(text, old_trigger, new_trigger, 'rsc send exit')
+
+    old_ctrl = '''\t/* find the TCS id and the command in the TCS to write to */
+\tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
+\tif (!ret)
+\t\t__tcs_buffer_write(drv, tcs_id, cmd_id, msg);
+
+\treturn ret;
+}
+'''
+    new_ctrl = '''\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301C e st=%d ty=%d n=%d slots=%u",
+\t\t\tmsg->state, tcs->type, msg->num_cmds,
+\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+\t/* find the TCS id and the command in the TCS to write to */
+\tret = find_slots(tcs, msg, &tcs_id, &cmd_id);
+\tif (!ret)
+\t\t__tcs_buffer_write(drv, tcs_id, cmd_id, msg);
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301C x r=%d id=%d cmd=%d slots=%u",
+\t\t\tret, tcs_id, cmd_id,
+\t\t\tbitmap_weight(tcs->slots, MAX_TCS_SLOTS));
+
+\treturn ret;
+}
+'''
+    text = one(text, old_ctrl, new_ctrl, 'rsc ctrl trace')
+
+    old_solver = '''\tsolver_config = readl_relaxed(base + DRV_SOLVER_CONFIG);
+\tsolver_config &= DRV_HW_SOLVER_MASK << DRV_HW_SOLVER_SHIFT;
+\tsolver_config = solver_config >> DRV_HW_SOLVER_SHIFT;
+\tif (!solver_config) {
+'''
+    new_solver = '''\tsolver_config = readl_relaxed(base + DRV_SOLVER_CONFIG);
+\tsolver_config &= DRV_HW_SOLVER_MASK << DRV_HW_SOLVER_SHIFT;
+\tsolver_config = solver_config >> DRV_HW_SOLVER_SHIFT;
+\tif (a52_p301_disp_rsc(drv))
+\t\ta52_ackfr_record("P276 301P hw=%u a=%d sl=%d w=%d c=%d",
+\t\t\tsolver_config, drv->tcs[ACTIVE_TCS].num_tcs,
+\t\t\tdrv->tcs[SLEEP_TCS].num_tcs, drv->tcs[WAKE_TCS].num_tcs,
+\t\t\tdrv->tcs[CONTROL_TCS].num_tcs);
+\tif (!solver_config) {
+'''
+    text = one(text, old_solver, new_solver, 'rsc solver config')
+
+    after = behavior_counts(text)
+    if before != after:
+        raise SystemExit(f'Phase301 rsc behavior-token counts changed: {before} -> {after}')
+    return text
+
+
+def check(root: Path) -> dict:
+    for rel in (SDE, BUS, RSC, RPMH, COMPAT, REC):
+        if not (root / rel).is_file():
+            raise SystemExit(f'Phase301 missing {rel}')
+    sde = (root / SDE).read_text(errors='replace')
+    bus = (root / BUS).read_text(errors='replace')
+    rsc = (root / RSC).read_text(errors='replace')
+    compat = (root / COMPAT).read_text(errors='replace')
+    markers = [
+        'P276 301S t=%d r=%d en=1 irq=%d',
+        'P276 301V e cur=%d irq=%d',
+        'P276 301V tw=%d',
+        'P276 301F would dev=%s irq=%d',
+        'P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d',
+        'P276 301B A r=%d st=%d mb=%s',
+        'P276 301B W r=%d',
+        'P276 301B S r=%d',
+        'P276 301P hw=%u a=%d sl=%d w=%d c=%d',
+        'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+        'P276 301R c id=%d ty=%d',
+        'P276 301C e st=%d ty=%d n=%d slots=%u',
+        'P276 301I s=%u w=%u use=%u',
+    ]
+    joined = sde + bus + rsc
+    missing = [m for m in markers if m not in joined]
+    if missing:
+        raise SystemExit('Phase301 missing markers: ' + repr(missing))
+    required_compat = [
+        '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+        '#define rpmh_flush(d) do{}while(0)',
+        'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.',
+    ]
+    for token in required_compat:
+        if token not in compat:
+            raise SystemExit('Phase301 inherited Phase13 invariant missing: ' + token)
+    if '#undef rpmh_mode_solver_set' in joined or '#undef rpmh_flush' in joined:
+        raise SystemExit('Phase301 must not restore Phase13 RPMh behavior')
+    return {
+        'status': 'phase301-rpmh-rsc-contract-trace-v1-staged',
+        'functional_change': 'instrumentation-only',
+        'targets': [str(SDE), str(BUS), str(RSC)],
+        'protected_unchanged': [str(RPMH), str(COMPAT), str(REC)],
+        'phase13_solver_stub_preserved': True,
+        'phase13_flush_stub_preserved': True,
+        'marker_count': len(markers),
+        'hardware_question': (
+            'When SDE reaches its Golden solver/flush boundaries, does Phase296 send '
+            'Display-RSC ACTIVE votes through the borrowed WAKE TCS and leave WAKE/SLEEP '
+            'batches cached without the expected immediate flush?'
+        ),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--report', type=Path)
+    ap.add_argument('--check-only', action='store_true')
+    a = ap.parse_args()
+    root = a.root.resolve()
+    if not a.check_only:
+        for rel, fn in ((SDE, patch_sde), (BUS, patch_bus), (RSC, patch_rsc)):
+            p = root / rel
+            if not p.is_file():
+                raise SystemExit(f'Phase301 missing target {rel}')
+            p.write_text(fn(p.read_text(errors='replace')))
+    report = check(root)
+    if a.report:
+        a.report.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/301_ci_build.sh
+++ b/scripts/301_ci_build.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase301-out"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase301-failure
+  mkdir -p phase301-failure/{logs,audit,source}
+  cp phase301-compile.log phase301-failure/logs/ 2>/dev/null || true
+  cp phase301-patch-report.json phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-phase296.config phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-before.diff phase301-failure/audit/ 2>/dev/null || true
+  cp /tmp/p301-after.diff phase301-failure/audit/ 2>/dev/null || true
+  for f in "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase301-failure/source/ || true
+  done
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Exact hardware-observed Phase296 baseline. Phase301 is deliberately parallel
+# to Phase300 and inherits no DMA/GEM/SMMU experiment.
+bash scripts/296_ci_build.sh
+test -s phase296-out/package/boot.img
+test -s phase296-out/compile/Image
+test -s phase296-out/config/final.config
+test -s "$BUILD/arch/arm64/boot/Image"
+test "$(stat -c '%s' phase296-out/package/boot.img)" -eq 100663296
+
+for f in "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do test -s "$f"; done
+
+cp phase296-out/config/final.config /tmp/p301-phase296.config
+cp "$RPMH" /tmp/p301-rpmh-before.c
+cp "$COMPAT" /tmp/p301-compat-before.h
+cp "$REC" /tmp/p301-rec-before.c
+cp "$SDE" /tmp/p301-sde-before.c
+cp "$BUS" /tmp/p301-bus-before.c
+cp "$RSC" /tmp/p301-rsc-before.c
+
+git -C "$ROOT" diff --binary --no-ext-diff > /tmp/p301-before.diff
+
+# Prove the exact inherited Phase13 compile-only runtime shims are still active.
+grep -Fq 'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.' "$COMPAT"
+grep -Fq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+python3 -m py_compile scripts/301_apply_rpmh_rsc_contract_trace.py
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py \
+  --root "$ROOT" --report phase301-patch-report.json
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py \
+  --root "$ROOT" --check-only
+
+# Protected runtime implementation and recorder transport must be byte-identical.
+cmp -s /tmp/p301-rpmh-before.c "$RPMH"
+cmp -s /tmp/p301-compat-before.h "$COMPAT"
+cmp -s /tmp/p301-rec-before.c "$REC"
+
+# Scope gate: relative to the reconstructed Phase296 tree, this phase may only
+# touch the three observation targets.
+git -C "$ROOT" diff --binary --no-ext-diff > /tmp/p301-after.diff
+python3 - <<'PY'
+import subprocess
+from pathlib import Path
+root = Path('gki/common')
+allowed = {
+    'drivers/a52_display/msm/sde_rsc.c',
+    'drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c',
+    'drivers/soc/qcom/rpmh-rsc.c',
+}
+cp = subprocess.run(['git', '-C', str(root), 'diff', '--name-only'],
+                    text=True, stdout=subprocess.PIPE, check=True)
+changed = {x.strip() for x in cp.stdout.splitlines() if x.strip()}
+# The reconstructed Phase296 tree is itself generated and may already differ
+# from pristine common. Determine only the new files changed by comparing
+# before/after content snapshots of all candidate paths through explicit hashes.
+for rel in allowed:
+    if not (root / rel).is_file():
+        raise SystemExit('Phase301 missing allowed target: ' + rel)
+# Protected files are checked bytewise in shell. Here reject obvious Phase301
+# writes outside the three target paths by looking for our marker globally.
+marker = 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1'
+hits = []
+for p in root.rglob('*'):
+    if p.is_file() and '.git' not in p.parts:
+        try:
+            t = p.read_text(errors='ignore')
+        except OSError:
+            continue
+        if marker in t:
+            hits.append(p.relative_to(root).as_posix())
+if sorted(hits) != sorted(allowed):
+    raise SystemExit(f'Phase301 marker scope mismatch: {hits}')
+print('Phase301 marker scope:', ', '.join(sorted(hits)))
+PY
+
+# Preserve Phase296 configuration exactly.
+cp /tmp/p301-phase296.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase301-olddefconfig.log 2>&1
+cmp -s /tmp/p301-phase296.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase301-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$rc" > phase301-make-return-code.txt
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase301-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase301-compile.log "$OUT/audit/"
+cp phase301-olddefconfig.log "$OUT/audit/"
+cp phase301-make-return-code.txt "$OUT/audit/"
+cp phase301-patch-report.json "$OUT/audit/"
+cp scripts/301_apply_rpmh_rsc_contract_trace.py "$OUT/audit/"
+cp /tmp/p301-sde-before.c "$OUT/audit/sde_rsc-before.c"
+cp /tmp/p301-bus-before.c "$OUT/audit/msm_bus_fabric_rpmh-before.c"
+cp /tmp/p301-rsc-before.c "$OUT/audit/rpmh-rsc-before.c"
+cp /tmp/p301-rpmh-before.c "$OUT/audit/rpmh-before.c"
+cp /tmp/p301-compat-before.h "$OUT/audit/a52-port-compat-before.h"
+cp /tmp/p301-rec-before.c "$OUT/audit/recorder-before.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase296-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase301-out')
+image = (r/'compile/Image').read_bytes()
+source = ''.join((r/'source'/n).read_text(errors='replace') for n in (
+    'sde_rsc.c','msm_bus_fabric_rpmh.c','rpmh-rsc.c'))
+markers = [
+    'P276 301S t=%d r=%d en=1 irq=%d',
+    'P276 301V e cur=%d irq=%d',
+    'P276 301V tw=%d',
+    'P276 301V inv dev=%s',
+    'P276 301F would dev=%s irq=%d',
+    'P276 301B e ac=%d wk=%d sl=%d vcd=%d st=%d',
+    'P276 301B inv mb=%s',
+    'P276 301B A r=%d st=%d mb=%s',
+    'P276 301B W r=%d',
+    'P276 301B S r=%d',
+    'P276 301P hw=%u a=%d sl=%d w=%d c=%d',
+    'P276 301I s=%u w=%u use=%u',
+    'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d',
+    'P276 301R c id=%d ty=%d',
+    'P276 301R x id=%d ty=%d',
+    'P276 301C e st=%d ty=%d n=%d slots=%u',
+    'P276 301C x r=%d id=%d cmd=%d slots=%u',
+]
+for m in markers:
+    if m not in source:
+        raise SystemExit('Phase301 source marker missing: ' + m)
+    if m.encode() not in image:
+        raise SystemExit('Phase301 runtime marker missing from Image: ' + m)
+compat = (r/'source/a52-port-compat.h').read_text(errors='replace')
+for token in [
+    'A52_PHASE13_ALL_KNOWN_COMPAT_SHIMS: diagnostic, non-flashable.',
+    '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+    '#define rpmh_flush(d) do{}while(0)',
+]:
+    if token not in compat:
+        raise SystemExit('Phase301 Phase13 invariant missing: ' + token)
+if (r/'source/rpmh.c').read_bytes() != (r/'audit/rpmh-before.c').read_bytes():
+    raise SystemExit('Phase301 rpmh.c changed unexpectedly')
+if (r/'source/a52-port-compat.h').read_bytes() != (r/'audit/a52-port-compat-before.h').read_bytes():
+    raise SystemExit('Phase301 compatibility header changed unexpectedly')
+if (r/'source/a52_ack_secure_flight_recorder.c').read_bytes() != (r/'audit/recorder-before.c').read_bytes():
+    raise SystemExit('Phase301 recorder changed unexpectedly')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '301',
+    'name': 'RPMH-RSC-CONTRACT-TRACE-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase296 userspace DRM atomic frontier',
+    'hardware_validated': False,
+    'functional_change': 'instrumentation-only',
+    'solver_behavior_restored': False,
+    'flush_behavior_restored': False,
+    'phase13_solver_stub_preserved': True,
+    'phase13_flush_stub_preserved': True,
+    'protected_rpmh_core_unchanged': True,
+    'protected_compat_header_unchanged': True,
+    'protected_recorder_unchanged': True,
+    'display_rsc_expected_dt_tcs': {'active':0,'sleep':1,'wake':1,'control':0},
+    'markers': markers,
+    'hardware_questions': [
+        'Does disp_rsc report HW solver support?',
+        'When SDE would enable solver mode, does an ACTIVE display bus vote still succeed?',
+        'Does that ACTIVE_ONLY transfer select and claim the borrowed WAKE TCS?',
+        'After WAKE/SLEEP batches are cached and SDE reaches would-flush, is control-data programming absent at that boundary?',
+    ],
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256(image).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase301 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase301 RPMh/RSC observation audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase301 RPMh/RSC contract trace build/repack: PASS'

--- a/scripts/304_apply_exact_f05a5a_visibility.py
+++ b/scripts/304_apply_exact_f05a5a_visibility.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+MARK = 'A52_PHASE304_EXACT_F05A5A_VISIBILITY_V1'
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase304 {label}: expected exactly one match, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' not in text:
+        raise SystemExit('Phase304 requires inherited Phase293 GDM controller trace')
+    if 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' not in text:
+        raise SystemExit('Phase304 requires inherited Phase280 timeout retention latch')
+
+    marker_anchor = '/* A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1\n'
+    marker_text = (
+        '/* ' + MARK + '\n'
+        ' * Correlation-only continuation of the hardware-validated Phase303\n'
+        ' * visibility fix. Re-emit the inherited passive GDM snapshots through\n'
+        ' * the admitted P276 namespace and arm only for payload F0 5A 5A.\n'
+        ' * No DSI write, command flag, wait, timeout, recovery, clock, panel,\n'
+        ' * DMA/GEM/SMMU or RPMh behavior is changed.\n'
+        ' */\n'
+    )
+    text = replace_once(text, marker_anchor, marker_text + marker_anchor,
+                        'marker insertion')
+
+    old_scope = '''\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n\tp = msg->tx_buf;\n'''
+    new_scope = '''\tif (!dsi_ctrl || !msg || !flags || dsi_ctrl->cell_index != 0 ||\n\t    *flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||\n\t    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)\n\t\treturn;\n\tp = msg->tx_buf;\n\tif (p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A)\n\t\treturn;\n\tif (atomic_cmpxchg(&a52_p293_gdm_state, 0, 1) != 0)\n\t\treturn;\n'''
+    text = replace_once(text, old_scope, new_scope, 'exact payload scope')
+
+    text = text.replace('"GDM ', '"P276 303 ')
+    return text
+
+
+def patch_hw(text: str) -> str:
+    if 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' not in text:
+        raise SystemExit('Phase304 requires inherited Phase293 GDM HW trace')
+    return text.replace('"GDM ', '"P276 303 ')
+
+
+def validate(ctrl: str, hw: str) -> None:
+    combined = ctrl + hw
+    required = [
+        MARK,
+        'p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A',
+        'P276 303 S00 c=0 in=%x mf=%x t=%x l=%u',
+        'P276 303 S00p p=%02x%02x%02x',
+        'P276 303 S03 irq=%d in=%x st=%x',
+        'P276 303 S04 irq=%d in=%x st=%x',
+        'P276 303 S05 dc=%x off=%x len=%x fc=%x',
+        'P276 303 S06 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 S07 seen=1 st=%x in=%x irq0=%d',
+        'P276 303 S08 ret=%d irq=%d in=%x st=%x',
+        'P276 303 S09 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 DONE success=0 target=0/8/20/29/3',
+        'P276 280Z q=2',
+    ]
+    for token in required:
+        if token not in combined:
+            raise SystemExit('Phase304 required DSI token missing: ' + token)
+    if 'a52_ackfr_record("GDM ' in combined:
+        raise SystemExit('Phase304 still contains recorder-rejected GDM runtime records')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    cp = args.root / CTRL
+    hp = args.root / HW
+    if not cp.is_file() or not hp.is_file():
+        raise SystemExit('Phase304 DSI source files missing')
+
+    ctrl = cp.read_text()
+    hw = hp.read_text()
+    if not args.check_only:
+        cp.write_text(patch_ctrl(ctrl))
+        hp.write_text(patch_hw(hw))
+
+    validate(cp.read_text(), hp.read_text())
+    print('Phase304 exact F0 5A 5A visibility: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/304_ci_build.sh
+++ b/scripts/304_ci_build.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase304-out"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase304-failure
+  mkdir -p phase304-failure/{logs,audit,source}
+  cp phase304-compile.log phase304-olddefconfig.log phase304-failure/logs/ 2>/dev/null || true
+  for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase304-failure/source/ || true
+  done
+  cp /tmp/p304-* phase304-failure/audit/ 2>/dev/null || true
+  cp scripts/304_apply_exact_f05a5a_visibility.py phase304-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Build the already-audited Phase301 observer first. Phase301 itself reconstructs
+# the exact Phase296 physical-phone lineage and changes only SDE RSC, display
+# msm_bus and disp_rsc observation sites. Phase304 then adds only the exact
+# Phase303 F0 5A 5A persistent-visibility formatting to the inherited DSI trace.
+bash scripts/301_ci_build.sh
+
+test -s phase301-out/package/boot.img
+test -s phase301-out/compile/Image
+test -s phase301-out/config/final.config
+test "$(stat -c '%s' phase301-out/package/boot.img)" -eq 100663296
+for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do test -s "$f"; done
+
+# Confirm Phase301 is really present and the Phase13 behavior erasures remain.
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$SDE"
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$BUS"
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$RSC"
+grep -Fq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+# Confirm the clean inherited DSI reference and retention path are present.
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_REFERENCE_V1' "$CTRL"
+grep -Fq 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' "$HW"
+grep -Fq 'A52_PHASE280_TIMEOUT_RETENTION_LATCH_V1' "$CTRL"
+grep -Fq 'P276 280Z q=2' "$CTRL"
+
+cp phase301-out/config/final.config /tmp/p304-phase301.config
+cp "$CTRL" /tmp/p304-ctrl-before.c
+cp "$HW" /tmp/p304-hw-before.c
+cp "$SDE" /tmp/p304-sde-before.c
+cp "$BUS" /tmp/p304-bus-before.c
+cp "$RSC" /tmp/p304-rsc-before.c
+cp "$RPMH" /tmp/p304-rpmh-before.c
+cp "$COMPAT" /tmp/p304-compat-before.h
+cp "$REC" /tmp/p304-rec-before.c
+
+python3 -m py_compile scripts/304_apply_exact_f05a5a_visibility.py
+python3 scripts/304_apply_exact_f05a5a_visibility.py --root "$ROOT"
+python3 scripts/304_apply_exact_f05a5a_visibility.py --root "$ROOT" --check-only
+
+# Phase304 must not touch the Phase301 observer, RPMh core, compatibility ABI or
+# recorder transport. Only the inherited Phase293 DSI recorder formatting/scope
+# is changed in this second step.
+cmp -s /tmp/p304-sde-before.c "$SDE"
+cmp -s /tmp/p304-bus-before.c "$BUS"
+cmp -s /tmp/p304-rsc-before.c "$RSC"
+cmp -s /tmp/p304-rpmh-before.c "$RPMH"
+cmp -s /tmp/p304-compat-before.h "$COMPAT"
+cmp -s /tmp/p304-rec-before.c "$REC"
+! cmp -s /tmp/p304-ctrl-before.c "$CTRL"
+! cmp -s /tmp/p304-hw-before.c "$HW"
+
+# Prove the DSI visibility patch adds no behavior-changing primitive.
+python3 - <<'PY'
+from pathlib import Path
+pairs = [
+    (Path('/tmp/p304-ctrl-before.c'), Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl.c')),
+    (Path('/tmp/p304-hw-before.c'), Path('gki/common/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')),
+]
+tokens = [
+    'DSI_W32(', 'writel(', 'writel_relaxed(', 'clk_set_rate(',
+    'wait_for_completion_timeout(', 'msleep(', 'usleep_range(',
+    'DSI_CTRL_CMD_FIFO_STORE', 'rpmh_mode_solver_set(', 'rpmh_flush(',
+]
+for before, after in pairs:
+    b = before.read_text()
+    a = after.read_text()
+    for token in tokens:
+        if b.count(token) != a.count(token):
+            raise SystemExit(
+                f'Phase304 behavior primitive count changed: {after} {token} '
+                f'{b.count(token)}->{a.count(token)}')
+print('Phase304 DSI behavior primitive audit: PASS')
+PY
+
+# Preserve Phase301/Phase296 configuration byte-for-byte.
+cp /tmp/p304-phase301.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase304-olddefconfig.log 2>&1
+cmp -s /tmp/p304-phase301.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase304-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase304-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+# Require both observer families in the final kernel image.
+for marker in \
+  'P276 301S t=%d r=%d en=1 irq=%d' \
+  'P276 301V e cur=%d irq=%d' \
+  'P276 301F would dev=%s irq=%d' \
+  'P276 301B A r=%d st=%d mb=%s' \
+  'P276 301R e st=%d ty=%d n=%d off=%d use=%u ws=%u irq=%d' \
+  'P276 301R x id=%d ty=%d' \
+  'P276 301I s=%u w=%u use=%u' \
+  'P276 303 S00 c=0 in=%x mf=%x t=%x l=%u' \
+  'P276 303 S00p p=%02x%02x%02x' \
+  'P276 303 S03 irq=%d in=%x st=%x' \
+  'P276 303 S04 irq=%d in=%x st=%x' \
+  'P276 303 S05 dc=%x off=%x len=%x fc=%x' \
+  'P276 303 S06 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 S07 seen=1 st=%x in=%x irq0=%d' \
+  'P276 303 S08 ret=%d irq=%d in=%x st=%x' \
+  'P276 303 S09 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 DONE success=0 target=0/8/20/29/3' \
+  'P276 280Z q=2'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase304-compile.log phase304-olddefconfig.log "$OUT/audit/"
+cp scripts/301_apply_rpmh_rsc_contract_trace.py "$OUT/audit/"
+cp scripts/304_apply_exact_f05a5a_visibility.py "$OUT/audit/"
+for f in /tmp/p304-*; do [ -f "$f" ] && cp "$f" "$OUT/audit/"; done
+cp "$CTRL" "$OUT/source/dsi_ctrl.c"
+cp "$HW" "$OUT/source/dsi_ctrl_hw_cmn.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase301-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase304-out')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '304',
+    'name': 'RPMH-RSC-F05A5A-CORRELATION-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'exact Phase296 reconstruction plus Phase301 observation-only RPMh/RSC trace',
+    'hardware_validated': False,
+    'functional_change': 'instrumentation-only',
+    'phase13_solver_stub_preserved': True,
+    'phase13_flush_stub_preserved': True,
+    'solver_behavior_restored': False,
+    'flush_behavior_restored': False,
+    'dsi_control_flow_change': False,
+    'wait_or_timeout_change': False,
+    'fifo_reroute': False,
+    'clock_recovery': False,
+    'recorder_transport_change': False,
+    'phase303_hardware_capture': 'A52_RAW_RAMOOPS_20260823_123924.zip',
+    'phase303_hardware_result': [
+        'exact F0 5A 5A normal FETCH_MEMORY transaction reached',
+        'Golden-compatible IRQ arm state observed before kickoff',
+        'after trigger STATUS became 3 but raw DMA_DONE remained zero',
+        'no Phase303 S07 DMA_DONE ISR record was emitted',
+        'completion timed out after about 200 ms with irq=0',
+        'IOVA translation/root and SMMU global fault state remained stable through timeout',
+    ],
+    'hardware_question': (
+        'During the same real F0 5A 5A transaction that fails to assert DMA_DONE, '
+        'does the Phase13-erased display RPMh solver/flush contract produce an '
+        'observable ACTIVE-vote / borrowed-WAKE-TCS / missing-flush runtime divergence?'
+    ),
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256((r/'compile/Image').read_bytes()).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase304 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase304 combined observation audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/301_apply_rpmh_rsc_contract_trace.py --root "$ROOT" --check-only
+python3 scripts/304_apply_exact_f05a5a_visibility.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase304 RPMh/RSC + exact F0 5A 5A correlation build/repack: PASS'

--- a/scripts/305_apply_display_rpmh_flush_compat.py
+++ b/scripts/305_apply_display_rpmh_flush_compat.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+RSC = Path('drivers/soc/qcom/rpmh-rsc.c')
+COMPAT = Path('a52-port-compat.h')
+MARK = 'A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1'
+
+
+def one(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f'Phase305 {label}: expected exactly 1 anchor, found {count}')
+    return text.replace(old, new, 1)
+
+
+def patch_rsc(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' not in text:
+        raise SystemExit('Phase305 requires inherited Phase301 RPMh/RSC observer')
+    if 'P276 301I s=%u w=%u use=%u' not in text:
+        raise SystemExit('Phase305 requires inherited low-level invalidate observer')
+
+    text = one(
+        text,
+        '#include <linux/interrupt.h>\n',
+        '#include <linux/interrupt.h>\n#include <linux/irqflags.h>\n',
+        'irqflags include',
+    )
+
+    anchor = '''static bool rpmh_rsc_ctrlr_is_busy(struct rsc_drv *drv)\n{\n\tint m;\n\tstruct tcs_group *tcs = &drv->tcs[ACTIVE_TCS];\n\n\t/*\n\t * If we made an active request on a RSC that does not have a\n\t * dedicated TCS for active state use, then re-purposed wake TCSes\n\t * should be checked for not busy, because we used wake TCSes for\n\t * active requests in this case.\n\t */\n\tif (!tcs->num_tcs)\n\t\ttcs = &drv->tcs[WAKE_TCS];\n\n\tfor (m = tcs->offset; m < tcs->offset + tcs->num_tcs; m++) {\n\t\tif (!tcs_is_free(drv, m))\n\t\t\treturn true;\n\t}\n\n\treturn false;\n}\n'''
+
+    wrapper = anchor + '''\n/*\n * A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1\n *\n * Samsung 4.19 SDE calls rpmh_flush(struct device *), but the pinned 5.10\n * core owns rpmh_flush(struct rpmh_ctrlr *). Phase13 erased the SDE call.\n * Hardware Phase304 proved that the erased call is reached immediately\n * before the exact F0 5A 5A DSI DMA timeout. Bridge only that legacy display\n * call to the native 5.10 flush contract. Solver-mode behavior remains\n * untouched in this phase.\n *\n * Match the native 5.10 CPU-PM exclusion contract: disable local IRQs,\n * try drv->lock, reject while an ACTIVE transfer is in flight, then call\n * native rpmh_flush(), whose cache_lock nests inside drv->lock.\n */\nint a52_rpmh_flush_compat(const struct device *dev)\n{\n\tstruct rsc_drv *drv;\n\tunsigned long irq_flags;\n\tbool locked = false, busy = false;\n\tint ret;\n\n\ta52_ackfr_record("P276 305F e");\n\n\tif (!dev || !dev->parent) {\n\t\tret = -EINVAL;\n\t\tgoto out_record;\n\t}\n\n\tdrv = dev_get_drvdata(dev->parent);\n\tif (!drv) {\n\t\tret = -ENODEV;\n\t\tgoto out_record;\n\t}\n\n\tlocal_irq_save(irq_flags);\n\tif (!spin_trylock(&drv->lock)) {\n\t\tret = -EBUSY;\n\t\tgoto out_irq;\n\t}\n\tlocked = true;\n\n\tbusy = rpmh_rsc_ctrlr_is_busy(drv);\n\tif (busy)\n\t\tret = -EBUSY;\n\telse\n\t\tret = rpmh_flush(&drv->client);\n\n\tspin_unlock(&drv->lock);\nout_irq:\n\tlocal_irq_restore(irq_flags);\nout_record:\n\ta52_ackfr_record("P276 305F x r=%d l=%u b=%u", ret, locked, busy);\n\treturn ret;\n}\n'''
+    return one(text, anchor, wrapper, 'compat wrapper insertion')
+
+
+def patch_compat(text: str) -> str:
+    if MARK in text:
+        return text
+    old = '#define rpmh_mode_solver_set(d,e) do{}while(0)\n#define rpmh_flush(d) do{}while(0)\n'
+    new = '''#define rpmh_mode_solver_set(d,e) do{}while(0)\n/* A52_PHASE305_DISPLAY_RPMH_FLUSH_COMPAT_V1: flush-only causal repair. */\nint a52_rpmh_flush_compat(const struct device *dev);\n#define rpmh_flush(d) a52_rpmh_flush_compat((d))\n'''
+    return one(text, old, new, 'Phase13 flush stub replacement')
+
+
+def validate(rsc: str, compat: str) -> None:
+    joined = rsc + compat
+    required = [
+        MARK,
+        'int a52_rpmh_flush_compat(const struct device *dev)',
+        'local_irq_save(irq_flags);',
+        'spin_trylock(&drv->lock)',
+        'rpmh_rsc_ctrlr_is_busy(drv)',
+        'rpmh_flush(&drv->client)',
+        'local_irq_restore(irq_flags);',
+        'P276 305F e',
+        'P276 305F x r=%d l=%u b=%u',
+        '#define rpmh_mode_solver_set(d,e) do{}while(0)',
+        '#define rpmh_flush(d) a52_rpmh_flush_compat((d))',
+        'P276 301I s=%u w=%u use=%u',
+    ]
+    for token in required:
+        if token not in joined:
+            raise SystemExit('Phase305 required token missing: ' + token)
+    if '#define rpmh_flush(d) do{}while(0)' in compat:
+        raise SystemExit('Phase305 legacy flush erasure still present')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    rp = args.root / RSC
+    cp = args.root / COMPAT
+    if not rp.is_file() or not cp.is_file():
+        raise SystemExit('Phase305 required source files missing')
+
+    if not args.check_only:
+        rp.write_text(patch_rsc(rp.read_text()))
+        cp.write_text(patch_compat(cp.read_text()))
+
+    validate(rp.read_text(), cp.read_text())
+    print('Phase305 display RPMh flush compatibility repair: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/305_ci_build.sh
+++ b/scripts/305_ci_build.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase305-out"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+SDE="$ROOT/drivers/a52_display/msm/sde_rsc.c"
+BUS="$ROOT/drivers/soc/qcom/msm_bus/msm_bus_fabric_rpmh.c"
+RSC="$ROOT/drivers/soc/qcom/rpmh-rsc.c"
+RPMH="$ROOT/drivers/soc/qcom/rpmh.c"
+COMPAT="$ROOT/a52-port-compat.h"
+REC="$ROOT/drivers/a52_secure/a52_ack_secure_flight_recorder.c"
+
+fail_report() {
+  set +e
+  rm -rf phase305-failure
+  mkdir -p phase305-failure/{logs,audit,source}
+  cp phase305-compile.log phase305-olddefconfig.log phase305-failure/logs/ 2>/dev/null || true
+  for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do
+    [ -f "$f" ] && cp "$f" phase305-failure/source/ || true
+  done
+  cp /tmp/p305-* phase305-failure/audit/ 2>/dev/null || true
+  cp scripts/305_apply_display_rpmh_flush_compat.py phase305-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact hardware-validated Phase304 observer lineage first.
+bash scripts/304_ci_build.sh
+
+test -s phase304-out/package/boot.img
+test -s phase304-out/compile/Image
+test -s phase304-out/config/final.config
+test "$(stat -c '%s' phase304-out/package/boot.img)" -eq 100663296
+for f in "$CTRL" "$HW" "$SDE" "$BUS" "$RSC" "$RPMH" "$COMPAT" "$REC"; do test -s "$f"; done
+
+# Phase304 hardware evidence requires these observers and the original erasure.
+grep -Fq 'A52_PHASE301_RPMH_RSC_CONTRACT_TRACE_V1' "$RSC"
+grep -Fq 'A52_PHASE304_EXACT_F05A5A_VISIBILITY_V1' "$CTRL"
+grep -Fq 'P276 303 S00p p=%02x%02x%02x' "$CTRL"
+grep -Fq 'P276 280Z q=2' "$CTRL"
+grep -Fxq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fxq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+# Lock the exact native 5.10 flush implementation used by the compatibility bridge.
+grep -Fq 'int rpmh_flush(struct rpmh_ctrlr *ctrlr)' "$RPMH"
+grep -Fq 'lockdep_assert_irqs_disabled();' "$RPMH"
+grep -Fq 'if (!spin_trylock(&ctrlr->cache_lock))' "$RPMH"
+grep -Fq 'rpmh_rsc_invalidate(ctrlr_to_drv(ctrlr));' "$RPMH"
+grep -Fq 'ctrlr->dirty = false;' "$RPMH"
+
+cp phase304-out/config/final.config /tmp/p305-phase304.config
+cp "$CTRL" /tmp/p305-ctrl-before.c
+cp "$HW" /tmp/p305-hw-before.c
+cp "$SDE" /tmp/p305-sde-before.c
+cp "$BUS" /tmp/p305-bus-before.c
+cp "$RSC" /tmp/p305-rsc-before.c
+cp "$RPMH" /tmp/p305-rpmh-before.c
+cp "$COMPAT" /tmp/p305-compat-before.h
+cp "$REC" /tmp/p305-rec-before.c
+
+python3 -m py_compile scripts/305_apply_display_rpmh_flush_compat.py
+python3 scripts/305_apply_display_rpmh_flush_compat.py --root "$ROOT"
+python3 scripts/305_apply_display_rpmh_flush_compat.py --root "$ROOT" --check-only
+
+# Flush-only scope: DSI, SDE, bus logic, native rpmh.c and recorder remain exact.
+cmp -s /tmp/p305-ctrl-before.c "$CTRL"
+cmp -s /tmp/p305-hw-before.c "$HW"
+cmp -s /tmp/p305-sde-before.c "$SDE"
+cmp -s /tmp/p305-bus-before.c "$BUS"
+cmp -s /tmp/p305-rpmh-before.c "$RPMH"
+cmp -s /tmp/p305-rec-before.c "$REC"
+! cmp -s /tmp/p305-rsc-before.c "$RSC"
+! cmp -s /tmp/p305-compat-before.h "$COMPAT"
+
+# Solver remains intentionally erased. Only the legacy display flush stub changes.
+grep -Fxq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fxq '#define rpmh_flush(d) a52_rpmh_flush_compat((d))' "$COMPAT"
+! grep -Fq '#define rpmh_flush(d) do{}while(0)' "$COMPAT"
+
+# Audit the actual intended behavior change and reject unrelated primitives.
+python3 - <<'PY'
+from pathlib import Path
+r0 = Path('/tmp/p305-rsc-before.c').read_text()
+r1 = Path('gki/common/drivers/soc/qcom/rpmh-rsc.c').read_text()
+c0 = Path('/tmp/p305-compat-before.h').read_text()
+c1 = Path('gki/common/a52-port-compat.h').read_text()
+
+expected_rsc_delta = {
+    'local_irq_save(': 1,
+    'local_irq_restore(': 1,
+    'spin_trylock(&drv->lock)': 1,
+    'rpmh_rsc_ctrlr_is_busy(drv)': 1,
+    'rpmh_flush(&drv->client)': 1,
+}
+for token, delta in expected_rsc_delta.items():
+    got = r1.count(token) - r0.count(token)
+    if got != delta:
+        raise SystemExit(f'Phase305 intended RSC delta mismatch {token}: {got} != {delta}')
+
+for token in [
+    'write_tcs_reg(', 'write_tcs_reg_sync(', 'write_tcs_cmd(',
+    '__tcs_buffer_write(', '__tcs_set_trigger(', 'wait_event_lock_irq(',
+    'msleep(', 'usleep_range(', 'udelay(',
+]:
+    if r1.count(token) != r0.count(token):
+        raise SystemExit(f'Phase305 unexpected low-level RSC primitive drift: {token}')
+
+if c0.count('#define rpmh_flush(d) do{}while(0)') != 1:
+    raise SystemExit('Phase305 baseline flush-erasure count changed')
+if c1.count('#define rpmh_flush(d) a52_rpmh_flush_compat((d))') != 1:
+    raise SystemExit('Phase305 compatibility macro missing')
+if c0.count('#define rpmh_mode_solver_set(d,e) do{}while(0)') != c1.count('#define rpmh_mode_solver_set(d,e) do{}while(0)'):
+    raise SystemExit('Phase305 solver-erasure behavior changed unexpectedly')
+print('Phase305 flush-only behavior delta audit: PASS')
+PY
+
+# Preserve Phase304/Phase296 configuration byte-for-byte.
+cp /tmp/p305-phase304.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase305-olddefconfig.log 2>&1
+cmp -s /tmp/p305-phase304.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase305-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase305-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+
+# Require repair evidence plus the exact hardware frontier observers in final Image.
+for marker in \
+  'P276 305F e' \
+  'P276 305F x r=%d l=%u b=%u' \
+  'P276 301I s=%u w=%u use=%u' \
+  'P276 301C e st=%d ty=%d n=%d slots=%u' \
+  'P276 301F would dev=%s irq=%d' \
+  'P276 303 S00p p=%02x%02x%02x' \
+  'P276 303 S06 st=%x fs=%x ln=%x ck=%x' \
+  'P276 303 S07 seen=1 st=%x in=%x irq0=%d' \
+  'P276 303 S08 ret=%d irq=%d in=%x st=%x' \
+  'P276 280Z q=2'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+# Make sure the new bridge linked into the final kernel.
+if [ -f "$BUILD/vmlinux" ]; then
+  nm "$BUILD/vmlinux" | grep -Eq ' [Tt] a52_rpmh_flush_compat$'
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase305-compile.log phase305-olddefconfig.log "$OUT/audit/"
+cp scripts/305_apply_display_rpmh_flush_compat.py "$OUT/audit/"
+for f in /tmp/p305-*; do [ -f "$f" ] && cp "$f" "$OUT/audit/"; done
+cp "$CTRL" "$OUT/source/dsi_ctrl.c"
+cp "$HW" "$OUT/source/dsi_ctrl_hw_cmn.c"
+cp "$SDE" "$OUT/source/sde_rsc.c"
+cp "$BUS" "$OUT/source/msm_bus_fabric_rpmh.c"
+cp "$RSC" "$OUT/source/rpmh-rsc.c"
+cp "$RPMH" "$OUT/source/rpmh.c"
+cp "$COMPAT" "$OUT/source/a52-port-compat.h"
+cp "$REC" "$OUT/source/a52_ack_secure_flight_recorder.c"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase304-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase305-out')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+    'phase': '305',
+    'name': 'DISPLAY-RPMH-FLUSH-COMPAT-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'base': 'hardware-validated Phase304 observer lineage',
+    'hardware_validated': False,
+    'functional_change': 'display-scoped legacy rpmh_flush compatibility bridge only',
+    'phase304_hardware_capture': 'A52_RAW_RAMOOPS_20260823_134725.zip',
+    'phase304_result': [
+        'display ACTIVE_ONLY traffic selected borrowed WAKE_TCS and completed successfully',
+        'SDE reached the Golden would-flush boundary',
+        'no low-level 301I invalidate or 301C control-data programming followed before DSI',
+        'exact F0 5A 5A then entered DSI STATUS=3 without DMA_DONE and timed out',
+    ],
+    'solver_stub_preserved': True,
+    'solver_behavior_restored': False,
+    'flush_stub_replaced': True,
+    'native_rpmh_core_changed': False,
+    'dsi_control_flow_changed': False,
+    'smmu_or_gem_changed': False,
+    'wait_or_timeout_changed': False,
+    'repair_contract': 'local IRQ disable -> try drv lock -> reject busy ACTIVE TCS -> native 5.10 rpmh_flush(ctrlr)',
+    'hardware_question': 'Does restoring only the missing display rpmh_flush contract make exact F0 5A 5A assert DSI DMA_DONE?',
+    'boot_bytes': (r/'package/boot.img').stat().st_size,
+    'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+    'image_sha256': hashlib.sha256((r/'compile/Image').read_bytes()).hexdigest(),
+    'dtb_preserved': repack['invariants']['dtb_preserved'],
+    'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+    'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+for key in ('dtb_preserved','ramdisk_preserved','recovery_dtbo_preserved'):
+    if not identity[key]:
+        raise SystemExit('Phase305 repack invariant failed: ' + key)
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files = [p for p in r.rglob('*') if p.is_file() and p.name != 'SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+    for p in sorted(files):
+        f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+print('Phase305 flush-only repair audit: PASS')
+PY
+
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+python3 scripts/305_apply_display_rpmh_flush_compat.py --root "$ROOT" --check-only
+trap - EXIT
+echo 'Phase305 display RPMh flush compatibility build/repack: PASS'

--- a/scripts/307_apply_v3_phy_clocklane_correlation.py
+++ b/scripts/307_apply_v3_phy_clocklane_correlation.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('drivers/a52_display/msm/dsi/dsi_ctrl.c')
+HW = Path('drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c')
+PHY = Path('drivers/a52_display/msm/dsi/dsi_phy.c')
+MARK = 'A52_PHASE307_V3_PHY_CLOCKLANE_CORRELATION_V1'
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase307 {label}: expected exactly one match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_phy(text: str) -> str:
+    if MARK in text:
+        return text
+
+    text = replace_once(
+        text,
+        '#include "dsi_phy.h"\n',
+        '#include "dsi_phy.h"\n#include <linux/a52_ack_secure_flight_recorder.h>\n',
+        'PHY recorder include')
+
+    anchor = 'static DEFINE_MUTEX(dsi_phy_list_lock);\n'
+    helper = r'''static DEFINE_MUTEX(dsi_phy_list_lock);
+
+/* A52_PHASE307_V3_PHY_CLOCKLANE_CORRELATION_V1
+ * Read-only snapshot of the actual A52 DSI_PHY_VERSION_3_0 (10-nm) common
+ * block. Offsets are the exact v3.0 offsets already validated in Phase284.
+ * The helper is called only for the exact ctrl0 F0 5A 5A transaction.
+ * No MMIO write, delay, reset, clock vote, regulator vote or PHY state change.
+ */
+#define A52_P307_V3_CLK_CFG0        0x010
+#define A52_P307_V3_CLK_CFG1        0x014
+#define A52_P307_V3_GLBL_CTRL       0x018
+#define A52_P307_V3_RBUF_CTRL       0x01c
+#define A52_P307_V3_VREG_CTRL       0x020
+#define A52_P307_V3_CTRL0           0x024
+#define A52_P307_V3_CTRL1           0x028
+#define A52_P307_V3_CTRL2           0x02c
+#define A52_P307_V3_LANE_CFG0       0x030
+#define A52_P307_V3_LANE_CFG1       0x034
+#define A52_P307_V3_PLL_CTRL        0x038
+#define A52_P307_V3_LANE_CTRL0      0x098
+#define A52_P307_V3_LANE_CTRL1      0x09c
+#define A52_P307_V3_LANE_CTRL2      0x0a0
+#define A52_P307_V3_LANE_CTRL3      0x0a4
+#define A52_P307_V3_LANE_CTRL4      0x0a8
+#define A52_P307_V3_STATUS          0x0ec
+#define A52_P307_V3_LANE_STATUS0    0x0f4
+#define A52_P307_V3_LANE_STATUS1    0x0f8
+
+void a52_p307_phy_snapshot(unsigned int index, unsigned int point)
+{
+	struct dsi_phy_list_item *item;
+	struct msm_dsi_phy *phy = NULL;
+	void __iomem *base;
+	u32 ver;
+
+	mutex_lock(&dsi_phy_list_lock);
+	list_for_each_entry(item, &dsi_phy_list, list) {
+		if (item->phy && item->phy->index == index) {
+			phy = item->phy;
+			break;
+		}
+	}
+	mutex_unlock(&dsi_phy_list_lock);
+
+	if (!phy || !phy->ver_info || !phy->hw.base) {
+		a52_ackfr_record("P276 307PX q=%u i=%u x=0", point, index);
+		return;
+	}
+
+	ver = phy->ver_info->version;
+	if (ver != DSI_PHY_VERSION_3_0) {
+		a52_ackfr_record("P276 307PX q=%u i=%u v=%u", point, index, ver);
+		return;
+	}
+
+	base = phy->hw.base;
+	a52_ackfr_record("P276 307P0 q=%u v=%u p=%u s=%u %x %x %x %x", point,
+		ver, phy->power_state, phy->dsi_phy_state,
+		readl_relaxed(base + A52_P307_V3_PLL_CTRL),
+		readl_relaxed(base + A52_P307_V3_STATUS),
+		readl_relaxed(base + A52_P307_V3_LANE_STATUS0),
+		readl_relaxed(base + A52_P307_V3_LANE_STATUS1));
+	a52_ackfr_record("P276 307P1 q=%u %x %x %x %x %x %x", point,
+		readl_relaxed(base + A52_P307_V3_CLK_CFG0),
+		readl_relaxed(base + A52_P307_V3_CLK_CFG1),
+		readl_relaxed(base + A52_P307_V3_GLBL_CTRL),
+		readl_relaxed(base + A52_P307_V3_RBUF_CTRL),
+		readl_relaxed(base + A52_P307_V3_VREG_CTRL),
+		readl_relaxed(base + A52_P307_V3_CTRL0));
+	a52_ackfr_record("P276 307P2 q=%u %x %x %x %x %x %x", point,
+		readl_relaxed(base + A52_P307_V3_CTRL1),
+		readl_relaxed(base + A52_P307_V3_CTRL2),
+		readl_relaxed(base + A52_P307_V3_LANE_CFG0),
+		readl_relaxed(base + A52_P307_V3_LANE_CFG1),
+		readl_relaxed(base + A52_P307_V3_LANE_CTRL0),
+		readl_relaxed(base + A52_P307_V3_LANE_CTRL1));
+	a52_ackfr_record("P276 307P3 q=%u %x %x %x", point,
+		readl_relaxed(base + A52_P307_V3_LANE_CTRL2),
+		readl_relaxed(base + A52_P307_V3_LANE_CTRL3),
+		readl_relaxed(base + A52_P307_V3_LANE_CTRL4));
+}
+
+'''
+    return replace_once(text, anchor, helper, 'PHY helper insertion')
+
+
+def patch_hw(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1' not in text:
+        raise SystemExit('Phase307 requires inherited Phase303/293 HW reference')
+
+    old = '''/* A52_PHASE293_GKI_DMA_DONE_HW_REFERENCE_V1 */\nextern bool a52_p293_gdm_trace_active(void);\nextern void a52_ackfr_record(const char *fmt, ...);\n'''
+    new = old + '''extern void a52_p307_phy_snapshot(unsigned int index, unsigned int point);\n\n/* A52_PHASE307_V3_PHY_CLOCKLANE_CORRELATION_V1\n * q0 = immediately before SW trigger, q1 = immediately after SW trigger.\n * Read-only controller + real v3 PHY correlation for exact F0 5A 5A only.\n */\nstatic void a52_p307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point)\n{\n\tif (!a52_p293_gdm_trace_active() || !ctrl || !ctrl->base)\n\t\treturn;\n\ta52_ackfr_record("P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x", point,\n\t\tDSI_R32(ctrl, DSI_STATUS), DSI_R32(ctrl, DSI_LANE_STATUS),\n\t\tDSI_R32(ctrl, DSI_CLK_STATUS), DSI_R32(ctrl, DSI_CLK_CTRL),\n\t\tDSI_R32(ctrl, DSI_INT_CTRL));\n\ta52_p307_phy_snapshot(ctrl->index, point);\n}\n'''
+    text = replace_once(text, old, new, 'HW helper insertion')
+
+    old_pre = '''\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER)) {\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\t\tif (a52_p293_gdm_trace_active()) {\n'''
+    new_pre = '''\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER)) {\n\t\ta52_p307_hw_snapshot(ctrl, 0);\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\t\ta52_p307_hw_snapshot(ctrl, 1);\n\t\tif (a52_p293_gdm_trace_active()) {\n'''
+    text = replace_once(text, old_pre, new_pre, 'memory kickoff q0/q1')
+
+    old_trig = '''void dsi_ctrl_hw_cmn_trigger_command_dma(struct dsi_ctrl_hw *ctrl)\n{\n\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\tif (a52_p293_gdm_trace_active()) {\n'''
+    new_trig = '''void dsi_ctrl_hw_cmn_trigger_command_dma(struct dsi_ctrl_hw *ctrl)\n{\n\ta52_p307_hw_snapshot(ctrl, 0);\n\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\ta52_p307_hw_snapshot(ctrl, 1);\n\tif (a52_p293_gdm_trace_active()) {\n'''
+    text = replace_once(text, old_trig, new_trig, 'deferred trigger q0/q1')
+    return text
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE304_EXACT_F05A5A_VISIBILITY_V1' not in text:
+        raise SystemExit('Phase307 requires inherited exact F0 5A 5A arming')
+
+    anchor = 'bool a52_p293_gdm_trace_active(void)\n{\n\treturn atomic_read(&a52_p293_gdm_state) == 1;\n}\n'
+    inject = anchor + '\n/* ' + MARK + ' */\nextern void a52_p307_phy_snapshot(unsigned int index, unsigned int point);\n'
+    text = replace_once(text, anchor, inject, 'controller PHY declaration')
+
+    old = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_p293_gdm_armed(dsi_ctrl)) {\n'''
+    new = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_p293_gdm_armed(dsi_ctrl)) {\n\t\ta52_ackfr_record("P276 307C q=2 st=%x ln=%x ck=%x cc=%x in=%x",\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_CTRL),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL));\n\t\ta52_p307_phy_snapshot(dsi_ctrl->cell_index, 2);\n'''
+    return replace_once(text, old, new, 'completion q2 snapshot')
+
+
+def validate(ctrl: str, hw: str, phy: str) -> None:
+    combined = ctrl + hw + phy
+    required = [
+        MARK,
+        'DSI_PHY_VERSION_3_0',
+        'A52_P307_V3_PLL_CTRL        0x038',
+        'A52_P307_V3_STATUS          0x0ec',
+        'A52_P307_V3_LANE_STATUS0    0x0f4',
+        'A52_P307_V3_LANE_STATUS1    0x0f8',
+        'P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x',
+        'P276 307C q=2 st=%x ln=%x ck=%x cc=%x in=%x',
+        'P276 307P0 q=%u v=%u p=%u s=%u %x %x %x %x',
+        'P276 307P1 q=%u %x %x %x %x %x %x',
+        'P276 307P2 q=%u %x %x %x %x %x %x',
+        'P276 307P3 q=%u %x %x %x',
+        'a52_p307_hw_snapshot(ctrl, 0);',
+        'a52_p307_hw_snapshot(ctrl, 1);',
+        'a52_p307_phy_snapshot(dsi_ctrl->cell_index, 2);',
+        'P276 303 S00p p=%02x%02x%02x',
+        'P276 303 S06 st=%x fs=%x ln=%x ck=%x',
+        'P276 303 S08 ret=%d irq=%d in=%x st=%x',
+    ]
+    for token in required:
+        if token not in combined:
+            raise SystemExit('Phase307 required token missing: ' + token)
+
+    # Observer-only audit: the patch must add no new write/delay/reset primitives.
+    for token in ['DSI_W32(', 'writel_relaxed(', 'writel(', 'msleep(', 'usleep_range(', 'udelay(']:
+        # Existing source naturally contains these; the apply script itself never injects them
+        # except the two pre-existing trigger lines included in replacement anchors.
+        pass
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    cp, hp, pp = args.root / CTRL, args.root / HW, args.root / PHY
+    for p in (cp, hp, pp):
+        if not p.is_file():
+            raise SystemExit('Phase307 source missing: ' + str(p))
+
+    if not args.check_only:
+        cp.write_text(patch_ctrl(cp.read_text()))
+        hp.write_text(patch_hw(hp.read_text()))
+        pp.write_text(patch_phy(pp.read_text()))
+
+    validate(cp.read_text(), hp.read_text(), pp.read_text())
+    print('Phase307 GKI v3 PHY/clock-lane exact-target observer: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/307_ci_build.sh
+++ b/scripts/307_ci_build.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase307-gki-out"
+CTRL="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+PHYV3="$ROOT/drivers/a52_display/msm/dsi/dsi_phy_hw_v3_0.c"
+TGPHYV3="$PWD/workspace/touchgrass-a52xq/techpack/display/msm/dsi/dsi_phy_hw_v3_0.c"
+COMPAT="$ROOT/a52-port-compat.h"
+
+fail_report() {
+  set +e
+  rm -rf phase307-gki-failure
+  mkdir -p phase307-gki-failure/{logs,audit,source}
+  cp phase307-gki-compile.log phase307-gki-olddefconfig.log phase307-gki-failure/logs/ 2>/dev/null || true
+  for f in "$CTRL" "$HW" "$PHY" "$PHYV3" "$COMPAT"; do [ -f "$f" ] && cp "$f" phase307-gki-failure/source/ || true; done
+  cp /tmp/p307-* phase307-gki-failure/audit/ 2>/dev/null || true
+  cp scripts/307_apply_v3_phy_clocklane_correlation.py phase307-gki-failure/audit/ 2>/dev/null || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact hardware-tested Phase305 state. Phase306 is intentionally excluded.
+bash scripts/305_ci_build.sh
+
+test -s phase305-out/package/boot.img
+test -s phase305-out/compile/Image
+test -s phase305-out/config/final.config
+test "$(stat -c '%s' phase305-out/package/boot.img)" -eq 100663296
+for f in "$CTRL" "$HW" "$PHY" "$PHYV3" "$TGPHYV3" "$COMPAT"; do test -s "$f"; done
+
+grep -Fxq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fxq '#define rpmh_flush(d) a52_rpmh_flush_compat((d))' "$COMPAT"
+grep -Fq 'A52_PHASE304_EXACT_F05A5A_VISIBILITY_V1' "$CTRL"
+grep -Fq 'P276 303 S00p p=%02x%02x%02x' "$CTRL"
+
+cp phase305-out/config/final.config /tmp/p307-phase305.config
+cp "$CTRL" /tmp/p307-ctrl-before.c
+cp "$HW" /tmp/p307-hw-before.c
+cp "$PHY" /tmp/p307-phy-before.c
+cp "$PHYV3" /tmp/p307-phyv3-gki.c
+cp "$TGPHYV3" /tmp/p307-phyv3-touchgrass.c
+
+# Source-level comparison of the actual v3 PHY programming implementation.
+sha256sum "$PHYV3" "$TGPHYV3" > /tmp/p307-v3-phy-source.sha256
+diff -u "$TGPHYV3" "$PHYV3" > /tmp/p307-v3-phy-source.diff || true
+if cmp -s "$TGPHYV3" "$PHYV3"; then
+  printf 'byte_identical=true\n' > /tmp/p307-v3-phy-source-summary.txt
+else
+  printf 'byte_identical=false\n' > /tmp/p307-v3-phy-source-summary.txt
+fi
+
+python3 -m py_compile scripts/307_apply_v3_phy_clocklane_correlation.py
+python3 scripts/307_apply_v3_phy_clocklane_correlation.py --root "$ROOT"
+python3 scripts/307_apply_v3_phy_clocklane_correlation.py --root "$ROOT" --check-only
+
+# Observer-only scope audit. No new MMIO write, clock mutation, reset or delay primitive.
+python3 - <<'PY'
+from pathlib import Path
+pairs = [
+    ('/tmp/p307-ctrl-before.c', 'gki/common/drivers/a52_display/msm/dsi/dsi_ctrl.c'),
+    ('/tmp/p307-hw-before.c', 'gki/common/drivers/a52_display/msm/dsi/dsi_ctrl_hw_cmn.c'),
+    ('/tmp/p307-phy-before.c', 'gki/common/drivers/a52_display/msm/dsi/dsi_phy.c'),
+]
+protected = [
+    'DSI_W32(', 'writel_relaxed(', 'writel(', 'clk_set_rate(',
+    'clk_prepare_enable(', 'clk_disable_unprepare(', 'regulator_enable(',
+    'regulator_disable(', 'msleep(', 'usleep_range(', 'udelay(',
+]
+for before, after in pairs:
+    a = Path(before).read_text()
+    b = Path(after).read_text()
+    for token in protected:
+        if a.count(token) != b.count(token):
+            raise SystemExit(f'Phase307 observer scope violation {Path(after).name}: {token} {a.count(token)} -> {b.count(token)}')
+print('Phase307 observer-only primitive audit: PASS')
+PY
+
+# The PHY hardware programming source itself must remain untouched by Phase307.
+cmp -s /tmp/p307-phyv3-gki.c "$PHYV3"
+# Preserve Phase305 RPMh behavior exactly.
+grep -Fxq '#define rpmh_mode_solver_set(d,e) do{}while(0)' "$COMPAT"
+grep -Fxq '#define rpmh_flush(d) a52_rpmh_flush_compat((d))' "$COMPAT"
+
+cp /tmp/p307-phase305.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase307-gki-olddefconfig.log 2>&1
+cmp -s /tmp/p307-phase305.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase307-gki-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase307-gki-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+for marker in \
+  'P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x' \
+  'P276 307C q=2 st=%x ln=%x ck=%x cc=%x in=%x' \
+  'P276 307P0 q=%u v=%u p=%u s=%u %x %x %x %x' \
+  'P276 307P1 q=%u %x %x %x %x %x %x' \
+  'P276 307P2 q=%u %x %x %x %x %x %x' \
+  'P276 307P3 q=%u %x %x %x' \
+  'P276 303 S00p p=%02x%02x%02x' \
+  'P276 303 S06 st=%x fs=%x ln=%x ck=%x' \
+  'P276 305F x r=%d l=%u b=%u' \
+  'P276 280Z q=2'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase307-gki-compile.log phase307-gki-olddefconfig.log "$OUT/audit/"
+cp scripts/307_apply_v3_phy_clocklane_correlation.py "$OUT/audit/"
+cp /tmp/p307-* "$OUT/audit/" 2>/dev/null || true
+cp "$CTRL" "$HW" "$PHY" "$PHYV3" "$OUT/source/"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase305-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase307-gki-out')
+summary = Path('/tmp/p307-v3-phy-source-summary.txt').read_text().strip().split('=',1)[1] == 'true'
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+  'phase': '307',
+  'variant': 'GKI-PHASE305-BASE',
+  'name': 'V3-PHY-CLOCKLANE-CORRELATION-V1',
+  'git_sha': os.getenv('GITHUB_SHA'),
+  'hardware_validated': False,
+  'base': 'hardware-tested Phase305 flush-repair lineage; Phase306 solver experiment excluded',
+  'observer_only': True,
+  'target': 'ctrl0 flags=0x20 msg.flags=0x8 type=0x29 len=3 payload=F0 5A 5A',
+  'points': {'q0':'immediately before SW_TRIGGER','q1':'immediately after SW_TRIGGER','q2':'after DMA completion/timeout'},
+  'phy_version_expected': 'DSI_PHY_VERSION_3_0 (enum 5, 10-nm)',
+  'touchgrass_gki_v3_phy_source_byte_identical': summary,
+  'solver_stub_preserved': True,
+  'phase305_flush_repair_preserved': True,
+  'mmio_writes_added': False,
+  'clock_or_regulator_changes_added': False,
+  'wait_timeout_reset_changes_added': False,
+  'boot_bytes': (r/'package/boot.img').stat().st_size,
+  'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+  'image_sha256': hashlib.sha256((r/'compile/Image').read_bytes()).hexdigest(),
+  'dtb_preserved': repack['invariants']['dtb_preserved'],
+  'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+  'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files=[p for p in r.rglob('*') if p.is_file() and p.name!='SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+  for p in sorted(files): f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+PY
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+trap - EXIT
+echo 'Phase307 GKI v3 PHY/clock-lane observer build/repack: PASS'

--- a/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+++ b/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
@@ -111,6 +111,7 @@ def patch_ctrl(text: str) -> str:
 /* A52_PHASE307_GOLDEN_V3_PHY_CLOCKLANE_REFERENCE_V1 */
 static atomic_t a52_g307_state = ATOMIC_INIT(0);
 extern void a52_g307_phy_snapshot(unsigned int index, unsigned int point);
+extern void a52_g307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point);
 
 bool a52_g307_trace_active(void)
 {
@@ -148,7 +149,7 @@ static void a52_g307_try_arm(struct dsi_ctrl *ctrl,
     text = repl(text, old_arm, new_arm, 'exact target arm')
 
     old_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
-    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\tpr_info("TG307 C q=2 st=%x ln=%x ck=%x cc=%x in=%x ret=%d irq=%d\\n",\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_CTRL),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL), ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\ta52_g307_phy_snapshot(dsi_ctrl->cell_index, 2);\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
+    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\ta52_g307_hw_snapshot(&dsi_ctrl->hw, 2);\n\t\tpr_info("TG307 C q=2 ret=%d irq=%d\\n", ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
     return repl(text, old_wait, new_wait, 'q2 completion snapshot')
 
 
@@ -161,7 +162,8 @@ def patch_hw(text: str) -> str:
 /* A52_PHASE307_GOLDEN_V3_PHY_CLOCKLANE_REFERENCE_V1 */
 extern bool a52_g307_trace_active(void);
 extern void a52_g307_phy_snapshot(unsigned int index, unsigned int point);
-static void a52_g307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point)
+void a52_g307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point);
+void a52_g307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point)
 {
 	if (!a52_g307_trace_active() || !ctrl || !ctrl->base)
 		return;

--- a/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+++ b/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
@@ -148,7 +148,7 @@ static void a52_g307_try_arm(struct dsi_ctrl *ctrl,
     text = repl(text, old_arm, new_arm, 'exact target arm')
 
     old_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
-    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\tpr_info("TG307 C q=2 st=%x ln=%x ck=%x cc=%x in=%x ret=%d irq=%d\n",\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_CTRL),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL), ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\ta52_g307_phy_snapshot(dsi_ctrl->cell_index, 2);\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
+    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\tpr_info("TG307 C q=2 st=%x ln=%x ck=%x cc=%x in=%x ret=%d irq=%d\\n",\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_CTRL),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL), ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\ta52_g307_phy_snapshot(dsi_ctrl->cell_index, 2);\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
     return repl(text, old_wait, new_wait, 'q2 completion snapshot')
 
 

--- a/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+++ b/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CTRL = Path('techpack/display/msm/dsi/dsi_ctrl.c')
+HW = Path('techpack/display/msm/dsi/dsi_ctrl_hw_cmn.c')
+PHY = Path('techpack/display/msm/dsi/dsi_phy.c')
+MARK = 'A52_PHASE307_GOLDEN_V3_PHY_CLOCKLANE_REFERENCE_V1'
+
+
+def repl(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase307G {label}: expected 1 match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_phy(text: str) -> str:
+    if MARK in text:
+        return text
+    anchor = 'static DEFINE_MUTEX(dsi_phy_list_lock);\n'
+    helper = r'''static DEFINE_MUTEX(dsi_phy_list_lock);
+
+/* A52_PHASE307_GOLDEN_V3_PHY_CLOCKLANE_REFERENCE_V1
+ * Read-only matched control for known-good TouchGrass 4.19.200.
+ * q0 before SW_TRIGGER, q1 after SW_TRIGGER, q2 after completion.
+ */
+#define A52_G307_V3_CLK_CFG0        0x010
+#define A52_G307_V3_CLK_CFG1        0x014
+#define A52_G307_V3_GLBL_CTRL       0x018
+#define A52_G307_V3_RBUF_CTRL       0x01c
+#define A52_G307_V3_VREG_CTRL       0x020
+#define A52_G307_V3_CTRL0           0x024
+#define A52_G307_V3_CTRL1           0x028
+#define A52_G307_V3_CTRL2           0x02c
+#define A52_G307_V3_LANE_CFG0       0x030
+#define A52_G307_V3_LANE_CFG1       0x034
+#define A52_G307_V3_PLL_CTRL        0x038
+#define A52_G307_V3_LANE_CTRL0      0x098
+#define A52_G307_V3_LANE_CTRL1      0x09c
+#define A52_G307_V3_LANE_CTRL2      0x0a0
+#define A52_G307_V3_LANE_CTRL3      0x0a4
+#define A52_G307_V3_LANE_CTRL4      0x0a8
+#define A52_G307_V3_STATUS          0x0ec
+#define A52_G307_V3_LANE_STATUS0    0x0f4
+#define A52_G307_V3_LANE_STATUS1    0x0f8
+
+void a52_g307_phy_snapshot(unsigned int index, unsigned int point)
+{
+	struct dsi_phy_list_item *item;
+	struct msm_dsi_phy *phy = NULL;
+	void __iomem *base;
+	u32 ver;
+
+	mutex_lock(&dsi_phy_list_lock);
+	list_for_each_entry(item, &dsi_phy_list, list) {
+		if (item->phy && item->phy->index == index) {
+			phy = item->phy;
+			break;
+		}
+	}
+	mutex_unlock(&dsi_phy_list_lock);
+	if (!phy || !phy->ver_info || !phy->hw.base) {
+		pr_info("TG307 PX q=%u i=%u x=0\n", point, index);
+		return;
+	}
+	ver = phy->ver_info->version;
+	if (ver != DSI_PHY_VERSION_3_0) {
+		pr_info("TG307 PX q=%u i=%u v=%u\n", point, index, ver);
+		return;
+	}
+	base = phy->hw.base;
+	pr_info("TG307 P0 q=%u v=%u p=%u s=%u %x %x %x %x\n", point,
+		ver, phy->power_state, phy->dsi_phy_state,
+		readl_relaxed(base + A52_G307_V3_PLL_CTRL),
+		readl_relaxed(base + A52_G307_V3_STATUS),
+		readl_relaxed(base + A52_G307_V3_LANE_STATUS0),
+		readl_relaxed(base + A52_G307_V3_LANE_STATUS1));
+	pr_info("TG307 P1 q=%u %x %x %x %x %x %x\n", point,
+		readl_relaxed(base + A52_G307_V3_CLK_CFG0),
+		readl_relaxed(base + A52_G307_V3_CLK_CFG1),
+		readl_relaxed(base + A52_G307_V3_GLBL_CTRL),
+		readl_relaxed(base + A52_G307_V3_RBUF_CTRL),
+		readl_relaxed(base + A52_G307_V3_VREG_CTRL),
+		readl_relaxed(base + A52_G307_V3_CTRL0));
+	pr_info("TG307 P2 q=%u %x %x %x %x %x %x\n", point,
+		readl_relaxed(base + A52_G307_V3_CTRL1),
+		readl_relaxed(base + A52_G307_V3_CTRL2),
+		readl_relaxed(base + A52_G307_V3_LANE_CFG0),
+		readl_relaxed(base + A52_G307_V3_LANE_CFG1),
+		readl_relaxed(base + A52_G307_V3_LANE_CTRL0),
+		readl_relaxed(base + A52_G307_V3_LANE_CTRL1));
+	pr_info("TG307 P3 q=%u %x %x %x\n", point,
+		readl_relaxed(base + A52_G307_V3_LANE_CTRL2),
+		readl_relaxed(base + A52_G307_V3_LANE_CTRL3),
+		readl_relaxed(base + A52_G307_V3_LANE_CTRL4));
+}
+
+'''
+    return repl(text, anchor, helper, 'PHY helper')
+
+
+def patch_ctrl(text: str) -> str:
+    if MARK in text:
+        return text
+    anchor = 'static DEFINE_MUTEX(dsi_ctrl_list_lock);\n'
+    helper = r'''static DEFINE_MUTEX(dsi_ctrl_list_lock);
+
+/* A52_PHASE307_GOLDEN_V3_PHY_CLOCKLANE_REFERENCE_V1 */
+static atomic_t a52_g307_state = ATOMIC_INIT(0);
+extern void a52_g307_phy_snapshot(unsigned int index, unsigned int point);
+
+bool a52_g307_trace_active(void)
+{
+	return atomic_read(&a52_g307_state) == 1;
+}
+
+static bool a52_g307_armed(struct dsi_ctrl *ctrl)
+{
+	return ctrl && ctrl->cell_index == 0 && a52_g307_trace_active();
+}
+
+static void a52_g307_try_arm(struct dsi_ctrl *ctrl,
+		const struct mipi_dsi_msg *msg, u32 flags)
+{
+	const u8 *p;
+	if (!ctrl || !msg || ctrl->cell_index != 0 ||
+	    flags != DSI_CTRL_CMD_FETCH_MEMORY || msg->flags != 0x8 ||
+	    msg->type != 0x29 || msg->tx_len != 3 || !msg->tx_buf)
+		return;
+	p = msg->tx_buf;
+	if (p[0] != 0xF0 || p[1] != 0x5A || p[2] != 0x5A)
+		return;
+	if (atomic_cmpxchg(&a52_g307_state, 0, 1) != 0)
+		return;
+	pr_info("TG307 ARM c=0 in=%x mf=%x t=%x l=%u p=%02x%02x%02x\n",
+		flags, msg->flags, msg->type, (unsigned int)msg->tx_len,
+		p[0], p[1], p[2]);
+}
+
+'''
+    text = repl(text, anchor, helper, 'controller arm helper')
+
+    old_arm = '''\tdsi_ctrl_validate_msg_flags(dsi_ctrl, msg, flags);\n\n\tif (dsi_ctrl->dma_wait_queued)\n'''
+    new_arm = '''\tdsi_ctrl_validate_msg_flags(dsi_ctrl, msg, flags);\n\ta52_g307_try_arm(dsi_ctrl, msg, *flags);\n\n\tif (dsi_ctrl->dma_wait_queued)\n'''
+    text = repl(text, old_arm, new_arm, 'exact target arm')
+
+    old_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
+    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\tpr_info("TG307 C q=2 st=%x ln=%x ck=%x cc=%x in=%x ret=%d irq=%d\n",\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_LANE_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_STATUS),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_CLK_CTRL),\n\t\t\tDSI_R32(&dsi_ctrl->hw, DSI_INT_CTRL), ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\ta52_g307_phy_snapshot(dsi_ctrl->cell_index, 2);\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
+    return repl(text, old_wait, new_wait, 'q2 completion snapshot')
+
+
+def patch_hw(text: str) -> str:
+    if MARK in text:
+        return text
+    anchor = '#include "sde_dbg.h"\n'
+    helper = r'''#include "sde_dbg.h"
+
+/* A52_PHASE307_GOLDEN_V3_PHY_CLOCKLANE_REFERENCE_V1 */
+extern bool a52_g307_trace_active(void);
+extern void a52_g307_phy_snapshot(unsigned int index, unsigned int point);
+static void a52_g307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point)
+{
+	if (!a52_g307_trace_active() || !ctrl || !ctrl->base)
+		return;
+	pr_info("TG307 C q=%u st=%x ln=%x ck=%x cc=%x in=%x\n", point,
+		DSI_R32(ctrl, DSI_STATUS), DSI_R32(ctrl, DSI_LANE_STATUS),
+		DSI_R32(ctrl, DSI_CLK_STATUS), DSI_R32(ctrl, DSI_CLK_CTRL),
+		DSI_R32(ctrl, DSI_INT_CTRL));
+	a52_g307_phy_snapshot(ctrl->index, point);
+}
+'''
+    text = repl(text, anchor, helper, 'HW snapshot helper')
+
+    old_kick = '''\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER))\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n}\n\n/**\n * kickoff_fifo_command()'''
+    new_kick = '''\tif (!(flags & DSI_CTRL_HW_CMD_WAIT_FOR_TRIGGER)) {\n\t\ta52_g307_hw_snapshot(ctrl, 0);\n\t\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\t\ta52_g307_hw_snapshot(ctrl, 1);\n\t}\n}\n\n/**\n * kickoff_fifo_command()'''
+    text = repl(text, old_kick, new_kick, 'memory q0/q1')
+
+    old_trig = '''void dsi_ctrl_hw_cmn_trigger_command_dma(struct dsi_ctrl_hw *ctrl)\n{\n\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n}\n'''
+    new_trig = '''void dsi_ctrl_hw_cmn_trigger_command_dma(struct dsi_ctrl_hw *ctrl)\n{\n\ta52_g307_hw_snapshot(ctrl, 0);\n\tDSI_W32(ctrl, DSI_CMD_MODE_DMA_SW_TRIGGER, 0x1);\n\ta52_g307_hw_snapshot(ctrl, 1);\n}\n'''
+    return repl(text, old_trig, new_trig, 'deferred q0/q1')
+
+
+def validate(ctrl: str, hw: str, phy: str) -> None:
+    need = [MARK, 'TG307 ARM c=0', 'TG307 C q=%u', 'TG307 C q=2',
+            'TG307 P0 q=%u', 'TG307 P1 q=%u', 'TG307 P2 q=%u', 'TG307 P3 q=%u',
+            'DSI_PHY_VERSION_3_0', 'A52_G307_V3_LANE_STATUS1    0x0f8']
+    alltxt = ctrl + hw + phy
+    for x in need:
+        if x not in alltxt:
+            raise SystemExit('Phase307G missing token: ' + x)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    ns = ap.parse_args()
+    paths = [ns.root / CTRL, ns.root / HW, ns.root / PHY]
+    for p in paths:
+        if not p.is_file(): raise SystemExit('Phase307G missing source: ' + str(p))
+    if not ns.check_only:
+        paths[0].write_text(patch_ctrl(paths[0].read_text()))
+        paths[1].write_text(patch_hw(paths[1].read_text()))
+        paths[2].write_text(patch_phy(paths[2].read_text()))
+    validate(*(p.read_text() for p in paths))
+    print('Phase307 Golden TouchGrass v3 PHY/clock-lane observer: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+++ b/scripts/307g_apply_golden_v3_phy_clocklane_reference.py
@@ -149,7 +149,7 @@ static void a52_g307_try_arm(struct dsi_ctrl *ctrl,
     text = repl(text, old_arm, new_arm, 'exact target arm')
 
     old_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
-    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\ta52_g307_hw_snapshot(&dsi_ctrl->hw, 2);\n\t\tpr_info("TG307 C q=2 ret=%d irq=%d\\n", ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
+    new_wait = '''\tret = wait_for_completion_timeout(\n\t\t\t&dsi_ctrl->irq_info.cmd_dma_done,\n\t\t\tmsecs_to_jiffies(DSI_CTRL_TX_TO_MS));\n\tif (a52_g307_armed(dsi_ctrl)) {\n\t\ta52_g307_hw_snapshot(&dsi_ctrl->hw, 2);\n\t\tpr_info("TG307 C q=2 ret=%d irq=%d\\n", ret,\n\t\t\tatomic_read(&dsi_ctrl->dma_irq_trig));\n\t\tatomic_set(&a52_g307_state, 2);\n\t}\n\tif (ret == 0 && !atomic_read(&dsi_ctrl->dma_irq_trig)) {\n'''
     return repl(text, old_wait, new_wait, 'q2 completion snapshot')
 
 
@@ -188,6 +188,7 @@ void a52_g307_hw_snapshot(struct dsi_ctrl_hw *ctrl, unsigned int point)
 def validate(ctrl: str, hw: str, phy: str) -> None:
     need = [MARK, 'TG307 ARM c=0', 'TG307 C q=%u', 'TG307 C q=2',
             'TG307 P0 q=%u', 'TG307 P1 q=%u', 'TG307 P2 q=%u', 'TG307 P3 q=%u',
+            'atomic_set(&a52_g307_state, 2);',
             'DSI_PHY_VERSION_3_0', 'A52_G307_V3_LANE_STATUS1    0x0f8']
     alltxt = ctrl + hw + phy
     for x in need:

--- a/scripts/307g_ci_build.sh
+++ b/scripts/307g_ci_build.sh
@@ -7,17 +7,50 @@ OUT="$ROOT/phase307-golden-out"
 FAIL="$ROOT/phase307-golden-failure"
 rm -rf "$OUT" "$FAIL"
 mkdir -p "$OUT"/{audit,source,package} "$FAIL"
+STAGE=init
+printf '%s\n' "$STAGE" > "$FAIL/stage.txt"
+exec > >(tee -a "$FAIL/full.log") 2>&1
+set -x
+
+stage() {
+  STAGE="$1"
+  set +x
+  printf '%s\n' "$STAGE" | tee "$FAIL/stage.txt"
+  printf 'PHASE307G_STAGE=%s\n' "$STAGE"
+  set -x
+}
 
 on_err() {
   rc=$?
+  set +x
   mkdir -p "$FAIL"
-  { echo "rc=$rc"; date -u; [ -d "$KERNEL" ] && git -C "$KERNEL" diff --check || true; } > "$FAIL/diagnostics.txt" 2>&1
+  {
+    echo "rc=$rc"
+    echo "stage=$STAGE"
+    date -u
+    if [ -d "$KERNEL" ]; then
+      echo '--- git status ---'
+      git -C "$KERNEL" status --short || true
+      echo '--- diff check ---'
+      git -C "$KERNEL" diff --check || true
+      echo '--- diff stat ---'
+      git -C "$KERNEL" diff --stat || true
+    fi
+  } > "$FAIL/diagnostics.txt" 2>&1
+  [ -d "$OUT" ] && cp -a "$OUT" "$FAIL/partial-out" 2>/dev/null || true
+  for f in "$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c" \
+           "$KERNEL/techpack/display/msm/dsi/dsi_ctrl_hw_cmn.c" \
+           "$KERNEL/techpack/display/msm/dsi/dsi_phy.c" \
+           "$KERNEL/techpack/display/msm/dsi/dsi_phy_hw_v3_0.c"; do
+    [ -f "$f" ] && { mkdir -p "$FAIL/source"; cp "$f" "$FAIL/source/"; } || true
+  done
   exit "$rc"
 }
 trap on_err ERR
 
 chmod +x scripts/*.sh scripts/*.py
 
+stage reconstruct-4.19.200
 # Exact reviewed TouchGrass 4.19.200 reconstruction used by the known-good control.
 ./scripts/01_prepare_source.sh
 ./scripts/03_apply_linux_4.19.153.sh
@@ -31,6 +64,7 @@ chmod +x scripts/*.sh scripts/*.py
 ./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
 ./scripts/checkpoint_resolve_linux_4.19.200.sh
 
+stage freeze-pre-observer
 CTRL="$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c"
 HW="$KERNEL/techpack/display/msm/dsi/dsi_ctrl_hw_cmn.c"
 PHY="$KERNEL/techpack/display/msm/dsi/dsi_phy.c"
@@ -42,11 +76,14 @@ cp "$PHY" "$OUT/audit/dsi_phy-before.c"
 cp "$PHYV3" "$OUT/audit/dsi_phy_hw_v3_0.c"
 sha256sum "$PHYV3" > "$OUT/audit/touchgrass-v3-phy-source.sha256"
 
+stage apply-observer
 python3 -m py_compile scripts/307g_apply_golden_v3_phy_clocklane_reference.py
 python3 scripts/307g_apply_golden_v3_phy_clocklane_reference.py --root "$KERNEL"
 python3 scripts/307g_apply_golden_v3_phy_clocklane_reference.py --root "$KERNEL" --check-only
 
 git -C "$KERNEL" diff --check
+
+stage observer-scope-audit
 python3 - <<'PY'
 from pathlib import Path
 out=Path('phase307-golden-out/audit')
@@ -63,9 +100,14 @@ PY
 # Programming implementation itself is untouched.
 cmp -s "$OUT/audit/dsi_phy_hw_v3_0.c" "$PHYV3"
 
+stage resukisu-hook
 ./scripts/07_patch_resukisu_exec_hook.sh
+
+stage kernel-build
 set -o pipefail
 ./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.200 2>&1 | tee "$OUT/golden-build.log"
+
+stage image-audit
 IMAGE="$(find artifacts -maxdepth 1 -type f -name 'Image-touchgrass-4.19.200-resukisu-v4.1.0-safe' -print -quit)"
 CONFIG="$(find artifacts -maxdepth 1 -type f -name 'config-touchgrass-4.19.200-resukisu-v4.1.0-safe' -print -quit)"
 test -n "$IMAGE" -a -s "$IMAGE" -a -n "$CONFIG" -a -s "$CONFIG"
@@ -80,6 +122,7 @@ for marker in 'TG307 ARM c=0' 'TG307 C q=%u' 'TG307 C q=2' 'TG307 P0 q=%u' 'TG30
 done
 grep -Fq 'Linux version 4.19.200-touchGrassKernel+' "$OUT/Image.strings.txt"
 
+stage identity
 cat > "$OUT/BUILD-IDENTITY.txt" <<EOF
 experiment=PHASE307-GOLDEN-TOUCHGRASS-V3-PHY-CLOCKLANE-REFERENCE-V1
 behavior_change=none-read-only-exact-F05A5A-only
@@ -92,4 +135,6 @@ clock_regulator_reset_timeout_changes=no
 flashable=pending-known-good-96MiB-container-repack
 EOF
 sha256sum "$OUT/Image" "$OUT/config" > "$OUT/SHA256SUMS"
+stage complete
+set +x
 echo 'Phase307 Golden TouchGrass v3 PHY/clock-lane observer build: PASS'

--- a/scripts/307g_ci_build.sh
+++ b/scripts/307g_ci_build.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+KERNEL="$ROOT/workspace/touchgrass-a52xq"
+OUT="$ROOT/phase307-golden-out"
+FAIL="$ROOT/phase307-golden-failure"
+rm -rf "$OUT" "$FAIL"
+mkdir -p "$OUT"/{audit,source,package} "$FAIL"
+
+on_err() {
+  rc=$?
+  mkdir -p "$FAIL"
+  { echo "rc=$rc"; date -u; [ -d "$KERNEL" ] && git -C "$KERNEL" diff --check || true; } > "$FAIL/diagnostics.txt" 2>&1
+  exit "$rc"
+}
+trap on_err ERR
+
+chmod +x scripts/*.sh scripts/*.py
+
+# Exact reviewed TouchGrass 4.19.200 reconstruction used by the known-good control.
+./scripts/01_prepare_source.sh
+./scripts/03_apply_linux_4.19.153.sh
+./scripts/04_apply_linux_4.19.154.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.154 4.19.159
+./scripts/checkpoint_resolve_linux_4.19.159.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.159 4.19.164
+./scripts/checkpoint_resolve_linux_4.19.164.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.164 4.19.180
+./scripts/checkpoint_resolve_linux_4.19.180.sh
+./scripts/05a_diagnose_linux_checkpoint.sh 4.19.180 4.19.200
+./scripts/checkpoint_resolve_linux_4.19.200.sh
+
+CTRL="$KERNEL/techpack/display/msm/dsi/dsi_ctrl.c"
+HW="$KERNEL/techpack/display/msm/dsi/dsi_ctrl_hw_cmn.c"
+PHY="$KERNEL/techpack/display/msm/dsi/dsi_phy.c"
+PHYV3="$KERNEL/techpack/display/msm/dsi/dsi_phy_hw_v3_0.c"
+for f in "$CTRL" "$HW" "$PHY" "$PHYV3"; do test -s "$f"; done
+cp "$CTRL" "$OUT/audit/dsi_ctrl-before.c"
+cp "$HW" "$OUT/audit/dsi_ctrl_hw_cmn-before.c"
+cp "$PHY" "$OUT/audit/dsi_phy-before.c"
+cp "$PHYV3" "$OUT/audit/dsi_phy_hw_v3_0.c"
+sha256sum "$PHYV3" > "$OUT/audit/touchgrass-v3-phy-source.sha256"
+
+python3 -m py_compile scripts/307g_apply_golden_v3_phy_clocklane_reference.py
+python3 scripts/307g_apply_golden_v3_phy_clocklane_reference.py --root "$KERNEL"
+python3 scripts/307g_apply_golden_v3_phy_clocklane_reference.py --root "$KERNEL" --check-only
+
+git -C "$KERNEL" diff --check
+python3 - <<'PY'
+from pathlib import Path
+out=Path('phase307-golden-out/audit')
+k=Path('workspace/touchgrass-a52xq/techpack/display/msm/dsi')
+pairs=[(out/'dsi_ctrl-before.c',k/'dsi_ctrl.c'),(out/'dsi_ctrl_hw_cmn-before.c',k/'dsi_ctrl_hw_cmn.c'),(out/'dsi_phy-before.c',k/'dsi_phy.c')]
+protected=['DSI_W32(','writel_relaxed(','writel(','clk_set_rate(','clk_prepare_enable(','clk_disable_unprepare(','regulator_enable(','regulator_disable(','msleep(','usleep_range(','udelay(']
+for a,b in pairs:
+    x=a.read_text(); y=b.read_text()
+    for t in protected:
+        if x.count(t)!=y.count(t):
+            raise SystemExit(f'Phase307G observer scope violation {b.name}: {t} {x.count(t)} -> {y.count(t)}')
+print('Phase307G observer-only primitive audit: PASS')
+PY
+# Programming implementation itself is untouched.
+cmp -s "$OUT/audit/dsi_phy_hw_v3_0.c" "$PHYV3"
+
+./scripts/07_patch_resukisu_exec_hook.sh
+set -o pipefail
+./scripts/08_build_resukisu_safe_checkpoint.sh 4.19.200 2>&1 | tee "$OUT/golden-build.log"
+IMAGE="$(find artifacts -maxdepth 1 -type f -name 'Image-touchgrass-4.19.200-resukisu-v4.1.0-safe' -print -quit)"
+CONFIG="$(find artifacts -maxdepth 1 -type f -name 'config-touchgrass-4.19.200-resukisu-v4.1.0-safe' -print -quit)"
+test -n "$IMAGE" -a -s "$IMAGE" -a -n "$CONFIG" -a -s "$CONFIG"
+cp "$IMAGE" "$OUT/Image"
+cp "$CONFIG" "$OUT/config"
+cp "$CTRL" "$HW" "$PHY" "$PHYV3" "$OUT/source/"
+cp scripts/307g_apply_golden_v3_phy_clocklane_reference.py "$OUT/audit/"
+
+strings "$OUT/Image" > "$OUT/Image.strings.txt"
+for marker in 'TG307 ARM c=0' 'TG307 C q=%u' 'TG307 C q=2' 'TG307 P0 q=%u' 'TG307 P1 q=%u' 'TG307 P2 q=%u' 'TG307 P3 q=%u'; do
+  grep -Fq "$marker" "$OUT/Image.strings.txt"
+done
+grep -Fq 'Linux version 4.19.200-touchGrassKernel+' "$OUT/Image.strings.txt"
+
+cat > "$OUT/BUILD-IDENTITY.txt" <<EOF
+experiment=PHASE307-GOLDEN-TOUCHGRASS-V3-PHY-CLOCKLANE-REFERENCE-V1
+behavior_change=none-read-only-exact-F05A5A-only
+touchgrass_base=6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+kernel_version=4.19.200-touchGrassKernel+
+phy=DSI_PHY_VERSION_3_0-10nm
+points=q0-before-sw-trigger,q1-after-sw-trigger,q2-after-dma-completion
+mmio_writes_added=no
+clock_regulator_reset_timeout_changes=no
+flashable=pending-known-good-96MiB-container-repack
+EOF
+sha256sum "$OUT/Image" "$OUT/config" > "$OUT/SHA256SUMS"
+echo 'Phase307 Golden TouchGrass v3 PHY/clock-lane observer build: PASS'


### PR DESCRIPTION
## Purpose

Directly compare the first trustworthy post-trigger Golden/GKI hardware divergence at the real A52 DSI PHY and controller clock-lane boundary.

Important correction from prior investigation: the A52 runtime PHY is `DSI_PHY_VERSION_3_0` (enum 5, 10-nm), as proven by Phase283 hardware and already handled by Phase284. Phase307 therefore uses only the exact v3.0 offsets, not the irrelevant v4.x map.

## Two matched controls

### GKI
Base is the hardware-tested Phase305 flush-repair lineage. Phase306 solver semantics are intentionally excluded. Existing exact `F0 5A 5A` Phase303 arming remains the gate.

### Golden
Separately reconstruct the exact reviewed TouchGrass 4.19.200 lineage rooted at `6bf351bdf18bdb228db79e66f14a7a9c0178e5d7`, then repack with the known-good 96 MiB Golden FDR boot container.

## Symmetric snapshot points

- `q0`: immediately before the real `DSI_CMD_MODE_DMA_SW_TRIGGER` write
- `q1`: immediately after that write
- `q2`: after DMA completion (Golden) or timeout/completion (GKI)

At each point record controller STATUS/LANE_STATUS/CLK_STATUS/CLK_CTRL/INT_CTRL plus the v3 PHY:

- `CLK_CFG0/1`
- `GLBL_CTRL`, `RBUF_CTRL`, `VREG_CTRL`
- `CTRL0/1/2`
- `LANE_CFG0/1`
- `PLL_CTRL`
- `LANE_CTRL0..4`
- `STATUS`
- `LANE_STATUS0/1`

GKI markers are `P276 307C`, `P276 307P0..P3`; Golden markers are `TG307 C`, `TG307 P0..P3`.

## Source comparison

CI also hashes/diffs the imported GKI `dsi_phy_hw_v3_0.c` against the exact TouchGrass implementation, while ensuring Phase307 itself does not modify that programming source.

## Observer-only audit

CI rejects any count change in MMIO-write, clock-rate/enable, regulator, reset-delay and sleep primitives across the three instrumented files. No DSI/PHY writes, clock forcing, regulator changes, resets, delays, timeout changes, panel commands, DT changes, SMMU/GEM changes, RPMh solver changes or recovery changes are allowed.

## Hardware question

Does the known-good TouchGrass PHY/controller clock-lane state transition at q0→q1 while the Phase305-based GKI PHY/controller does not, for the exact same first successful/failing `F0 5A 5A` command?

This is an observation-only comparison, not a repair.