### PR TITLE
Phase313: repair inherited v3 TIMING_CTRL_9 at F0 handoff

### DIFF
--- a/.github/workflows/313-a52-gki-v3-timing9-handoff-repair.yml
+++ b/.github/workflows/313-a52-gki-v3-timing9-handoff-repair.yml
@@ -1,0 +1,114 @@
+name: 313 - A52 GKI v3 timing9 handoff repair A/B
+run-name: Phase 313 - GKI v3 TIMING_CTRL_9 handoff repair A/B
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - agent/a52-phase313-gki-v3-timing9-handoff-repair-ab-v1
+    paths:
+      - .github/workflows/313-a52-gki-v3-timing9-handoff-repair.yml
+      - scripts/313_apply_v3_timing9_handoff_repair.py
+      - scripts/313_ci_build.sh
+      - .github/workflows/312-a52-gki-f0-source-dependency-recorder.yml
+      - scripts/312_apply_f0_source_dependency_recorder.py
+      - scripts/312_ci_build.sh
+  pull_request:
+    branches:
+      - agent/a52-phase312-gki-f0-source-dependency-recorder-v1
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: a52-phase313-timing9-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GKI_COMMON_SHA: f960ed27302b1ff8e61e152fc202554d778deccd
+  TOUCHGRASS_COMMIT: 6bf351bdf18bdb228db79e66f14a7a9c0178e5d7
+  TOUCHGRASS_REPO: https://github.com/micr0softstore/samsung_android_kernel_a52xq.git
+  PHASE227_SEED_ARTIFACT_ID: '9160764832'
+
+jobs:
+  build:
+    name: Build Phase312-based v3 TIMING9 repair A/B
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Check out Phase313 branch
+        uses: actions/checkout@v4
+
+      - name: Prepare environment
+        run: |
+          set -Eeuo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl ca-certificates unzip make gcc g++ python3 bc bison flex \
+            clang lld llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+            libssl-dev libelf-dev rsync cpio gzip lz4 file dwarves
+          python3 -m py_compile scripts/313_apply_v3_timing9_handoff_repair.py
+          python3 -m py_compile scripts/312_apply_f0_source_dependency_recorder.py
+          bash -n scripts/313_ci_build.sh
+          bash -n scripts/312_ci_build.sh
+
+      - name: Restore pinned GKI source
+        uses: actions/cache/restore@v4
+        with:
+          path: gki
+          key: android12-5.10-gki-source-v1-${{ runner.os }}-android12-5.10-2026-04_r1-${{ env.GKI_COMMON_SHA }}
+          fail-on-cache-miss: true
+
+      - name: Restore exact TouchGrass source
+        id: touchgrass-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: workspace/touchgrass-a52xq
+          key: a52xq-touchgrass-linux-4.19.200-main-v2-${{ runner.os }}-${{ env.TOUCHGRASS_COMMIT }}
+
+      - name: Clone exact TouchGrass source on cache miss
+        if: steps.touchgrass-cache.outputs.cache-hit != 'true'
+        run: |
+          set -Eeuo pipefail
+          rm -rf workspace/touchgrass-a52xq
+          mkdir -p workspace/touchgrass-a52xq
+          git -C workspace/touchgrass-a52xq init
+          git -C workspace/touchgrass-a52xq remote add origin "$TOUCHGRASS_REPO"
+          git -C workspace/touchgrass-a52xq fetch --depth=1 origin "$TOUCHGRASS_COMMIT"
+          git -C workspace/touchgrass-a52xq checkout --detach FETCH_HEAD
+
+      - name: Build and audit Phase313 timing9 repair
+        run: bash scripts/313_ci_build.sh
+
+      - name: Upload complete Phase313 evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase313-GKI-V3-TIMING9-HANDOFF-AB-${{ github.run_number }}-NOT-HARDWARE-VALIDATED
+          path: phase313-gki-out/
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 30
+
+      - name: Upload Phase313 boot image
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase313-GKI-V3-TIMING9-HANDOFF-AB-${{ github.run_number }}-BOOT-IMG
+          path: phase313-gki-out/package/boot.img
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: A52XQ-Phase313-GKI-V3-TIMING9-HANDOFF-AB-${{ github.run_number }}-FAILED
+          path: phase313-gki-failure/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/313_apply_v3_timing9_handoff_repair.py
+++ b/scripts/313_apply_v3_timing9_handoff_repair.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+PHY_REL = Path('drivers/a52_display/msm/dsi/dsi_phy_hw_v3_0.c')
+MARK = 'A52_PHASE313_V3_TIMING9_HANDOFF_REPAIR_AB_V1'
+
+OLD = '''\treg |= BIT(2);\n\tDSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));\n\twmb(); /* Ensure that the freezeio bit is toggled */\n'''
+
+NEW = '''\treg |= BIT(2);\n\t/* A52_PHASE313_V3_TIMING9_HANDOFF_REPAIR_AB_V1\n\t * Phase312 recorded DSIPHY_CMN_TIMING_CTRL_9=0x12 at the exact first\n\t * Samsung F0 transfer while the already-calculated v3 timing cfg was\n\t * 0x02. Pinned TouchGrass hard-codes lane_v3[9]=0x02 and normal v3 PHY\n\t * enable writes that value directly. Continuous splash skips that normal\n\t * hardware programming, so repair this one inherited field before the\n\t * existing FreezeIO release sequence. The existing following wmb() orders\n\t * this write; do not add a new barrier or change release timing/order.\n\t */\n\tDSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);\n\tDSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));\n\twmb(); /* Ensure that the freezeio bit is toggled */\n'''
+
+
+def patch(text: str) -> str:
+    if MARK in text:
+        return text
+    if 'A52_PHASE311_V3_DCTRL3_HANDOFF_REPAIR_AB_V1' not in text:
+        raise SystemExit('Phase313: inherited Phase311 DCTRL3 handoff repair missing')
+    if '#define DSIPHY_CMN_TIMING_CTRL_9' not in text:
+        raise SystemExit('Phase313: DSIPHY_CMN_TIMING_CTRL_9 definition missing')
+    if text.count(OLD) != 1:
+        raise SystemExit(
+            f'Phase313: expected one Phase311 repaired release anchor, found {text.count(OLD)}'
+        )
+    return text.replace(OLD, NEW, 1)
+
+
+def validate(text: str) -> None:
+    required = [
+        MARK,
+        'A52_PHASE311_V3_DCTRL3_HANDOFF_REPAIR_AB_V1',
+        'DSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);',
+        'DSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));',
+        'DSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg & ~BIT(0));',
+    ]
+    for token in required:
+        if token not in text:
+            raise SystemExit('Phase313 required token missing: ' + token)
+    if text.count(MARK) != 1:
+        raise SystemExit(f'Phase313 expected one marker, found {text.count(MARK)}')
+    if text.count('DSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);') != 1:
+        raise SystemExit('Phase313 expected exactly one timing9 repair write')
+    if text.count(NEW) != 1:
+        raise SystemExit('Phase313 exact repaired release block not unique')
+    if text.count(OLD) != 0:
+        raise SystemExit('Phase313 original Phase311-only release block still present')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--root', type=Path, required=True)
+    ap.add_argument('--check-only', action='store_true')
+    ns = ap.parse_args()
+
+    path = ns.root / PHY_REL
+    if not path.is_file():
+        raise SystemExit('Phase313 source missing: ' + str(path))
+
+    if not ns.check_only:
+        path.write_text(patch(path.read_text()))
+    validate(path.read_text())
+    print('Phase313 v3 TIMING_CTRL_9 handoff repair A/B: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/313_apply_v3_timing9_handoff_repair.py
+++ b/scripts/313_apply_v3_timing9_handoff_repair.py
@@ -9,7 +9,7 @@ MARK = 'A52_PHASE313_V3_TIMING9_HANDOFF_REPAIR_AB_V1'
 
 OLD = '''\treg |= BIT(2);\n\tDSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));\n\twmb(); /* Ensure that the freezeio bit is toggled */\n'''
 
-NEW = '''\treg |= BIT(2);\n\t/* A52_PHASE313_V3_TIMING9_HANDOFF_REPAIR_AB_V1\n\t * Phase312 recorded DSIPHY_CMN_TIMING_CTRL_9=0x12 at the exact first\n\t * Samsung F0 transfer while the already-calculated v3 timing cfg was\n\t * 0x02. Pinned TouchGrass hard-codes lane_v3[9]=0x02 and normal v3 PHY\n\t * enable writes that value directly. Continuous splash skips that normal\n\t * hardware programming, so repair this one inherited field before the\n\t * existing FreezeIO release sequence. The existing following wmb() orders\n\t * this write; do not add a new barrier or change release timing/order.\n\t */\n\tDSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);\n\tDSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));\n\twmb(); /* Ensure that the freezeio bit is toggled */\n'''
+NEW = '''\treg |= BIT(2);\n\t/* A52_PHASE313_V3_TIMING9_HANDOFF_REPAIR_AB_V1\n\t * Phase312 recorded DSIPHY_CMN_TIMING_CTRL_9=0x12 at the exact first\n\t * Samsung F0 transfer while the already-calculated v3 timing cfg was\n\t * 0x02. Pinned TouchGrass hard-codes lane_v3[9]=0x02 and normal v3 PHY\n\t * enable writes that value directly. Continuous splash skips that normal\n\t * hardware programming, so repair this one inherited field before the\n\t * existing FreezeIO release sequence. The existing following write\n\t * barrier orders this write; do not change release timing/order.\n\t */\n\tDSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);\n\tDSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));\n\twmb(); /* Ensure that the freezeio bit is toggled */\n'''
 
 
 def patch(text: str) -> str:

--- a/scripts/313_ci_build.sh
+++ b/scripts/313_ci_build.sh
@@ -269,8 +269,8 @@ set_stage "checksums"
 (
   cd "$OUT"
   find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+  sha256sum -c SHA256SUMS
 )
-sha256sum -c "$OUT/SHA256SUMS"
 
 set_stage "complete"
 echo 'Phase313 V3 TIMING_CTRL_9 handoff repair A/B: PASS'

--- a/scripts/313_ci_build.sh
+++ b/scripts/313_ci_build.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$PWD/gki/common"
+BUILD="$PWD/workspace/gki-phase199-out"
+TG="$PWD/workspace/touchgrass-a52xq"
+OUT="$PWD/phase313-gki-out"
+PHY="$ROOT/drivers/a52_display/msm/dsi/dsi_phy.c"
+DISP="$ROOT/drivers/clk/qcom/dispcc-lagoon.c"
+HW="$ROOT/drivers/a52_display/msm/dsi/dsi_phy_hw_v3_0.c"
+GKITIM="$ROOT/drivers/a52_display/msm/dsi/dsi_phy_timing_v3_0.c"
+TGPHYV3="$TG/techpack/display/msm/dsi/dsi_phy_hw_v3_0.c"
+TGTIM="$TG/techpack/display/msm/dsi/dsi_phy_timing_v3_0.c"
+
+fail_report() {
+  set +e
+  rm -rf phase313-gki-failure
+  mkdir -p phase313-gki-failure/{logs,audit,source,nested}
+  cp phase313-gki-compile.log phase313-gki-olddefconfig.log phase313-gki-failure/logs/ 2>/dev/null || true
+  cp /tmp/p313-* phase313-gki-failure/audit/ 2>/dev/null || true
+  cp scripts/313_apply_v3_timing9_handoff_repair.py phase313-gki-failure/audit/ 2>/dev/null || true
+  [ -f "$HW" ] && cp "$HW" phase313-gki-failure/source/ || true
+  [ -f "$PHY" ] && cp "$PHY" phase313-gki-failure/source/ || true
+  [ -f "$DISP" ] && cp "$DISP" phase313-gki-failure/source/ || true
+  for d in phase*-gki-failure; do
+    [ -d "$d" ] || continue
+    [ "$d" = "phase313-gki-failure" ] && continue
+    cp -a "$d" phase313-gki-failure/nested/ || true
+  done
+}
+trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
+
+# Reconstruct the exact successful Phase312 tree first. Phase313 changes one
+# source-proven inherited v3 PHY register and nothing else.
+set +e
+bash scripts/312_ci_build.sh 2>&1 | tee /tmp/p313-phase312.log
+phase312_rc=${PIPESTATUS[0]}
+set -e
+if [ "$phase312_rc" -ne 0 ]; then
+  echo "ERROR: Phase312 reconstruction failed rc=$phase312_rc" >&2
+  exit "$phase312_rc"
+fi
+
+for f in \
+  phase312-gki-out/package/boot.img \
+  phase312-gki-out/compile/Image \
+  phase312-gki-out/config/final.config \
+  "$PHY" "$DISP" "$HW" "$GKITIM" "$TGPHYV3" "$TGTIM"; do
+  test -s "$f"
+done
+test "$(stat -c '%s' phase312-gki-out/package/boot.img)" -eq 100663296
+grep -Fq 'A52_PHASE311_V3_DCTRL3_HANDOFF_REPAIR_AB_V1' "$HW"
+grep -Fq 'A52_PHASE312_GKI_F0_PHY_DEPENDENCY_RECORDER_V1' "$PHY"
+grep -Fq 'A52_PHASE312_GKI_DISPCC_MISC_CMD_RECORDER_V1' "$DISP"
+
+# Source provenance: both reconstructed GKI and pinned TouchGrass define
+# TIMING_CTRL_9 at 0x0d0, calculate lane_v3[9] as 0x02, and normal v3 enable
+# writes that timing value directly to the hardware register.
+python3 - "$HW" "$TGPHYV3" "$GKITIM" "$TGTIM" <<'PY'
+from pathlib import Path
+import re, sys
+
+def macro_hex(text, name):
+    m = re.search(r'(?m)^#define\s+' + re.escape(name) + r'\s+0x([0-9A-Fa-f]+)', text)
+    if not m:
+        raise SystemExit('Phase313 source gate missing macro: ' + name)
+    return int(m.group(1), 16)
+
+for path in map(Path, sys.argv[1:3]):
+    text = path.read_text()
+    got = macro_hex(text, 'DSIPHY_CMN_TIMING_CTRL_9')
+    if got != 0x0d0:
+        raise SystemExit(f'Phase313 TIMING_CTRL_9 offset mismatch {path}: 0x{got:x}')
+    direct = 'DSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, timing->lane_v3[9]);'
+    if direct not in text:
+        raise SystemExit(f'Phase313 direct timing9 write missing in {path}')
+
+for path in map(Path, sys.argv[3:5]):
+    text = path.read_text()
+    if not re.search(r'timing->lane_v3\[9\]\s*=\s*0x02\s*;', text):
+        raise SystemExit(f'Phase313 source-required lane_v3[9]=0x02 missing in {path}')
+
+print('Phase313 GKI/Golden timing9 provenance gate: PASS')
+PY
+
+cp phase312-gki-out/config/final.config /tmp/p313-phase312.config
+cp "$HW" /tmp/p313-hw-before.c
+cp "$PHY" /tmp/p313-phy-before.c
+cp "$DISP" /tmp/p313-disp-before.c
+
+python3 -m py_compile scripts/313_apply_v3_timing9_handoff_repair.py
+python3 scripts/313_apply_v3_timing9_handoff_repair.py --root "$ROOT"
+python3 scripts/313_apply_v3_timing9_handoff_repair.py --root "$ROOT" --check-only
+
+cp "$HW" /tmp/p313-hw-after.c
+cp "$PHY" /tmp/p313-phy-after.c
+cp "$DISP" /tmp/p313-disp-after.c
+diff -u /tmp/p313-hw-before.c /tmp/p313-hw-after.c > /tmp/p313-hw.diff || true
+cmp -s /tmp/p313-phy-before.c /tmp/p313-phy-after.c
+cmp -s /tmp/p313-disp-before.c /tmp/p313-disp-after.c
+
+# One-variable hardware A/B. Exactly one DSI write is added. Existing barrier
+# count/order and every other protected primitive must remain unchanged.
+python3 - "$HW" <<'PY'
+from pathlib import Path
+import sys
+before = Path('/tmp/p313-hw-before.c').read_text()
+after = Path(sys.argv[1]).read_text()
+
+if after.count('DSI_W32(') - before.count('DSI_W32(') != 1:
+    raise SystemExit('Phase313 expected exactly one new DSI_W32 source site')
+if after.count('DSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);') != 1:
+    raise SystemExit('Phase313 exact TIMING_CTRL_9=0x02 repair write missing/not unique')
+if after.count('A52_PHASE313_V3_TIMING9_HANDOFF_REPAIR_AB_V1') != 1:
+    raise SystemExit('Phase313 repair marker missing/not unique')
+
+protected_unchanged = [
+    'DSI_R32(', 'MDSS_PLL_REG_W(',
+    'writel_relaxed(', 'writel(', 'regmap_write(', 'regmap_update_bits(',
+    'wmb(', 'mb(', 'rmb(',
+    'readl_poll_timeout', 'wait_for_completion_timeout(',
+    'udelay(', 'ndelay(', 'usleep_range(', 'msleep(',
+    'clk_set_rate(', 'clk_set_parent(', 'clk_prepare_enable(',
+    'clk_disable_unprepare(', 'clk_prepare(', 'clk_unprepare(',
+    'clk_enable(', 'clk_disable(',
+    'regulator_enable(', 'regulator_disable(',
+    'reset_control_assert(', 'reset_control_deassert(',
+]
+for token in protected_unchanged:
+    if before.count(token) != after.count(token):
+        raise SystemExit(
+            f'Phase313 scope violation: {token} {before.count(token)} -> {after.count(token)}'
+        )
+
+# The Phase311 FreezeIO release sequence is still two writes with the same two
+# barriers; Phase313 only inserts the timing write immediately before it.
+required = [
+    'reg |= BIT(2);',
+    'DSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02);',
+    'DSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg | BIT(0));',
+    'wmb(); /* Ensure that the freezeio bit is toggled */',
+    'DSI_W32(phy, DSIPHY_LNX_TX_DCTRL(3), reg & ~BIT(0));',
+    'A52_PHASE311_V3_DCTRL3_HANDOFF_REPAIR_AB_V1',
+]
+for token in required:
+    if token not in after:
+        raise SystemExit('Phase313 inherited/repaired token missing: ' + token)
+
+print('Phase313 one-write TIMING9 A/B scope audit: PASS')
+PY
+
+cp /tmp/p313-phase312.config "$BUILD/.config"
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
+  > phase313-gki-olddefconfig.log 2>&1
+cmp -s /tmp/p313-phase312.config "$BUILD/.config"
+
+set +e
+make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+  CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
+  2>&1 | tee phase313-gki-compile.log
+rc=${PIPESTATUS[0]}
+set -e
+if [ "$rc" -ne 0 ]; then
+  grep -nE '(^|: )(fatal error|error): |undefined reference to' phase313-gki-compile.log | tail -n 300 || true
+  exit "$rc"
+fi
+
+IMAGE="$BUILD/arch/arm64/boot/Image"
+test -s "$IMAGE"
+# Retain the phone-visible Phase312 discriminator and inherited F0 observers.
+for marker in \
+  'P276 312T1 %x %x %x %x %x %x' \
+  'P276 312TE1 %x %x %x %x %x %x' \
+  'P276 312D q=%u rc=%d m=%x b0=%u b5=%u b7=%u b9=%u' \
+  'P276 308T q=%u %x %x %x %x %x' \
+  'P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x' \
+  'P276 303 S00p p=%02x%02x%02x'; do
+  grep -aFq "$marker" "$IMAGE"
+done
+
+rm -rf "$OUT"
+mkdir -p "$OUT"/{compile,config,package,audit,source}
+cp "$IMAGE" "$OUT/compile/Image"
+cp "$BUILD/.config" "$OUT/config/final.config"
+cp phase313-gki-compile.log phase313-gki-olddefconfig.log "$OUT/audit/"
+cp scripts/313_apply_v3_timing9_handoff_repair.py "$OUT/audit/"
+cp /tmp/p313-* "$OUT/audit/" 2>/dev/null || true
+cp "$HW" "$OUT/source/dsi_phy_hw_v3_0.c"
+cp "$PHY" "$OUT/source/dsi_phy.c"
+cp "$DISP" "$OUT/source/dispcc-lagoon.c"
+cp "$GKITIM" "$OUT/source/dsi_phy_timing_v3_0.c"
+cp phase312-gki-out/BUILD-IDENTITY.json "$OUT/audit/PHASE312-BASE-BUILD-IDENTITY.json"
+
+gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
+python3 scripts/38_repack_a52_p1_boot.py \
+  --source phase312-gki-out/package/boot.img \
+  --kernel "$OUT/package/Image.gz" \
+  --output "$OUT/package/boot.img" \
+  --report "$OUT/package/repack-report.json"
+test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
+
+python3 - <<'PY'
+import hashlib, json, os
+from pathlib import Path
+r = Path('phase313-gki-out')
+
+def sha(p):
+    h = hashlib.sha256()
+    with p.open('rb') as f:
+        for b in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(b)
+    return h.hexdigest()
+
+identity = {
+    'phase': '313',
+    'variant': 'GKI-PHASE312-BASE',
+    'name': 'V3-TIMING9-HANDOFF-REPAIR-AB-V1',
+    'git_sha': os.getenv('GITHUB_SHA'),
+    'hardware_validated': False,
+    'base': 'Phone-tested Phase312 exact-F0 dependency recorder',
+    'evidence': {
+        'phase312_hw_timing9': '0x12',
+        'phase312_cfg_timing9': '0x02',
+        'golden_v3_timing9': '0x02',
+        'repair': 'one DSI_W32 to DSIPHY_CMN_TIMING_CTRL_9=0x02 before inherited FreezeIO release',
+    },
+    'image_sha256': sha(r/'compile/Image'),
+    'boot_img_sha256': sha(r/'package/boot.img'),
+    'boot_img_size': (r/'package/boot.img').stat().st_size,
+}
+(r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True) + '\n')
+PY
+
+(
+  cd "$OUT"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+)
+sha256sum -c "$OUT/SHA256SUMS"
+
+echo 'Phase313 V3 TIMING_CTRL_9 handoff repair A/B: PASS'

