### PR TITLE
Phase309: matched GKI persistent clamp release latch

### DIFF
--- a/.github/workflows/309-a52-gki-clamp-release-latch.yml
+++ b/.github/workflows/309-a52-gki-clamp-release-latch.yml
@@ -1,0 +1,115 @@
+name: 309 - A52 GKI persistent clamp release latch
+run-name: Phase 309 - GKI software-only clamp release latch at exact F0
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase309-gki-clamp-release-latch-v1
+    paths:
+      - .github/workflows/309-a52-gki-clamp-release-latch.yml
+      - scripts/309_apply_gki_clamp_release_latch.py
+      - scripts/309_ci_build.sh
+      - scripts/308_apply_pll_lock_clamp_observer.py
+      - scripts/308_ci_build.sh
+      - scripts/307_apply_v3_phy_clocklane_correlation.py
+      - scripts/307_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase308-pll-lock-clamp-observer-v1
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase309-gki-clamp-latch-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build Phase308-based software-only clamp release latch
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase309 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/308_apply_pll_lock_clamp_observer.py
+          python3 -m py_compile scripts/309_apply_gki_clamp_release_latch.py
+          bash -n scripts/308_ci_build.sh
+          bash -n scripts/309_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase309 GKI clamp latch
+        run: bash scripts/309_ci_build.sh
+
+      - name: Upload complete Phase309 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase309-GKI-CLAMP-RELEASE-LATCH-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase309-gki-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase309 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase309-GKI-CLAMP-RELEASE-LATCH-${{ github.run_number }}-BOOT-IMG
+          path: phase309-gki-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase309-GKI-CLAMP-RELEASE-LATCH-${{ github.run_number }}-FAILED
+          path: phase309-gki-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/309_apply_gki_clamp_release_latch.py
+++ b/scripts/309_apply_gki_clamp_release_latch.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+PHY_REL = Path('drivers/a52_display/msm/dsi/dsi_phy.c')
+MARK = 'A52_PHASE309_GKI_CLAMP_RELEASE_LATCH_V1'
+P308 = 'A52_PHASE308_PLL_LOCK_CLAMP_OBSERVER_V1'
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f'Phase309 {label}: expected exactly one match, found {n}')
+    return text.replace(old, new, 1)
+
+
+def patch_phy(text: str) -> str:
+    if MARK in text:
+        return text
+    if P308 not in text:
+        raise SystemExit('Phase309 requires inherited Phase308 PLL/clamp observer')
+
+    old = '''extern void a52_p308_pll_snapshot(unsigned int index, unsigned int point);\n\nstatic void a52_p308_tx_dctrl_snapshot(struct msm_dsi_phy *phy,\n'''
+    new = '''extern void a52_p308_pll_snapshot(unsigned int index, unsigned int point);\n\n/* A52_PHASE309_GKI_CLAMP_RELEASE_LATCH_V1\n * Software-only persistent counters. They are incremented only after the\n * existing clamp_ctrl callback returns, so cr>0 proves that the real release\n * callback completed before the exact F0 5A 5A q snapshot. No HW operation.\n */\n#define A52_P309_PHY_MAX 2\nstatic atomic_t a52_p309_clamp_enable[A52_P309_PHY_MAX];\nstatic atomic_t a52_p309_clamp_release[A52_P309_PHY_MAX];\n\nstatic void a52_p309_clamp_snapshot(unsigned int index, unsigned int point)\n{\n\tint ce = -1, cr = -1;\n\n\tif (index < A52_P309_PHY_MAX) {\n\t\tce = atomic_read(&a52_p309_clamp_enable[index]);\n\t\tcr = atomic_read(&a52_p309_clamp_release[index]);\n\t}\n\n\ta52_ackfr_record("P276 309T q=%u i=%u ce=%d cr=%d",\n\t\tpoint, index, ce, cr);\n}\n\nstatic void a52_p308_tx_dctrl_snapshot(struct msm_dsi_phy *phy,\n'''
+    text = replace_once(text, old, new, 'counter declaration/helper')
+
+    old_snapshot = '''\ta52_ackfr_record("P276 308T q=%u %x %x %x %x %x", point,\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(0)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(1)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(2)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(3)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(4)));\n\ta52_p308_pll_snapshot(index, point);\n}\n'''
+    new_snapshot = '''\ta52_ackfr_record("P276 308T q=%u %x %x %x %x %x", point,\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(0)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(1)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(2)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(3)),\n\t\treadl_relaxed(base + A52_P308_V3_LNX_TX_DCTRL(4)));\n\ta52_p309_clamp_snapshot(index, point);\n\ta52_p308_pll_snapshot(index, point);\n}\n'''
+    text = replace_once(text, old_snapshot, new_snapshot, 'exact-F0 counter snapshot')
+
+    old_clamp = '''\tif (phy->hw.ops.clamp_ctrl)\n\t\tphy->hw.ops.clamp_ctrl(&phy->hw, enable);\n\n\ta52_p308_tx_dctrl_snapshot(phy, enable, 1);\n'''
+    new_clamp = '''\tif (phy->hw.ops.clamp_ctrl) {\n\t\tphy->hw.ops.clamp_ctrl(&phy->hw, enable);\n\t\tif (phy->index < A52_P309_PHY_MAX) {\n\t\t\tif (enable)\n\t\t\t\tatomic_inc(&a52_p309_clamp_enable[phy->index]);\n\t\t\telse\n\t\t\t\tatomic_inc(&a52_p309_clamp_release[phy->index]);\n\t\t\ta52_ackfr_record("P276 309K i=%u e=%u ce=%d cr=%d",\n\t\t\t\tphy->index, enable ? 1 : 0,\n\t\t\t\tatomic_read(&a52_p309_clamp_enable[phy->index]),\n\t\t\t\tatomic_read(&a52_p309_clamp_release[phy->index]));\n\t\t}\n\t}\n\n\ta52_p308_tx_dctrl_snapshot(phy, enable, 1);\n'''
+    return replace_once(text, old_clamp, new_clamp, 'post-callback latch')
+
+
+def validate(text: str) -> None:
+    required = [
+        MARK,
+        'static atomic_t a52_p309_clamp_enable[A52_P309_PHY_MAX];',
+        'static atomic_t a52_p309_clamp_release[A52_P309_PHY_MAX];',
+        'atomic_inc(&a52_p309_clamp_release[phy->index]);',
+        'P276 309K i=%u e=%u ce=%d cr=%d',
+        'P276 309T q=%u i=%u ce=%d cr=%d',
+        'a52_p309_clamp_snapshot(index, point);',
+        'phy->hw.ops.clamp_ctrl(&phy->hw, enable);',
+        'P276 308T q=%u %x %x %x %x %x',
+        'a52_p308_pll_snapshot(index, point);',
+    ]
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase309 required token missing: ' + token)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    args = ap.parse_args()
+
+    phy = args.root / PHY_REL
+    if not phy.is_file():
+        raise SystemExit('Phase309 PHY source missing: ' + str(phy))
+
+    if not args.check_only:
+        phy.write_text(patch_phy(phy.read_text()))
+
+    validate(phy.read_text())
+    print('Phase309 GKI persistent clamp-release latch observer: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/309_ci_build.sh
+++ b/scripts/309_ci_build.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+OUT="$PWD/phase309-gki-out"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+
+fail_report() {
+  set +e
+  rm -rf phase309-gki-failure
+  mkdir -p phase309-gki-failure/{logs,audit,source}
+  cp phase309-gki-compile.log phase309-gki-olddefconfig.log phase309-gki-failure/logs/ 2>/dev/null || true
+  cp /tmp/p309-* phase309-gki-failure/audit/ 2>/dev/null || true
+  cp scripts/309_apply_gki_clamp_release_latch.py phase309-gki-failure/audit/ 2>/dev/null || true
+  [ -f "$PHY" ] && cp "$PHY" phase309-gki-failure/source/ || true
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+bash scripts/308_ci_build.sh
+
+test -s phase308-gki-out/package/boot.img
+test -s phase308-gki-out/compile/Image
+test -s phase308-gki-out/config/final.config
+test -s "$PHY"
+test "$(stat -c '%s' phase308-gki-out/package/boot.img)" -eq 100663296
+grep -Fq 'A52_PHASE308_PLL_LOCK_CLAMP_OBSERVER_V1' "$PHY"
+grep -Fq 'P276 308T q=%u %x %x %x %x %x' "$PHY"
+
+cp phase308-gki-out/config/final.config /tmp/p309-phase308.config
+cp "$PHY" /tmp/p309-phy-before.c
+
+python3 -m py_compile scripts/309_apply_gki_clamp_release_latch.py
+python3 scripts/309_apply_gki_clamp_release_latch.py --root "$ROOT"
+python3 scripts/309_apply_gki_clamp_release_latch.py --root "$ROOT" --check-only
+cp "$PHY" /tmp/p309-phy-after.c
+diff -u /tmp/p309-phy-before.c /tmp/p309-phy-after.c > /tmp/p309-phy.diff || true
+
+# Phase309 may add only software atomics/recorder output around the existing
+# clamp callback. No HW write, delay, timeout, clock, regulator, reset, or
+# provider-resource primitive count may change from the hardware-tested 308.
+python3 - "$PHY" <<'PY'
+from pathlib import Path
+import sys
+before = Path('/tmp/p309-phy-before.c').read_text()
+after = Path(sys.argv[1]).read_text()
+protected = [
+    'DSI_W32(', 'MDSS_PLL_REG_W(', 'writel_relaxed(', 'writel(',
+    'clk_set_rate(', 'clk_prepare_enable(', 'clk_disable_unprepare(',
+    'regulator_enable(', 'regulator_disable(', 'reset_control_assert(',
+    'reset_control_deassert(', 'msleep(', 'usleep_range(', 'udelay(',
+    'ndelay(', 'mdss_pll_resource_enable(',
+]
+for token in protected:
+    if before.count(token) != after.count(token):
+        raise SystemExit(
+            f'Phase309 observer scope violation: {token} '
+            f'{before.count(token)} -> {after.count(token)}'
+        )
+required = [
+    'phy->hw.ops.clamp_ctrl(&phy->hw, enable);',
+    'atomic_inc(&a52_p309_clamp_enable[phy->index]);',
+    'atomic_inc(&a52_p309_clamp_release[phy->index]);',
+    'P276 309K i=%u e=%u ce=%d cr=%d',
+    'P276 309T q=%u i=%u ce=%d cr=%d',
+]
+for token in required:
+    if token not in after:
+        raise SystemExit('Phase309 required source token missing: ' + token)
+print('Phase309 software-only clamp latch scope audit: PASS')
+PY
+
+cp /tmp/p309-phase308.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase309-gki-olddefconfig.log 2>&1
+cmp -s /tmp/p309-phase308.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase309-gki-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase309-gki-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+for marker in \
+  'P276 309K i=%u e=%u ce=%d cr=%d' \
+  'P276 309T q=%u i=%u ce=%d cr=%d' \
+  'P276 308T q=%u %x %x %x %x %x' \
+  'P276 308L q=%u i=%u on=%u ho=%u re=%u rr=%u lk=%x' \
+  'P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x' \
+  'P276 303 S00p p=%02x%02x%02x'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase309-gki-compile.log phase309-gki-olddefconfig.log "$OUT/audit/"
+cp scripts/309_apply_gki_clamp_release_latch.py "$OUT/audit/"
+cp /tmp/p309-* "$OUT/audit/" 2>/dev/null || true
+cp "$PHY" "$OUT/source/dsi_phy.c"
+cp phase308-gki-out/BUILD-IDENTITY.json "$OUT/audit/PHASE308-BASE-BUILD-IDENTITY.json"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase308-gki-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase309-gki-out')
+repack = json.loads((r/'package/repack-report.json').read_text())
+identity = {
+  'phase': '309',
+  'variant': 'GKI-PHASE308-BASE',
+  'name': 'PERSISTENT-CLAMP-RELEASE-LATCH-V1',
+  'git_sha': os.getenv('GITHUB_SHA'),
+  'hardware_validated': False,
+  'base': 'Phase308 GKI exact-F0 PLL/lock + TX_DCTRL/clamp observer',
+  'observer_only': True,
+  'target': 'ctrl0 flags=0x20 msg.flags=0x8 type=0x29 len=3 payload=F0 5A 5A',
+  'exact_f0_points': {'q0':'before SW_TRIGGER','q1':'immediately after SW_TRIGGER','q2':'after DMA completion/timeout'},
+  'clamp_latch_semantics': 'ce/cr atomics increment only after the existing clamp_ctrl callback returns',
+  'golden_discriminator': 'Golden Phase308G has ce=0 cr=1 before exact target; compare GKI Phase309 q0 cr',
+  'decision': {'cr_eq_0':'GKI missed Golden FreezeIO/clamp release path','cr_ge_1':'clamp callback parity; proceed to Lagoon DISP_CC/link-clock observer'},
+  'existing_phase308_txdctrl_reads_preserved': True,
+  'existing_phase308_pll_reads_preserved': True,
+  'mmio_writes_added': False,
+  'delay_or_timeout_changes_added': False,
+  'clock_regulator_reset_changes_added': False,
+  'software_state_added': ['atomic clamp_enable[2]','atomic clamp_release[2]'],
+  'boot_bytes': (r/'package/boot.img').stat().st_size,
+  'boot_sha256': hashlib.sha256((r/'package/boot.img').read_bytes()).hexdigest(),
+  'image_sha256': hashlib.sha256((r/'compile/Image').read_bytes()).hexdigest(),
+  'dtb_preserved': repack['invariants']['dtb_preserved'],
+  'ramdisk_preserved': repack['invariants']['ramdisk_preserved'],
+  'recovery_dtbo_preserved': repack['invariants']['recovery_dtbo_preserved'],
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True)+'\n')
+files=[p for p in r.rglob('*') if p.is_file() and p.name!='SHA256SUMS']
+with (r/'SHA256SUMS').open('w') as f:
+  for p in sorted(files):
+    f.write(hashlib.sha256(p.read_bytes()).hexdigest()+'  ./'+p.relative_to(r).as_posix()+'\n')
+PY
+(cd "$OUT" && sha256sum -c SHA256SUMS)
+trap - EXIT
+echo 'Phase309 GKI persistent clamp-release latch build/repack: PASS'


### PR DESCRIPTION
Adds a Phase308-based, software-only persistent clamp enable/release latch for the exact F0 5A 5A observer path.

Scope:
- increments ce/cr only after the existing dsi_phy clamp_ctrl callback returns
- records ce/cr at inherited q0/q1/q2 via the existing PHY snapshot path
- preserves all Phase308 TX_DCTRL and PLL observations
- adds no MMIO writes, delays, timeout changes, clock/regulator/reset changes, or provider-resource calls
- CI audits hardware primitive counts and produces evidence + a flashable 96 MiB boot image

Decision target: Golden Phase308G has cr=1 before the exact F0 command. GKI Phase309 cr=0 would isolate a missing FreezeIO/clamp-release handoff; cr>=1 establishes callback parity and moves the investigation to Lagoon DISP_CC/link-clock state.