--- a/scripts/313_ci_build.sh
+++ b/scripts/313_ci_build.sh
@@ -11,14 +11,25 @@ HW="$ROOT/drivers/a52_display/msm/dsi/dsi_phy_hw_v3_0.c"
 GKITIM="$ROOT/drivers/a52_display/msm/dsi/dsi_phy_timing_v3_0.c"
 TGPHYV3="$TG/techpack/display/msm/dsi/dsi_phy_hw_v3_0.c"
 TGTIM="$TG/techpack/display/msm/dsi/dsi_phy_timing_v3_0.c"
+PHASE313_STAGE="startup"
+
+set_stage() {
+  PHASE313_STAGE="$1"
+  echo "== Phase313 stage: $PHASE313_STAGE =="
+}
 
 fail_report() {
   set +e
   rm -rf phase313-gki-failure
-  mkdir -p phase313-gki-failure/{logs,audit,source,nested}
+  mkdir -p phase313-gki-failure/{logs,audit,source,nested,compile,package-meta}
+  printf '%s\n' "$PHASE313_STAGE" > phase313-gki-failure/FAILED-STAGE.txt
   cp phase313-gki-compile.log phase313-gki-olddefconfig.log phase313-gki-failure/logs/ 2>/dev/null || true
   cp /tmp/p313-* phase313-gki-failure/audit/ 2>/dev/null || true
   cp scripts/313_apply_v3_timing9_handoff_repair.py phase313-gki-failure/audit/ 2>/dev/null || true
+  [ -s "$BUILD/arch/arm64/boot/Image" ] && cp "$BUILD/arch/arm64/boot/Image" phase313-gki-failure/compile/Image || true
+  [ -f "$OUT/package/repack-report.json" ] && cp "$OUT/package/repack-report.json" phase313-gki-failure/package-meta/ || true
+  [ -f "$OUT/BUILD-IDENTITY.json" ] && cp "$OUT/BUILD-IDENTITY.json" phase313-gki-failure/package-meta/ || true
+  [ -f "$OUT/SHA256SUMS" ] && cp "$OUT/SHA256SUMS" phase313-gki-failure/package-meta/ || true
   [ -f "$HW" ] && cp "$HW" phase313-gki-failure/source/ || true
   [ -f "$PHY" ] && cp "$PHY" phase313-gki-failure/source/ || true
   [ -f "$DISP" ] && cp "$DISP" phase313-gki-failure/source/ || true
@@ -30,6 +41,7 @@ fail_report() {
 }
 trap 'rc=$?; [ "$rc" -eq 0 ] || fail_report; exit "$rc"' EXIT
 
+set_stage "reconstruct Phase312"
 # Reconstruct the exact successful Phase312 tree first. Phase313 changes one
 # source-proven inherited v3 PHY register and nothing else.
 set +e
@@ -53,6 +65,7 @@ grep -Fq 'A52_PHASE311_V3_DCTRL3_HANDOFF_REPAIR_AB_V1' "$HW"
 grep -Fq 'A52_PHASE312_GKI_F0_PHY_DEPENDENCY_RECORDER_V1' "$PHY"
 grep -Fq 'A52_PHASE312_GKI_DISPCC_MISC_CMD_RECORDER_V1' "$DISP"
 
+set_stage "source provenance"
 # Source provenance: both reconstructed GKI and pinned TouchGrass define
 # TIMING_CTRL_9 at 0x0d0, calculate lane_v3[9] as 0x02, and normal v3 enable
 # writes that timing value directly to the hardware register.
@@ -88,6 +101,7 @@ cp "$HW" /tmp/p313-hw-before.c
 cp "$PHY" /tmp/p313-phy-before.c
 cp "$DISP" /tmp/p313-disp-before.c
 
+set_stage "apply Phase313 repair"
 python3 -m py_compile scripts/313_apply_v3_timing9_handoff_repair.py
 python3 scripts/313_apply_v3_timing9_handoff_repair.py --root "$ROOT"
 python3 scripts/313_apply_v3_timing9_handoff_repair.py --root "$ROOT" --check-only
@@ -99,6 +113,7 @@ diff -u /tmp/p313-hw-before.c /tmp/p313-hw-after.c > /tmp/p313-hw.diff || true
 cmp -s /tmp/p313-phy-before.c /tmp/p313-phy-after.c
 cmp -s /tmp/p313-disp-before.c /tmp/p313-disp-after.c
 
+set_stage "scope audit"
 # One-variable hardware A/B. Exactly one DSI write is added. Existing barrier
 # count/order and every other protected primitive must remain unchanged.
 python3 - "$HW" <<'PY'
@@ -149,12 +164,14 @@ for token in required:
 print('Phase313 one-write TIMING9 A/B scope audit: PASS')
 PY
 
+set_stage "config invariant"
 cp /tmp/p313-phase312.config "$BUILD/.config"
 make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
   CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 olddefconfig \
   > phase313-gki-olddefconfig.log 2>&1
 cmp -s /tmp/p313-phase312.config "$BUILD/.config"
 
+set_stage "compile Phase313 Image"
 set +e
 make -C "$ROOT" O="$BUILD" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
   CLANG_TRIPLE=aarch64-linux-gnu- LLVM=1 LLVM_IAS=1 -j"$(nproc)" Image \
@@ -168,17 +185,31 @@ fi
 
 IMAGE="$BUILD/arch/arm64/boot/Image"
 test -s "$IMAGE"
-# Retain the phone-visible Phase312 discriminator and inherited F0 observers.
-for marker in \
-  'P276 312T1 %x %x %x %x %x %x' \
-  'P276 312TE1 %x %x %x %x %x %x' \
-  'P276 312D q=%u rc=%d m=%x b0=%u b5=%u b7=%u b9=%u' \
-  'P276 308T q=%u %x %x %x %x %x' \
-  'P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x' \
-  'P276 303 S00p p=%02x%02x%02x'; do
-  grep -aFq "$marker" "$IMAGE"
-done
 
+require_image_marker() {
+  local marker="$1"
+  local label="$2"
+  printf 'Phase313 Image audit %-8s : ' "$label"
+  if grep -aFq -- "$marker" "$IMAGE"; then
+    echo 'PASS'
+  else
+    echo 'FAIL'
+    printf '%s\n' "$marker" > /tmp/p313-missing-image-marker.txt
+    echo "::error::Phase313 Image audit missing marker $label" >&2
+    return 1
+  fi
+}
+
+set_stage "Image marker audit"
+# Retain the phone-visible Phase312 discriminator and inherited F0 observers.
+require_image_marker 'P276 312T1 %x %x %x %x %x %x' '312T1'
+require_image_marker 'P276 312TE1 %x %x %x %x %x %x' '312TE1'
+require_image_marker 'P276 312D q=%u rc=%d m=%x b0=%u b5=%u b7=%u b9=%u' '312D'
+require_image_marker 'P276 308T q=%u %x %x %x %x %x' '308T'
+require_image_marker 'P276 307C q=%u st=%x ln=%x ck=%x cc=%x in=%x' '307C'
+require_image_marker 'P276 303 S00p p=%02x%02x%02x' '303S00p'
+
+set_stage "assemble Phase313 evidence"
 rm -rf "$OUT"
 mkdir -p "$OUT"/{compile,config,package,audit,source}
 cp "$IMAGE" "$OUT/compile/Image"
@@ -192,6 +223,7 @@ cp "$DISP" "$OUT/source/dispcc-lagoon.c"
 cp "$GKITIM" "$OUT/source/dsi_phy_timing_v3_0.c"
 cp phase312-gki-out/BUILD-IDENTITY.json "$OUT/audit/PHASE312-BASE-BUILD-IDENTITY.json"
 
+set_stage "repack boot image"
 gzip -n -c "$IMAGE" > "$OUT/package/Image.gz"
 python3 scripts/38_repack_a52_p1_boot.py \
   --source phase312-gki-out/package/boot.img \
@@ -200,6 +232,7 @@ python3 scripts/38_repack_a52_p1_boot.py \
   --report "$OUT/package/repack-report.json"
 test "$(stat -c '%s' "$OUT/package/boot.img")" -eq 100663296
 
+set_stage "write build identity"
 python3 - <<'PY'
 import hashlib, json, os
 from pathlib import Path
@@ -232,10 +265,12 @@ identity = {
 (r/'BUILD-IDENTITY.json').write_text(json.dumps(identity, indent=2, sort_keys=True) + '\n')
 PY
 
+set_stage "checksums"
 (
   cd "$OUT"
   find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
 )
 sha256sum -c "$OUT/SHA256SUMS"
 
+set_stage "complete"
 echo 'Phase313 V3 TIMING_CTRL_9 handoff repair A/B: PASS'


### PR DESCRIPTION
Phase313 is a one-variable A/B on top of the phone-tested Phase312 recorder.

Phone evidence from `A52_RAW_RAMOOPS_20260825_084129.zip` at the exact first Samsung F0 transfer:
- HW `P276 312T1`: `a a a 12 4 0`
- calculated cfg `P276 312TE1`: `a a a 2 4 0`
- all other 11 timing slots match
- Phase311 TX_DCTRL3 repair remains correct at `0x04`
- transfer still ends `DONE success=0`

Pinned TouchGrass (`6bf351bdf18bdb228db79e66f14a7a9c0178e5d7`) proves:
- `dsi_phy_hw_v3_0_update_timing_params()` sets `lane_v3[9] = 0x02`
- normal `dsi_phy_hw_v3_0_enable()` writes `timing->lane_v3[9]` directly to `DSIPHY_CMN_TIMING_CTRL_9`
- continuous splash skips the normal PHY HW enable path, leaving bootloader state inherited

Repair scope:
- add exactly one `DSI_W32(phy, DSIPHY_CMN_TIMING_CTRL_9, 0x02)` immediately before the existing Phase311 FreezeIO release writes
- no new barrier, delay, branch, clock, reset, regulator, PLL, DMA, or command-path change
- retain all Phase312 observers so phone A/B directly shows whether HW timing slot 9 becomes `0x02` and whether F0 progresses

CI reconstructs Phase312 first, gates offset/value against both reconstructed GKI and pinned TouchGrass, requires exactly +1 DSI write, requires Phase312 recorder files byte-identical, rebuilds/repackages boot.img, and emits full evidence. Hardware validation remains false until phone test.